### PR TITLE
Adding gitversion directory to the acc-provision RPM package

### DIFF
--- a/provision/rpm/acc-provision.spec.in
+++ b/provision/rpm/acc-provision.spec.in
@@ -34,6 +34,7 @@ install -p -D -m 755 bin/acikubectl %{buildroot}/%{_bindir}/acikubectl
 %doc README.md
 %{python2_sitelib}/acc_provision
 %{python2_sitelib}/acc_provision-%%{version}*.egg-info
+%{python2_sitelib}/gitversion
 %{_bindir}/acc-provision
 %{_bindir}/acikubectl
 

--- a/provision/setup.py
+++ b/provision/setup.py
@@ -1,8 +1,5 @@
-import sys
-sys.dont_write_bytecode = True
-
 from setuptools import setup, find_packages
-import os 
+import os, sys 
 file_dir = os.path.dirname(__file__)
 sys.path.append(file_dir)
 from gitversion.gitversion import get_git_version


### PR DESCRIPTION
RPM packaging requires enlisting every file/directory to be added to the package. So adding the gitversion/ directory needed to store git commit info for acc-provision(first coded in #9)

(cherry picked from commit c1f77c3c0b031225462f4579546930993abfb91e)