### PR TITLE
Fix reference to infra_vlan

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -921,10 +921,14 @@ def provision(args, apic_file, no_random):
             "prov_apic": prov_apic,
             "debug_apic": args.debug,
         },
-        "discovered": {
-            "infra_vlan": args.infra_vlan,
-        },
     }
+
+    # infra_vlan is not part of command line input, but we do
+    # pass it as a command line arg in unit tests to pass in
+    # configuration which would otherwise be discovered from
+    # the APIC
+    config["discovered"] = {"infra_vlan": getattr(args, "infra_vlan", None)}
+
     if args.username:
         config["aci_config"]["apic_login"]["username"] = args.username
 

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -245,6 +245,10 @@ def get_args(**overrides):
         "flavor": None,
         "version_token": "dummy",
         "release": False,
+        # infra_vlan is not part of command line input, but we do
+        # pass it as a command line arg in unit tests to pass in
+        # configuration which would otherwise be discovered from
+        # the APIC
         "infra_vlan": None,
     }
     argc = collections.namedtuple('argc', list(arg.keys()))


### PR DESCRIPTION
The commit: d406d53272d7d78b15b4147f8794a9a201f7c41a

referred to the infra_vlan as a part of command line input.
However, that happens only in the UTs (otherwise it's part
of the config file). This patch makes that reference safe
to use.

(cherry picked from commit 5f07d79eff2e4fc8d44b85a78d181a76fe1a8e96)