### PR TITLE
Integrate acikubectl commands with kubectl CLI

### DIFF
--- a/provision/debian/dirs
+++ b/provision/debian/dirs
@@ -1,0 +1,1 @@
+usr/local/bin/

--- a/provision/debian/rules
+++ b/provision/debian/rules
@@ -7,12 +7,14 @@ include /usr/share/dpkg/default.mk
 
 %:
 	dh $@ --with python2 --buildsystem=python_distutils
+	dh_installdirs     
 
 override_dh_auto_clean:
 	dh_clean
 
 override_dh_auto_install:
 	dh_auto_install --  -O1 --install-data /
+	cp bin/acikubectl $(CURDIR)/debian/acc-provision/usr/local/bin/kubectl-aci
 
 ifeq (,$(findstring nocheck, $(DEB_BUILD_OPTIONS)))
 override_dh_auto_test:

--- a/provision/rpm/acc-provision.spec.in
+++ b/provision/rpm/acc-provision.spec.in
@@ -29,6 +29,13 @@ rm -f requirements.txt
 %install
 %{__python2} setup.py install -O1 --install-data / --skip-build --root %{buildroot}
 install -p -D -m 755 bin/acikubectl %{buildroot}/%{_bindir}/acikubectl
+mkdir -p %{buildroot}/var/lib/aci-containers/kubectl/plugins/aci
+cat > %{buildroot}/var/lib/aci-containers/kubectl/plugins/aci/plugin.yaml <<-EOF
+name: "aci"
+shortDesc: "CLI plugin for acikubectl commands"
+command: "acikubectl" 
+EOF
+chmod 0755 %{buildroot}/var/lib/aci-containers/kubectl/plugins/aci/plugin.yaml
 
 %files
 %doc README.md
@@ -37,6 +44,7 @@ install -p -D -m 755 bin/acikubectl %{buildroot}/%{_bindir}/acikubectl
 %{python2_sitelib}/gitversion
 %{_bindir}/acc-provision
 %{_bindir}/acikubectl
+/var/lib/aci-containers/kubectl/plugins/aci/plugin.yaml
 
 %changelog
 * Tue Aug 01 2017 Mandeep Dhami <dhami@noironetworks.com> - 1.0.0


### PR DESCRIPTION
For kubectl installations:
  To access acikubectl commands using kubectl, just run "kubectl aci". For eg,
  kubectl aci --help

For Openshift installations:
  Export env variable KUBECTL_PLUGINS_PATH on the machine:
  export KUBECTL_PLUGINS_PATH=/var/lib/aci-containers/kubectl/plugins
  OR if KUBECTL_PLUGINS_PATH already exists:
  export KUBECTL_PLUGINS_PATH=/var/lib/aci-containers/kubectl/plugins:{$KUBECTL_PLUGINS_PATH}
  oc plugin aci help

(cherry picked from commit 26ffd8acdd669a172bc6bfa8c88820a8271e11e7)