### PR TITLE
Add ReplicationController ClusterRole for Host Agent

### DIFF
--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -226,6 +226,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -202,6 +202,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -202,6 +202,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -190,6 +190,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -213,6 +213,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -202,6 +202,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -202,6 +202,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -202,6 +202,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -202,6 +202,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -202,6 +202,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -202,6 +202,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -202,6 +202,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -203,6 +203,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -204,6 +204,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -202,6 +202,7 @@ rules:
   - pods
   - endpoints
   - services
+  - replicationcontrollers
   verbs:
   - list
   - watch


### PR DESCRIPTION
To align with the following change in aci-containers:
https://github.com/noironetworks/aci-containers/commit/81e95f6143585a19fc337c05f8e9bd6353dd8852