### PR TITLE
Fix for unsupported description format in pypi packages

### DIFF
--- a/provision/Makefile
+++ b/provision/Makefile
@@ -13,4 +13,10 @@ clean:
 	rm -rf dist acc_provision.egg-info acc_provision/__pycache__ testdata/tmp-*
 
 upload: clean
+	python setup.py --description
 	python setup.py sdist upload
+
+upload-twine: clean
+	python setup.py --description
+	python setup.py sdist bdist_wheel 
+	twine upload --repository pypi dist/*	

--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -572,8 +572,12 @@ def config_validate_preexisting(config, prov_apic):
 
 def generate_sample(filep):
     data = pkgutil.get_data('acc_provision', 'templates/provision-config.yaml')
-    filep.write(data)
-    filep.flush()
+    try:
+        filep.write(data)
+    except TypeError:
+        filep.write(data.decode(filep.encoding))
+    finally:
+        filep.flush()
     return filep
 
 

--- a/provision/gitversion/gitversion.py
+++ b/provision/gitversion/gitversion.py
@@ -10,7 +10,7 @@ def call_git_rev_parse():
 		p = Popen(['date', '-u', '+%m-%d-%Y.%H:%M:%S.UTC'], stdout=PIPE, stderr=PIPE)
 		p.stderr.close()
 		line = line + "Build time: " + p.stdout.readlines()[0].decode()
-		return line.strip()
+		return line.strip('\n', '')
 
 	except:
 		return None

--- a/provision/setup.py
+++ b/provision/setup.py
@@ -7,7 +7,7 @@ from gitversion.gitversion import get_git_version
 setup(
     name='acc_provision',
     version='4.1.0',
-    description='Tool to provision ACI for ACI Containers Controller\n\nBuild info: \n' + get_git_version(),
+    description='Tool to provision ACI for ACI Containers Controller  Build info: ' + get_git_version(),
     author="Cisco Systems, Inc.",
     author_email="apicapi@noironetworks.com",
     url='http://github.com/noironetworks/aci-containers/',


### PR DESCRIPTION
More details on issue: https://github.com/noironetworks/support/issues/851
Added another make destination in Makefile, "upload-twine" to start pushing packages using twine instead of python upload

Also fix for decoding sample kube.yaml file generated in acc-provision supported by python3

(cherry picked from commit ee1d1b35798e16e599e2875ccc228aa9bd76ffc9)