### PR TITLE
1:A new contract "openshift-monitoring" with the following details:

### DIFF
--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -109,12 +109,27 @@ flavors:
         kubectl: oc
         system_namespace: aci-containers-system
       aci_config:
-        ports:
+        items:
           - name: openshift-svc-catalog
-            range: [2379, 2379]
+            range:
+              -
+                [2379, 2379]
             etherT: ip
             prot: tcp
             stateful: "no"
+            consumed: ["kube-system"]
+            provided: ["kube-nodes"]
+          - name: openshift-monitoring
+            range:
+              -
+                [9091, 9091]
+              -
+                [9094, 9094]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+            provided: ["kube-system","kube-default","kube-nodes"]
+            consumed: ["kube-system","kube-default"]
         vmm_domain:
           type: OpenShift
     status: null
@@ -133,12 +148,27 @@ flavors:
         kubectl: oc
         system_namespace: aci-containers-system
       aci_config:
-        ports:
+        items:
           - name: openshift-svc-catalog
-            range: [2379, 2379]
+            range:
+              -
+                [2379, 2379]
             etherT: ip
             prot: tcp
             stateful: "no"
+            consumed: ["kube-system"]
+            provided: ["kube-nodes"]
+          - name: openshift-monitoring
+            range:
+              -
+                [9091, 9091]
+              -
+                [9094, 9094]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+            provided: ["kube-system","kube-default","kube-nodes"]
+            consumed: ["kube-system","kube-default"]
         vmm_domain:
           type: OpenShift
     status: null
@@ -157,12 +187,27 @@ flavors:
         kubectl: oc
         system_namespace: aci-containers-system
       aci_config:
-        ports:
+        items:
           - name: openshift-svc-catalog
-            range: [2379, 2379]
+            range:
+              -
+                [2379, 2379]
             etherT: ip
             prot: tcp
             stateful: "no"
+            consumed: ["kube-system"]
+            provided: ["kube-nodes"]
+          - name: openshift-monitoring
+            range:
+              -
+                [9091, 9091]
+              -
+                [9094, 9094]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+            provided: ["kube-system","kube-default","kube-nodes"]
+            consumed: ["kube-system","kube-default"]
         vmm_domain:
           type: OpenShift
     status: null
@@ -200,12 +245,27 @@ flavors:
       #                             }
       #                         }
       #                     }
-        ports:
+        items:
           - name: openshift-svc-catalog
-            range: [2379, 2379]
+            range:
+              -
+                [2379, 2379]
             etherT: ip
             prot: tcp
             stateful: "no"
+            consumed: ["kube-system"]
+            provided: ["kube-nodes"]
+          - name: openshift-monitoring
+            range:
+              -
+                [9091, 9091]
+              -
+                [9094, 9094]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+            provided: ["kube-system","kube-default","kube-nodes"]
+            consumed: ["kube-system","kube-default"]
         vmm_domain:
           type: OpenShift
     status: null
@@ -220,7 +280,7 @@ flavors:
     config:
       aci_config:
   #https://docs.docker.com/ee/ucp/admin/install/system-requirements/
-        ports:
+        items:
           - name: ucp-ui-port
             range: [443, 443]
             etherT: ip

--- a/provision/testdata/flavor_openshift.apic.txt
+++ b/provision/testdata/flavor_openshift.apic.txt
@@ -303,6 +303,20 @@ None
                                                 "tnVzBrCPName": "kube-api"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "openshift-monitoring"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "openshift-monitoring"
+                                            }
+                                        }
                                     }
                                 ]
                             }
@@ -370,6 +384,20 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-api"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsCons": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog"
@@ -379,7 +407,14 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "openshift-monitoring"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "openshift-monitoring"
                                             }
                                         }
                                     }
@@ -448,6 +483,13 @@ None
                                                 "tnVzBrCPName": "openshift-svc-catalog"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "openshift-monitoring"
+                                            }
+                                        }
                                     }
                                 ]
                             }
@@ -506,6 +548,20 @@ None
                                                 "tnVzBrCPName": "kube-api"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "openshift-monitoring"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "openshift-monitoring"
+                                            }
+                                        }
                                     }
                                 ]
                             }
@@ -562,6 +618,20 @@ None
                                         "fvRsCons": {
                                             "attributes": {
                                                 "tnVzBrCPName": "kube-api"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "openshift-monitoring"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "openshift-monitoring"
                                             }
                                         }
                                     }
@@ -923,6 +993,33 @@ None
                 }
             },
             {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "openshift-monitoring"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "openshift-monitoring-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "openshift-monitoring-filter"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
                 "vzFilter": {
                     "attributes": {
                         "name": "openshift-svc-catalog-filter"
@@ -931,11 +1028,46 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog",
+                                    "name": "openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
                                     "dToPort": "2379",
+                                    "stateful": "no",
+                                    "tcpRules": ""
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "openshift-monitoring-filter"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "openshift-monitoring-9091",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9091",
+                                    "dToPort": "9091",
+                                    "stateful": "no",
+                                    "tcpRules": ""
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "openshift-monitoring-9094",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9094",
+                                    "dToPort": "9094",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }


### PR DESCRIPTION
tcp: 9091, 9094
Provided by: kube-system, kube-default, kube-nodes
Consumed by: kube-system, kube-default
2: "kube-system" will also now provide the "kube-api" contract (currently its only consuming).
3: The flavors definition in flavors.yaml is being updated
to allow adding contract relationships (provided/consumed).

(cherry picked from commit fe600e28af66527fd6e9094e7b2bde3300986507)