### PR TITLE
Generalize APIC resources name according to the container ecosystem

### DIFF
--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -859,6 +859,8 @@ class ApicKubeConfig(object):
         return path, data
 
     def associate_aep(self):
+        app_profile = self.config["aci_config"]["app_profile"]
+        system_id = self.config["aci_config"]["system_id"]
         aep_name = self.config["aci_config"]["aep"]
         phys_name = self.config["aci_config"]["physical_domain"]["domain"]
         vmm_name = self.config["aci_config"]["vmm_domain"]["domain"]
@@ -1041,9 +1043,11 @@ class ApicKubeConfig(object):
                                                                         [
                                                                             (
                                                                                 "tDn",
-                                                                                "uni/tn-%s/ap-kubernetes/epg-kube-nodes"
+                                                                                "uni/tn-%s/ap-%s/epg-%s-nodes"
                                                                                 % (
                                                                                     tn_name,
+                                                                                    app_profile,
+                                                                                    system_id,
                                                                                 ),
                                                                             ),
                                                                             (
@@ -1107,7 +1111,7 @@ class ApicKubeConfig(object):
         else:
             rsfun = (
                 base + "/gen-default/rsfuncToEpg-"
-                "[uni/tn-%s/ap-kubernetes/epg-kube-nodes].json" % (tn_name)
+                "[uni/tn-%s/ap-%s/epg-%s-nodes].json" % (tn_name, app_profile, system_id)
             )
             return path, data, rsvmm, rsphy, rsfun
 
@@ -1496,6 +1500,7 @@ class ApicKubeConfig(object):
 
     def kube_tn(self, flavor):
         system_id = self.config["aci_config"]["system_id"]
+        app_profile = self.config["aci_config"]["app_profile"]
         tn_name = self.config["aci_config"]["cluster_tenant"]
         vmm_name = self.config["aci_config"]["vmm_domain"]["domain"]
         phys_name = self.config["aci_config"]["physical_domain"]["domain"]
@@ -1612,7 +1617,7 @@ class ApicKubeConfig(object):
                                 (
                                     "attributes",
                                     collections.OrderedDict(
-                                        [("tnFvBDName", "kube-pod-bd")]
+                                        [("tnFvBDName", "%s-pod-bd" % system_id)]
                                     ),
                                 )
                             ]
@@ -1633,7 +1638,7 @@ class ApicKubeConfig(object):
                                     (
                                         "attributes",
                                         collections.OrderedDict(
-                                            [("tnVzBrCPName", "kube-api")]
+                                            [("tnVzBrCPName", "%s-api" % system_id)]
                                         ),
                                     )
                                 ]
@@ -1669,7 +1674,7 @@ class ApicKubeConfig(object):
                                     (
                                         "attributes",
                                         collections.OrderedDict(
-                                            [("tnNdPfxPolName", "kube-nd-ra-policy")]
+                                            [("tnNdPfxPolName", "%s-nd-ra-policy" % system_id)]
                                         ),
                                     )
                                 ]
@@ -1708,7 +1713,7 @@ class ApicKubeConfig(object):
                                                         (
                                                             "attributes",
                                                             collections.OrderedDict(
-                                                                [("name", "kubernetes")]
+                                                                [("name", "%s" % app_profile)]
                                                             ),
                                                         ),
                                                         (
@@ -1726,7 +1731,7 @@ class ApicKubeConfig(object):
                                                                                             [
                                                                                                 (
                                                                                                     "name",
-                                                                                                    "kube-default",
+                                                                                                    "%s-default" % system_id,
                                                                                                 )
                                                                                             ]
                                                                                         ),
@@ -1752,7 +1757,7 @@ class ApicKubeConfig(object):
                                                                                             [
                                                                                                 (
                                                                                                     "name",
-                                                                                                    "kube-system",
+                                                                                                    "%s-system" % system_id,
                                                                                                 )
                                                                                             ]
                                                                                         ),
@@ -1860,7 +1865,7 @@ class ApicKubeConfig(object):
                                                                                                                         [
                                                                                                                             (
                                                                                                                                 "tnVzBrCPName",
-                                                                                                                                "kube-api",
+                                                                                                                                "%s-api" % system_id,
                                                                                                                             )
                                                                                                                         ]
                                                                                                                     ),
@@ -1931,7 +1936,7 @@ class ApicKubeConfig(object):
                                                                                                                         [
                                                                                                                             (
                                                                                                                                 "tnFvBDName",
-                                                                                                                                "kube-pod-bd",
+                                                                                                                                "%s-pod-bd" % system_id,
                                                                                                                             )
                                                                                                                         ]
                                                                                                                     ),
@@ -1960,7 +1965,7 @@ class ApicKubeConfig(object):
                                                                                             [
                                                                                                 (
                                                                                                     "name",
-                                                                                                    "kube-nodes",
+                                                                                                    "%s-nodes" % system_id,
                                                                                                 )
                                                                                             ]
                                                                                         ),
@@ -2002,7 +2007,7 @@ class ApicKubeConfig(object):
                                                                                                                         [
                                                                                                                             (
                                                                                                                                 "tnVzBrCPName",
-                                                                                                                                "kube-api",
+                                                                                                                                "%s-api" % system_id,
                                                                                                                             )
                                                                                                                         ]
                                                                                                                     ),
@@ -2119,7 +2124,7 @@ class ApicKubeConfig(object):
                                                                                                                         [
                                                                                                                             (
                                                                                                                                 "tnFvBDName",
-                                                                                                                                "kube-node-bd",
+                                                                                                                                "%s-node-bd" % system_id,
                                                                                                                             )
                                                                                                                         ]
                                                                                                                     ),
@@ -2155,7 +2160,7 @@ class ApicKubeConfig(object):
                                                                 [
                                                                     (
                                                                         "name",
-                                                                        "kube-node-bd",
+                                                                        "%s-node-bd" % system_id,
                                                                     ),
                                                                     (
                                                                         "arpFlood",
@@ -2238,7 +2243,7 @@ class ApicKubeConfig(object):
                                                                 [
                                                                     (
                                                                         "name",
-                                                                        "kube-pod-bd",
+                                                                        "%s-pod-bd" % system_id,
                                                                     )
                                                                 ]
                                                             ),
@@ -2640,7 +2645,7 @@ class ApicKubeConfig(object):
                                                                 [
                                                                     (
                                                                         "name",
-                                                                        "kube-api-filter",
+                                                                        "%s-api-filter" % system_id,
                                                                     )
                                                                 ]
                                                             ),
@@ -2660,7 +2665,7 @@ class ApicKubeConfig(object):
                                                                                             [
                                                                                                 (
                                                                                                     "name",
-                                                                                                    "kube-api",
+                                                                                                    "%s-api" % system_id,
                                                                                                 ),
                                                                                                 (
                                                                                                     "etherT",
@@ -2706,7 +2711,7 @@ class ApicKubeConfig(object):
                                                                                             [
                                                                                                 (
                                                                                                     "name",
-                                                                                                    "kube-api2",
+                                                                                                    "%s-api2" % system_id,
                                                                                                 ),
                                                                                                 (
                                                                                                     "etherT",
@@ -2756,7 +2761,7 @@ class ApicKubeConfig(object):
                                                         (
                                                             "attributes",
                                                             collections.OrderedDict(
-                                                                [("name", "kube-api")]
+                                                                [("name", "%s-api" % system_id)]
                                                             ),
                                                         ),
                                                         (
@@ -2774,7 +2779,7 @@ class ApicKubeConfig(object):
                                                                                             [
                                                                                                 (
                                                                                                     "name",
-                                                                                                    "kube-api-subj",
+                                                                                                    "%s-api-subj" % system_id,
                                                                                                 ),
                                                                                                 (
                                                                                                     "consMatchT",
@@ -2802,7 +2807,7 @@ class ApicKubeConfig(object):
                                                                                                                         [
                                                                                                                             (
                                                                                                                                 "tnVzFilterName",
-                                                                                                                                "kube-api-filter",
+                                                                                                                                "%s-api-filter" % system_id,
                                                                                                                             )
                                                                                                                         ]
                                                                                                                     ),
@@ -3173,7 +3178,7 @@ class ApicKubeConfig(object):
                                             [
                                                 ("ctrl", "on-link,router-address"),
                                                 ("lifetime", "2592000"),
-                                                ("name", "kube-nd-ra-policy"),
+                                                ("name", "%s-nd-ra-policy" % system_id),
                                                 ("prefLifetime", "604800"),
                                             ]
                                         ),
@@ -3210,7 +3215,8 @@ class ApicKubeConfig(object):
             # lookup kube-node-bd data
             for child in children:
                 if "fvBD" in child:
-                    if child["fvBD"]["attributes"]["name"] == "kube-node-bd":
+                    node_bd_name = "%s-node-bd" % system_id
+                    if child["fvBD"]["attributes"]["name"] == node_bd_name:
                         child["fvBD"]["children"].append(attr)
                         break
 
@@ -3228,7 +3234,7 @@ class ApicKubeConfig(object):
         if "items" in self.config["aci_config"].keys():
             items = self.config["aci_config"]["items"]
             if vmm_type == "OpenShift":
-                openshift_flavor_specific_handling(data, items)
+                openshift_flavor_specific_handling(data, items, system_id)
             elif flavor == "docker-ucp-3.0":
                 dockerucp_flavor_specific_handling(data, items)
 
@@ -3414,7 +3420,7 @@ class ApicKubeConfig(object):
         return path, data
 
 
-def openshift_flavor_specific_handling(data, items):
+def openshift_flavor_specific_handling(data, items, system_id):
     if items is None or len(items) == 0:
         err("Error in getting items for flavor")
     # kube-systems needs to provide kube-api contract
@@ -3516,18 +3522,21 @@ def openshift_flavor_specific_handling(data, items):
         )
 
         # 0 = kube-default, 1 = kube-system, 2 = kube-nodes
-        if 'kube-default' in item['consumed']:
+        default_ns = "%s-default" % system_id
+        system_ns = "%s-system" % system_id
+        nodes_ns = "%s-nodes" % system_id
+        if default_ns in item['consumed']:
             data['fvTenant']['children'][0]['fvAp']['children'][0]['fvAEPg']['children'].append(consume_os_contract)
-        if 'kube-system' in item['consumed']:
+        if system_ns in item['consumed']:
             data['fvTenant']['children'][0]['fvAp']['children'][1]['fvAEPg']['children'].append(consume_os_contract)
-        if 'kube-nodes' in item['consumed']:
+        if nodes_ns in item['consumed']:
             data['fvTenant']['children'][0]['fvAp']['children'][2]['fvAEPg']['children'].append(consume_os_contract)
 
-        if 'kube-default' in item['provided']:
+        if default_ns in item['provided']:
             data['fvTenant']['children'][0]['fvAp']['children'][0]['fvAEPg']['children'].append(provide_os_contract)
-        if 'kube-system' in item['provided']:
+        if system_ns in item['provided']:
             data['fvTenant']['children'][0]['fvAp']['children'][1]['fvAEPg']['children'].append(provide_os_contract)
-        if 'kube-nodes' in item['provided']:
+        if nodes_ns in item['provided']:
             data['fvTenant']['children'][0]['fvAp']['children'][2]['fvAEPg']['children'].append(provide_os_contract)
 
     # add new contract and subject

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -137,7 +137,7 @@ def test_pod_external_access():
 @in_testdir
 def test_flavor_openshift_39():
     run_provision(
-        "base_case.inp.yaml",
+        "flavor_openshift.inp.yaml",
         "flavor_openshift.kube.yaml",
         "flavor_openshift.apic.txt",
         overrides={"flavor": "openshift-3.9"}
@@ -147,8 +147,8 @@ def test_flavor_openshift_39():
 @in_testdir
 def test_flavor_dockerucp_30():
     run_provision(
-        "base_case.inp.yaml",
-        "base_case.kube.yaml",
+        "flavor_dockerucp.inp.yaml",
+        "flavor_dockerucp.kube.yaml",
         "flavor_dockerucp.apic.txt",
         overrides={"flavor": "docker-ucp-3.0"}
     )

--- a/provision/testdata/flavor_dockerucp.apic.txt
+++ b/provision/testdata/flavor_dockerucp.apic.txt
@@ -1,8 +1,8 @@
-/api/mo/uni/infra/vlanns-[kube-pool]-static.json
+/api/mo/uni/infra/vlanns-[ucp-pool]-static.json
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "name": "kube-pool",
+            "name": "ucp-pool",
             "allocMode": "static"
         },
         "children": [
@@ -27,12 +27,12 @@
         ]
     }
 }
-/api/mo/uni/infra/maddrns-kube-mpool.json
+/api/mo/uni/infra/maddrns-ucp-mpool.json
 {
     "fvnsMcastAddrInstP": {
         "attributes": {
-            "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "name": "ucp-mpool",
+            "dn": "uni/infra/maddrns-ucp-mpool"
         },
         "children": [
             {
@@ -46,29 +46,29 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
+/api/mo/uni/phys-ucp-pdom.json
 {
     "physDomP": {
         "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "dn": "uni/phys-ucp-pdom",
+            "name": "ucp-pdom"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[ucp-pool]-static"
                     }
                 }
             }
         ]
     }
 }
-/api/mo/uni/vmmp-Kubernetes/dom-kube.json
+/api/mo/uni/vmmp-Kubernetes/dom-ucp.json
 {
     "vmmDomP": {
         "attributes": {
-            "name": "kube",
+            "name": "ucp",
             "mode": "k8s",
             "enfPref": "sw",
             "encapMode": "vxlan",
@@ -79,7 +79,7 @@
             {
                 "vmmCtrlrP": {
                     "attributes": {
-                        "name": "kube",
+                        "name": "ucp",
                         "mode": "k8s",
                         "scope": "kubernetes",
                         "hostOrIp": "1.1.1.1"
@@ -89,7 +89,7 @@
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-ucp-mpool"
                     }
                 }
             }
@@ -106,14 +106,14 @@
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                        "tDn": "uni/vmmp-Kubernetes/dom-ucp"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-ucp-pdom"
                     }
                 }
             },
@@ -151,7 +151,7 @@
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
-                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
+                                    "tDn": "uni/tn-ucp/ap-dockerucp/epg-ucp-nodes",
                                     "encap": "vlan-4001"
                                 }
                             }
@@ -162,11 +162,11 @@
         ]
     }
 }
-/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/vmmp-Kubernetes/dom-kube].json
+/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/vmmp-Kubernetes/dom-ucp].json
 None
-/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/phys-kube-pdom].json
+/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/phys-ucp-pdom].json
 None
-/api/mo/uni/infra/attentp-kube-aep/gen-default/rsfuncToEpg-[uni/tn-kube/ap-kubernetes/epg-kube-nodes].json
+/api/mo/uni/infra/attentp-kube-aep/gen-default/rsfuncToEpg-[uni/tn-ucp/ap-dockerucp/epg-ucp-nodes].json
 None
 /api/mo/uni/infra.json
 {
@@ -188,7 +188,7 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "ucp-allow-all-filter"
                     },
                     "children": [
                         {
@@ -204,7 +204,7 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "ucp-l3out-allow-all"
                     },
                     "children": [
                         {
@@ -218,7 +218,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "ucp-allow-all-filter"
                                             }
                                         }
                                     }
@@ -231,34 +231,34 @@ None
         ]
     }
 }
-/api/mo/uni/tn-common/flt-kube-allow-all-filter.json
+/api/mo/uni/tn-common/flt-ucp-allow-all-filter.json
 None
-/api/mo/uni/tn-common/brc-kube-l3out-allow-all.json
+/api/mo/uni/tn-common/brc-ucp-l3out-allow-all.json
 None
-/api/mo/uni/tn-kube.json
+/api/mo/uni/tn-ucp.json
 {
     "fvTenant": {
         "attributes": {
-            "name": "kube",
-            "dn": "uni/tn-kube"
+            "name": "ucp",
+            "dn": "uni/tn-ucp"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "dockerucp"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "ucp-default"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-ucp"
                                             }
                                         }
                                     },
@@ -272,7 +272,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "ucp-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -293,7 +293,7 @@ None
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "ucp-pod-bd"
                                             }
                                         }
                                     }
@@ -303,7 +303,7 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "ucp-system"
                                 },
                                 "children": [
                                     {
@@ -337,28 +337,28 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "ucp-api"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "ucp-l3out-allow-all"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-ucp"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "ucp-pod-bd"
                                             }
                                         }
                                     }
@@ -368,7 +368,7 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "ucp-nodes"
                                 },
                                 "children": [
                                     {
@@ -381,7 +381,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "ucp-api"
                                             }
                                         }
                                     },
@@ -402,7 +402,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "ucp-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -410,14 +410,14 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-ucp-pdom"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "ucp-node-bd"
                                             }
                                         }
                                     }
@@ -433,7 +433,7 @@ None
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-ucp"
                                             }
                                         }
                                     },
@@ -447,7 +447,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "ucp-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "ucp-pod-bd"
                                             }
                                         }
                                     }
@@ -484,7 +484,7 @@ None
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-ucp"
                                             }
                                         }
                                     },
@@ -498,7 +498,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "ucp-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -519,7 +519,7 @@ None
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "ucp-pod-bd"
                                             }
                                         }
                                     }
@@ -532,7 +532,7 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-node-bd",
+                        "name": "ucp-node-bd",
                         "arpFlood": "yes"
                     },
                     "children": [
@@ -564,7 +564,7 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "ucp-pod-bd"
                     },
                     "children": [
                         {
@@ -687,13 +687,13 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "ucp-api-filter"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "kube-api",
+                                    "name": "ucp-api",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6443",
@@ -706,7 +706,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "kube-api2",
+                                    "name": "ucp-api2",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8443",
@@ -774,13 +774,13 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "ucp-api"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "kube-api-subj",
+                                    "name": "ucp-api-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
@@ -788,7 +788,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "ucp-api-filter"
                                             }
                                         }
                                     }
@@ -913,17 +913,17 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "ucp-l3out-allow-all"
         }
     }
 }
-/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-kube-l3out-allow-all.json
+/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-ucp-l3out-allow-all.json
 None
-/api/node/mo/uni/userext/user-kube.json
+/api/node/mo/uni/userext/user-ucp.json
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube",
+            "name": "ucp",
             "accountStatus": "active",
             "pwd": "NotRandom!"
         },
@@ -948,17 +948,17 @@ None
         ]
     }
 }
-/api/node/mo/uni/userext/user-kube.json
+/api/node/mo/uni/userext/user-ucp.json
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "ucp"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
-                        "name": "kube.crt",
+                        "name": "ucp.crt",
                         "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
                     }
                 }

--- a/provision/testdata/flavor_dockerucp.inp.yaml
+++ b/provision/testdata/flavor_dockerucp.inp.yaml
@@ -1,0 +1,49 @@
+aci_config:
+  system_id: ucp
+  apic_hosts:
+    - 10.30.120.100
+  apic_login:
+    username: admin
+    password: noir0123
+  aep: kube-aep
+  vrf:
+    name: kube
+    tenant: common
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  custom_epgs:
+    - group1
+    - group2
+
+net_config:
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+
+kube_config:
+  controller: 1.1.1.1
+  use_cluster_role: true
+  use_ds_rolling_update: true
+
+registry:
+  image_prefix: noiro
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -11,34 +11,34 @@ data:
     {
         "log-level": "info",
         "apic-hosts": [
-            "10.1.1.101"
+            "10.30.120.100"
         ],
-        "apic-username": "mykube",
+        "apic-username": "ucp",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
         "apic-use-inst-tag": true,
-        "aci-prefix": "mykube",
+        "aci-prefix": "ucp",
         "aci-vmm-type": "Kubernetes",
-        "aci-vmm-domain": "mykube",
-        "aci-vmm-controller": "mykube",
-        "aci-policy-tenant": "mykube",
+        "aci-vmm-domain": "ucp",
+        "aci-vmm-controller": "ucp",
+        "aci-policy-tenant": "ucp",
         "require-netpol-annot": false,
-        "aci-service-phys-dom": "mykube-pdom",
+        "aci-service-phys-dom": "ucp-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 0,
         "aci-vrf-tenant": "common",
-        "aci-l3out": "mykube_l3out",
+        "aci-l3out": "l3out",
         "aci-ext-networks": [
-            "mykube_extepg"
+            "default"
         ],
-        "aci-vrf": "mykube-vrf",
+        "aci-vrf": "kube",
         "default-endpoint-group": {
-            "policy-space": "mykube",
-            "name": "kubernetes|mykube-default"
+            "policy-space": "ucp",
+            "name": "dockerucp|ucp-default"
         },
         "namespace-default-endpoint-group": {
             "kube-system": {
-                "policy-space": "mykube",
-                "name": "kubernetes|mykube-system"
+                "policy-space": "ucp",
+                "name": "dockerucp|ucp-system"
             }
         },
         "service-ip-pool": [
@@ -74,10 +74,10 @@ data:
     {
         "log-level": "info",
         "aci-vmm-type": "Kubernetes",
-        "aci-vmm-domain": "mykube",
-        "aci-vmm-controller": "mykube",
-        "aci-prefix": "mykube",
-        "aci-vrf": "mykube-vrf",
+        "aci-vmm-domain": "ucp",
+        "aci-vmm-controller": "ucp",
+        "aci-prefix": "ucp",
+        "aci-vrf": "kube",
         "aci-vrf-tenant": "common",
         "service-vlan": 4003,
         "encap-type": "vxlan",
@@ -95,13 +95,13 @@ data:
             }
         ],
         "default-endpoint-group": {
-            "policy-space": "mykube",
-            "name": "kubernetes|mykube-default"
+            "policy-space": "ucp",
+            "name": "dockerucp|ucp-default"
         },
         "namespace-default-endpoint-group": {
             "kube-system": {
-                "policy-space": "mykube",
-                "name": "kubernetes|mykube-system"
+                "policy-space": "ucp",
+                "name": "dockerucp|ucp-system"
             }
         }
     }
@@ -122,8 +122,8 @@ metadata:
   labels:
     aci-containers-config-version: "dummy"
 data:
-  user.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUNlQUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQW1Jd2dnSmVBZ0VBQW9HQkFOTmkzVUZvbWhtQjJrVlYKWkxOdVB3aG5wUW9Lb2Rkelo1Qmw2YktsZjlGMEFOQmNrNVlUWGhRcXZ1cGt6SFVUVWxCbW5VS1daZHRkQmovbwptQW5wNlZVNmVVNlg2V2ljWTJtSHhxOE0zNXVYcXc2MjRoSlRrN0JxZTh6R0o1NTRFeGxTOHRJcjBVVDNkbThXCk5Vb3JFZmR0dlFXdUVvVENZYnowUVBXUUp4MlhBZ01CQUFFQ2dZRUF3TXFlZVJWcDFuRzBIU0F3NCtWYzM5R0gKbUl6eDVvcCtuaGdVK0xZd3lWcy9rc21jWVhmd2lmd2llNnpMUE13T2V2M2IxK3RMb3JKSkRPaWFJaENRbVY2UApEL2Q1QWhCQnNIQUR3SGV3c1hFdm1XeGl1cEhVK3MxSUFIUEJoOXJoMFlnTGlMZ0IxWkZQSk5EOUFWTTJNZU1SCmcyMmZoWEJicXU1RUZHSjI0U0VDUVFEcWJIeTlTQXdMSUdOZHFaTExiUDZCdlVaSFMrd3k2R2JhQVlWdlZrcWcKNG1TbzY5aHdIUXhRUmYvOVF2TVN1b2lZbUc0TDdaQkRpUkMzdmJFNHVsMWRBa0VBNXRlUU9uN2FCSmdMeXliSgpxbkYreFlJRFVWMk0wQ0owQmpxNndjTkg5MnpSdnZVc0hxVnBwMUs5WTVsZGN6WGlYU014cHROcGIvMEhpbGk4CkRDSkRnd0pBWnE0eVRTNWJxQnY5cWk3Mmo0Z2tTbXUvZHNjNHBHdkxjVDR0VmtFejJ4aVBBcmFiVFRCTURuVTYKMVpJWHFtSnVKbmpONndlWm94dE1hVTc3YTErbU9RSkJBTUdlUXJuZGxnM09YZTM2VGFIcGFoUk5WVzBVa3p3cgorYmNUNFhzTnlUb05pdXVwQm1WNkJtRXlzK2xyUkllU3haZXJJa1UwQTdiTHUxeGR5dlErZFBNQ1FRQ0lNOW0yCkxXVVkvVUpINjA5QzUwK3A3b1F1cWVHWVRyRlVNcXFiaUJ5eFVjdCt4V0FaTXpmZWljNldaOFRvczFZSmZqYmcKOWFCL3dqVUdXazMwY1FtTAotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==
-  user.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUI1akNDQVU4Q0FnUG9NQTBHQ1NxR1NJYjNEUUVCQlFVQU1Ec3hDekFKQmdOVkJBWVRBbFZUTVJZd0ZBWUQKVlFRS0RBMURhWE5qYnlCVGVYTjBaVzF6TVJRd0VnWURWUVFEREF0VmMyVnlJRzE1YTNWaVpUQWVGdzB4TnpBMgpNREl3TmpJMU1qUmFGdzB5TnpBMU16RXdOakkxTWpSYU1Ec3hDekFKQmdOVkJBWVRBbFZUTVJZd0ZBWURWUVFLCkRBMURhWE5qYnlCVGVYTjBaVzF6TVJRd0VnWURWUVFEREF0VmMyVnlJRzE1YTNWaVpUQ0JuekFOQmdrcWhraUcKOXcwQkFRRUZBQU9CalFBd2dZa0NnWUVBMDJMZFFXaWFHWUhhUlZWa3MyNC9DR2VsQ2dxaDEzTm5rR1hwc3FWLwowWFFBMEZ5VGxoTmVGQ3ErNm1UTWRSTlNVR2FkUXBabDIxMEdQK2lZQ2VucFZUcDVUcGZwYUp4amFZZkdyd3pmCm01ZXJEcmJpRWxPVHNHcDd6TVlubm5nVEdWTHkwaXZSUlBkMmJ4WTFTaXNSOTIyOUJhNFNoTUpodlBSQTlaQW4KSFpjQ0F3RUFBVEFOQmdrcWhraUc5dzBCQVFVRkFBT0JnUUFvTVlhbHNaTDhZTHNBOFpwQnV2eFAydGwyWlRnYQp4WnFuN1hjZUlURlJ6UkR3M3lYOHZud0wxVkovSVJjekorcGUvNzB5NC90MVBpekxFM3h0VnpjSFU0S1ozWDMzCmg0ZGFnZmdWeHVVRFV1NWNjY1dVVTVVNnFNSkFEclBMaXh3d3FZUExKNXRUTUFtck9KZW4wNEt1VitYd0M5TVoKUDE2VXNKZmRETmdodmc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+  user.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUNkZ0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQW1Bd2dnSmNBZ0VBQW9HQkFOcitBK2dPS2JBVlZySnMKYjMrWldiY25WWG8vZ2R1eElUa3ZtMDlrZWlGQ24rVXAvU0dkcXY2QWgramxKZkY3dXYrRmdDSnRDeEQ4N3FZdwowcTVEY0dWTEljZkY0WlViOUI4ckpXS0JJNndKZnh0TWZGdVVOWTI0Y2d3UXBKcXJNVXFBRHovTVcrd3JaZWhzClNuRnN5ZXdYUjM4OGVSN0VLakRXZWdkSnlQY1hBZ01CQUFFQ2dZQjlBWGIxWmZCQ0JVeEIrVWdFVEdNNys0WDkKakhieUUwQmx4bGtmanJsd2R2bVM5TTc3KzJaNmRLQWdQMzNUUk0vUHdFTU9ZN1JuZEJvK1g2eERzVmRjVEpJeQo1Vnc4eFVabHIrYXVFT2xzMlpuWngxMWU1emg3c1UzTmo1SzM1QldSOUdUWEo2UE1kcFQ0OWxCOWJsbE1qRHJMCjcrNWJDc2R1NjNPOEthTjlZUUpCQVBHTWJwSHBGc3RDMWNXR3BSUXgzaXdGK1pMWUFyQVViQ0tiV1FmYmlaVHAKQ1M4RGdPbXlVN3VLVFJLaUMrMlJZVFMzcHJMVjU3R3ZmZkZ4SmpUd0d5a0NRUURvR0J3ZjVpT3N5dU1RTno3SwpSaXJiRDBKN1I2WWVRa0paK3BDZUt3eStOeUlxeGgwTEJEbUJ5bVNLdlgwV0VLQ2l0T2dwaTMyRldCb3FIamYzCk1RZy9Ba0JMQkxScWVKdnRzT28zbUtPNGEreDJlN3lSVUtrMUNvS3pGTkJIMG5VZVhHblB3aVROYitiMWZmU0YKN3ZJSmJIZG1LZ3VKeTBsVU5BN0haNzdYL2lKUkFrQWpuYmVMS1p6bDRraVA3M3BpUGZ4TG0zN2ZQakoreURvNApacHdVdVpSK0NDWGxISHZPZWZwOU1WcldjNWVqY0MvR2FDNk1XWXlNanVXTSt4QXBqY3V2QWtFQXpZK3AxNDBDCnh3cHI5NWxpbm52V2NDN043MDhBSkZpbTMvRlUxMEdEbzc3eUlPSTVoKzUzN0piWWRtNTU1aE9lSC9LalNla2gKRUY0TW14UlBtaXQ5OXc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==
+  user.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUI2RENDQVZFQ0FnUG9NQTBHQ1NxR1NJYjNEUUVCQlFVQU1Ed3hDekFKQmdOVkJBWVRBbFZUTVJZd0ZBWUQKVlFRS0RBMURhWE5qYnlCVGVYTjBaVzF6TVJVd0V3WURWUVFEREF4VmMyVnlJRzFoYm1SbFpYQXdIaGNOTVRjdwpOVEUyTWpFeU9UTXdXaGNOTWpjd05URTBNakV5T1RNd1dqQThNUXN3Q1FZRFZRUUdFd0pWVXpFV01CUUdBMVVFCkNnd05RMmx6WTI4Z1UzbHpkR1Z0Y3pFVk1CTUdBMVVFQXd3TVZYTmxjaUJ0WVc1a1pXVndNSUdmTUEwR0NTcUcKU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FEYS9nUG9EaW13RlZheWJHOS9tVm0zSjFWNlA0SGJzU0U1TDV0UApaSG9oUXAvbEtmMGhuYXIrZ0lmbzVTWHhlN3IvaFlBaWJRc1EvTzZtTU5LdVEzQmxTeUhIeGVHVkcvUWZLeVZpCmdTT3NDWDhiVEh4YmxEV051SElNRUtTYXF6RktnQTgvekZ2c0syWG9iRXB4Yk1uc0YwZC9QSGtleENvdzFub0gKU2NqM0Z3SURBUUFCTUEwR0NTcUdTSWIzRFFFQkJRVUFBNEdCQUhYK2tMVGU2TENBQmV3bUNUdk1zanVzSGRwWgpraTAxK25RN0tobkVSYkJtL3RaNXNjWkU0Y3RJcWNoM255MUVJVEhOdFlXS0JONENkVUtjanZEVzJoMnZrSGVnCnJ0WWJWK0FhRXNxMG00dkdGOUVtdnQxY3A5WTQxSXlNQlpZcXc4Yy9WMUF0bVJRY1JUWVFBOEgzT0ZEY2h5QjIKMEpIU0RuQm9TN2ZmU2JCeAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/provision/testdata/flavor_openshift.apic.txt
+++ b/provision/testdata/flavor_openshift.apic.txt
@@ -1,8 +1,8 @@
-/api/mo/uni/infra/vlanns-[kube-pool]-static.json
+/api/mo/uni/infra/vlanns-[os-pool]-static.json
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "name": "kube-pool",
+            "name": "os-pool",
             "allocMode": "static"
         },
         "children": [
@@ -27,12 +27,12 @@
         ]
     }
 }
-/api/mo/uni/infra/maddrns-kube-mpool.json
+/api/mo/uni/infra/maddrns-os-mpool.json
 {
     "fvnsMcastAddrInstP": {
         "attributes": {
-            "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "name": "os-mpool",
+            "dn": "uni/infra/maddrns-os-mpool"
         },
         "children": [
             {
@@ -46,29 +46,29 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
+/api/mo/uni/phys-os-pdom.json
 {
     "physDomP": {
         "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "dn": "uni/phys-os-pdom",
+            "name": "os-pdom"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[os-pool]-static"
                     }
                 }
             }
         ]
     }
 }
-/api/mo/uni/vmmp-OpenShift/dom-kube.json
+/api/mo/uni/vmmp-OpenShift/dom-os.json
 {
     "vmmDomP": {
         "attributes": {
-            "name": "kube",
+            "name": "os",
             "mode": "openshift",
             "enfPref": "sw",
             "encapMode": "vxlan",
@@ -79,7 +79,7 @@
             {
                 "vmmCtrlrP": {
                     "attributes": {
-                        "name": "kube",
+                        "name": "os",
                         "mode": "openshift",
                         "scope": "openshift",
                         "hostOrIp": "1.1.1.1"
@@ -89,7 +89,7 @@
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-os-mpool"
                     }
                 }
             }
@@ -100,20 +100,20 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "os-aep"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-OpenShift/dom-kube"
+                        "tDn": "uni/vmmp-OpenShift/dom-os"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-os-pdom"
                     }
                 }
             },
@@ -151,7 +151,7 @@
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
-                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
+                                    "tDn": "uni/tn-os/ap-openshift/epg-os-nodes",
                                     "encap": "vlan-4001"
                                 }
                             }
@@ -162,11 +162,11 @@
         ]
     }
 }
-/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/vmmp-OpenShift/dom-kube].json
+/api/mo/uni/infra/attentp-os-aep/rsdomP-[uni/vmmp-OpenShift/dom-os].json
 None
-/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/phys-kube-pdom].json
+/api/mo/uni/infra/attentp-os-aep/rsdomP-[uni/phys-os-pdom].json
 None
-/api/mo/uni/infra/attentp-kube-aep/gen-default/rsfuncToEpg-[uni/tn-kube/ap-kubernetes/epg-kube-nodes].json
+/api/mo/uni/infra/attentp-os-aep/gen-default/rsfuncToEpg-[uni/tn-os/ap-openshift/epg-os-nodes].json
 None
 /api/mo/uni/infra.json
 {
@@ -188,7 +188,7 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "os-allow-all-filter"
                     },
                     "children": [
                         {
@@ -204,7 +204,7 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "os-l3out-allow-all"
                     },
                     "children": [
                         {
@@ -218,7 +218,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "os-allow-all-filter"
                                             }
                                         }
                                     }
@@ -231,34 +231,34 @@ None
         ]
     }
 }
-/api/mo/uni/tn-common/flt-kube-allow-all-filter.json
+/api/mo/uni/tn-common/flt-os-allow-all-filter.json
 None
-/api/mo/uni/tn-common/brc-kube-l3out-allow-all.json
+/api/mo/uni/tn-common/brc-os-l3out-allow-all.json
 None
-/api/mo/uni/tn-kube.json
+/api/mo/uni/tn-os.json
 {
     "fvTenant": {
         "attributes": {
-            "name": "kube",
-            "dn": "uni/tn-kube"
+            "name": "os",
+            "dn": "uni/tn-os"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "openshift"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "os-default"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-OpenShift/dom-kube"
+                                                "tDn": "uni/vmmp-OpenShift/dom-os"
                                             }
                                         }
                                     },
@@ -272,7 +272,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "os-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -293,14 +293,14 @@ None
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "os-pod-bd"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "os-api"
                                             }
                                         }
                                     },
@@ -324,7 +324,7 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "os-system"
                                 },
                                 "children": [
                                     {
@@ -358,28 +358,28 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "os-api"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "os-l3out-allow-all"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-OpenShift/dom-kube"
+                                                "tDn": "uni/vmmp-OpenShift/dom-os"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "os-pod-bd"
                                             }
                                         }
                                     },
@@ -424,7 +424,7 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "os-nodes"
                                 },
                                 "children": [
                                     {
@@ -437,7 +437,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "os-api"
                                             }
                                         }
                                     },
@@ -458,7 +458,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "os-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -466,14 +466,14 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-os-pdom"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "os-node-bd"
                                             }
                                         }
                                     },
@@ -503,7 +503,7 @@ None
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-OpenShift/dom-kube"
+                                                "tDn": "uni/vmmp-OpenShift/dom-os"
                                             }
                                         }
                                     },
@@ -517,7 +517,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "os-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -538,14 +538,14 @@ None
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "os-pod-bd"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "os-api"
                                             }
                                         }
                                     },
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-OpenShift/dom-kube"
+                                                "tDn": "uni/vmmp-OpenShift/dom-os"
                                             }
                                         }
                                     },
@@ -589,7 +589,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "os-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -610,14 +610,14 @@ None
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "os-pod-bd"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "os-api"
                                             }
                                         }
                                     },
@@ -644,7 +644,7 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-node-bd",
+                        "name": "os-node-bd",
                         "arpFlood": "yes"
                     },
                     "children": [
@@ -659,7 +659,7 @@ None
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "os"
                                 }
                             }
                         },
@@ -676,7 +676,7 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "os-pod-bd"
                     },
                     "children": [
                         {
@@ -689,7 +689,7 @@ None
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "os"
                                 }
                             }
                         }
@@ -799,13 +799,13 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "os-api-filter"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "kube-api",
+                                    "name": "os-api",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6443",
@@ -818,7 +818,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "kube-api2",
+                                    "name": "os-api2",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8443",
@@ -834,13 +834,13 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "os-api"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "kube-api-subj",
+                                    "name": "os-api-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
@@ -848,7 +848,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "os-api-filter"
                                             }
                                         }
                                     }
@@ -1084,17 +1084,17 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "os-l3out-allow-all"
         }
     }
 }
-/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-kube-l3out-allow-all.json
+/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-os-l3out-allow-all.json
 None
-/api/node/mo/uni/userext/user-kube.json
+/api/node/mo/uni/userext/user-os.json
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube",
+            "name": "os",
             "accountStatus": "active",
             "pwd": "NotRandom!"
         },
@@ -1119,17 +1119,17 @@ None
         ]
     }
 }
-/api/node/mo/uni/userext/user-kube.json
+/api/node/mo/uni/userext/user-os.json
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "os"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
-                        "name": "kube.crt",
+                        "name": "os.crt",
                         "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
                     }
                 }

--- a/provision/testdata/flavor_openshift.inp.yaml
+++ b/provision/testdata/flavor_openshift.inp.yaml
@@ -1,0 +1,50 @@
+aci_config:
+  system_id: os
+  apic_hosts:
+    - 10.30.120.100
+  apic_login:
+    username: admin
+    password: noir0123
+  aep: os-aep
+  app_profile: openshift
+  vrf:
+    name: os
+    tenant: common
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  custom_epgs:
+    - group1
+    - group2
+
+net_config:
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+
+kube_config:
+  controller: 1.1.1.1
+  use_cluster_role: true
+  use_ds_rolling_update: true
+
+registry:
+  image_prefix: noiro
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -23,16 +23,16 @@ data:
         "apic-hosts": [
             "10.30.120.100"
         ],
-        "apic-username": "kube",
+        "apic-username": "os",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
         "apic-use-inst-tag": true,
-        "aci-prefix": "kube",
+        "aci-prefix": "os",
         "aci-vmm-type": "OpenShift",
-        "aci-vmm-domain": "kube",
-        "aci-vmm-controller": "kube",
-        "aci-policy-tenant": "kube",
+        "aci-vmm-domain": "os",
+        "aci-vmm-controller": "os",
+        "aci-policy-tenant": "os",
         "require-netpol-annot": false,
-        "aci-service-phys-dom": "kube-pdom",
+        "aci-service-phys-dom": "os-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 0,
         "aci-vrf-tenant": "common",
@@ -40,15 +40,15 @@ data:
         "aci-ext-networks": [
             "default"
         ],
-        "aci-vrf": "kube",
+        "aci-vrf": "os",
         "default-endpoint-group": {
-            "policy-space": "kube",
-            "name": "kubernetes|kube-default"
+            "policy-space": "os",
+            "name": "openshift|os-default"
         },
         "namespace-default-endpoint-group": {
             "aci-containers-system": {
-                "policy-space": "kube",
-                "name": "kubernetes|kube-system"
+                "policy-space": "os",
+                "name": "openshift|os-system"
             }
         },
         "service-ip-pool": [
@@ -85,10 +85,10 @@ data:
     {
         "log-level": "info",
         "aci-vmm-type": "OpenShift",
-        "aci-vmm-domain": "kube",
-        "aci-vmm-controller": "kube",
-        "aci-prefix": "kube",
-        "aci-vrf": "kube",
+        "aci-vmm-domain": "os",
+        "aci-vmm-controller": "os",
+        "aci-prefix": "os",
+        "aci-vrf": "os",
         "aci-vrf-tenant": "common",
         "service-vlan": 4003,
         "encap-type": "vxlan",
@@ -106,13 +106,13 @@ data:
             }
         ],
         "default-endpoint-group": {
-            "policy-space": "kube",
-            "name": "kubernetes|kube-default"
+            "policy-space": "os",
+            "name": "openshift|os-default"
         },
         "namespace-default-endpoint-group": {
             "aci-containers-system": {
-                "policy-space": "kube",
-                "name": "kubernetes|kube-system"
+                "policy-space": "os",
+                "name": "openshift|os-system"
             }
         }
     }


### PR DESCRIPTION
Added option to add "app_profile" as part of the input file to acc-provision, defaults according to the flavor name: "openshift", "dockerucp", and kubernetes for the rest.

More info: noironetworks/support#845