### PR TITLE
Moving Docker UCP 3.0 from experimental to supported

### DIFF
--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -31,31 +31,31 @@ flavors:
     default_version: 4.1
     status: null
     hidden: false
-    order: 4 
+    order: 5
   kubernetes-1.13:
     desc: Kubernetes 1.13
     default_version: 4.1
     status: null
     hidden: false
-    order: 5
+    order: 6
   kubernetes-1.12:
     desc: Kubernetes 1.12
     default_version: 4.1
     status: null
     hidden: true
-    order: 6
+    order: 7
   kubernetes-1.11:
     desc: Kubernetes 1.11
     default_version: 1.9
     status: null
     hidden: true
-    order: 7
+    order: 8
   kubernetes-1.10:
     desc: Kubernetes 1.10
     default_version: 1.9
     status: null
     hidden: true
-    order: 8
+    order: 9
   openshift-3.11:
     desc: Red Hat OpenShift Container Platform 3.11
     default_version: 4.1
@@ -177,7 +177,7 @@ flavors:
   docker-ucp-3.0:
     desc: Docker Universal Control Plane (UCP) 3.0
     default_version: 4.1
-    status: Experimental
+    status: null
     hidden: false
     config:
       aci_config:
@@ -203,7 +203,7 @@ flavors:
             etherT: ip
             prot: tcp
             stateful: "no"
-    order: 10
+    order: 4
   # CloudFoundry
   cloudfoundry-1.0:
     desc: CloudFoundry cf-deployment 1.x
@@ -215,7 +215,7 @@ flavors:
     options: *anchor
     status: null
     hidden: false
-    order: 9
+    order: 10
   k8s-localhost:
     desc: Kubernetes localhost 
     default_version: 4.1

--- a/provision/testdata/list_flavors.stdout.txt
+++ b/provision/testdata/list_flavors.stdout.txt
@@ -2,8 +2,8 @@ INFO: Available configuration flavors:
 INFO: openshift-3.11:	Red Hat OpenShift Container Platform 3.11
 INFO: openshift-3.10:	Red Hat OpenShift Container Platform 3.10
 INFO: openshift-3.9:	Red Hat OpenShift Container Platform 3.9
+INFO: docker-ucp-3.0:	Docker Universal Control Plane (UCP) 3.0
 INFO: kubernetes-1.14:	Kubernetes 1.14
 INFO: kubernetes-1.13:	Kubernetes 1.13
 INFO: cloudfoundry-1.0:	CloudFoundry cf-deployment 1.x
-INFO: docker-ucp-3.0:	Docker Universal Control Plane (UCP) 3.0 [Experimental]
 INFO: k8s-localhost:	Kubernetes localhost [Experimental]


### PR DESCRIPTION
(cherry picked from commit 15756618cb4d4858a7ff1d6989e14b43d6c7aadb)