### PR TITLE
CSCvq63491 Setting memory limit for OVS container in the Spec.

### DIFF
--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -716,6 +716,9 @@ spec:
         - name: aci-containers-openvswitch
           image: {{ config.registry.image_prefix }}/openvswitch:{{ config.registry.openvswitch_version }}
           imagePullPolicy: {{ config.kube_config.image_pull_policy }}
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             {% if config.kube_config.use_privileged_containers %}
             privileged: true

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -532,6 +532,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -532,6 +532,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -590,6 +590,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noirolabs/openvswitch:latest
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -593,6 +593,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             privileged: true
             capabilities:

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -532,6 +532,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -532,6 +532,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -532,6 +532,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -532,6 +532,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -532,6 +532,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -532,6 +532,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -532,6 +532,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -532,6 +532,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -533,6 +533,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -572,6 +572,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             privileged: true
             capabilities:

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -534,6 +534,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -532,6 +532,9 @@ spec:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.1.1.5.r16
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "20Gi"
           securityContext:
             capabilities:
               add:


### PR DESCRIPTION
To handle a potential memory-leak issue in upstream OVS code.