### PR TITLE
Revise RBAC permissions on resources like pods

### DIFF
--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -290,7 +290,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "{{ config.kube_config.use_netpol_apigroup }}"
   resources:
@@ -323,9 +325,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
   {% else %}
   verbs:
   - '*'

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -252,7 +252,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -272,9 +274,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -252,7 +252,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -272,9 +274,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -252,7 +252,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -272,9 +274,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -292,7 +292,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -263,7 +263,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -283,9 +285,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -252,7 +252,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -272,9 +274,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -252,7 +252,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -272,9 +274,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -252,7 +252,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -272,9 +274,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -252,7 +252,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -272,9 +274,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -252,7 +252,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -272,9 +274,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -252,7 +252,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -272,9 +274,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -252,7 +252,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -272,9 +274,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -252,7 +252,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -272,9 +274,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -253,7 +253,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -273,9 +275,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -254,7 +254,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -274,9 +276,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -254,7 +254,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -274,9 +276,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -252,7 +252,9 @@ rules:
   - configmaps
   - replicationcontrollers
   verbs:
-  - '*'
+  - list
+  - watch
+  - get
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -272,9 +274,6 @@ rules:
   - list
   - watch
   - get
-  - update
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Removed update/create/delete permissions for acc controller on k8s resources like pods, services, deployments

(cherry picked from commit 93d5956693bea88bdf5b4b318fa8911c3d9085d5)