### PR TITLE
SNAT Operator configuration changes

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -174,6 +174,7 @@ def config_default():
             "ovs_memory_limit": "10Gi",
             "snat_operator": {
                 "name": "snat-operator",
+                "watch_namespace": "",
                 "snat_namespace": "default",
                 "globalinfo_name": "snatglobalinfo",
             },

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -90,7 +90,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -319,12 +319,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "{{ config.kube_config.use_netpol_apigroup }}"
   resources:
@@ -873,6 +883,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: "{{ config.kube_config.snat_operator.watch_namespace }}"
             - name: ACI_SNAT_NAMESPACE
               value: "{{ config.kube_config.snat_operator.snat_namespace }}"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -281,12 +281,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -686,6 +696,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -281,12 +281,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -686,6 +696,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -281,12 +281,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -686,6 +696,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "snat_namespace"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -76,7 +76,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -321,12 +321,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -745,6 +755,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -47,7 +47,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -292,12 +292,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -748,6 +758,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -281,12 +281,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -686,6 +696,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -281,12 +281,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -686,6 +696,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -281,12 +281,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -686,6 +696,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -281,12 +281,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -686,6 +696,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -281,12 +281,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -686,6 +696,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -281,12 +281,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -686,6 +696,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -281,12 +281,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -686,6 +696,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -281,12 +281,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -686,6 +696,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -282,12 +282,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -687,6 +697,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -283,12 +283,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -727,6 +737,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -283,12 +283,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -688,6 +698,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -37,7 +37,7 @@ spec:
     listKind: SnatPolicyList
     plural: snatpolicies
     singular: snatpolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:
@@ -281,12 +281,22 @@ rules:
   - endpoints
   - services
   - events
-  - configmaps
   - replicationcontrollers
   verbs:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
 - apiGroups:
   - "networking.k8s.io"
   resources:
@@ -686,6 +696,8 @@ spec:
           command:
           - snat-operator
           env:
+            - name: WATCH_NAMESPACE
+              value: ""
             - name: ACI_SNAT_NAMESPACE
               value: "default"
             - name: ACI_SNAGLOBALINFO_NAME


### PR DESCRIPTION
1. Allowing create/update/delete access to configmaps

2. Making snatpolicy namespaceless
by:
a. Updating the scope of snatpolicy CRD to Cluster
     scope: Cluster
b. Adding empty watch_namespace in the deployment
      env:
                  - name: WATCH_NAMESPACE
                    value: ""