### PR TITLE
Configure external pod connectivity

### DIFF
--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -1580,28 +1580,6 @@ class ApicKubeConfig(object):
             collections.OrderedDict(
                 [
                     (
-                        "fvRsCons",
-                        collections.OrderedDict(
-                            [
-                                (
-                                    "attributes",
-                                    collections.OrderedDict(
-                                        [
-                                            (
-                                                "tnVzBrCPName",
-                                                "%s-l3out-allow-all" % system_id,
-                                            )
-                                        ]
-                                    ),
-                                )
-                            ]
-                        ),
-                    )
-                ]
-            ),
-            collections.OrderedDict(
-                [
-                    (
                         "fvRsProv",
                         collections.OrderedDict(
                             [
@@ -1662,6 +1640,28 @@ class ApicKubeConfig(object):
                                         "attributes",
                                         collections.OrderedDict(
                                             [("tnVzBrCPName", "kube-api")]
+                                        ),
+                                    )
+                                ]
+                            ),
+                        )
+                    ]
+                )
+            )
+
+        if eade is True:
+            kube_default_children.append(
+                collections.OrderedDict(
+                    [
+                        (
+                            "fvRsCons",
+                            collections.OrderedDict(
+                                [
+                                    (
+                                        "attributes",
+                                        collections.OrderedDict(
+                                            [("tnVzBrCPName",
+                                              "%s-l3out-allow-all" % system_id)]
                                         ),
                                     )
                                 ]

--- a/provision/testdata/base_case.apic.txt
+++ b/provision/testdata/base_case.apic.txt
@@ -270,13 +270,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"
@@ -445,13 +438,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"
@@ -492,13 +478,6 @@ None
                                         "fvRsCons": {
                                             "attributes": {
                                                 "tnVzBrCPName": "dns"
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
                                             }
                                         }
                                     },

--- a/provision/testdata/base_case_ipv6.apic.txt
+++ b/provision/testdata/base_case_ipv6.apic.txt
@@ -270,13 +270,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"

--- a/provision/testdata/flavor_dockerucp.apic.txt
+++ b/provision/testdata/flavor_dockerucp.apic.txt
@@ -270,13 +270,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"
@@ -445,13 +438,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"
@@ -492,13 +478,6 @@ None
                                         "fvRsCons": {
                                             "attributes": {
                                                 "tnVzBrCPName": "dns"
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
                                             }
                                         }
                                     },

--- a/provision/testdata/flavor_openshift.apic.txt
+++ b/provision/testdata/flavor_openshift.apic.txt
@@ -270,13 +270,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"
@@ -515,13 +508,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"
@@ -583,13 +569,6 @@ None
                                         "fvRsCons": {
                                             "attributes": {
                                                 "tnVzBrCPName": "dns"
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
                                             }
                                         }
                                     },

--- a/provision/testdata/nested-elag.apic.txt
+++ b/provision/testdata/nested-elag.apic.txt
@@ -348,13 +348,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"

--- a/provision/testdata/nested-portgroup.apic.txt
+++ b/provision/testdata/nested-portgroup.apic.txt
@@ -340,13 +340,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"

--- a/provision/testdata/nested-vlan.apic.txt
+++ b/provision/testdata/nested-vlan.apic.txt
@@ -340,13 +340,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"

--- a/provision/testdata/nested-vxlan.apic.txt
+++ b/provision/testdata/nested-vxlan.apic.txt
@@ -305,13 +305,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"

--- a/provision/testdata/pod_ext_access.apic.txt
+++ b/provision/testdata/pod_ext_access.apic.txt
@@ -270,13 +270,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"
@@ -301,6 +294,13 @@ None
                                         "fvRsCons": {
                                             "attributes": {
                                                 "tnVzBrCPName": "kube-api"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all"
                                             }
                                         }
                                     }
@@ -452,13 +452,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"
@@ -483,6 +476,13 @@ None
                                         "fvRsCons": {
                                             "attributes": {
                                                 "tnVzBrCPName": "kube-api"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all"
                                             }
                                         }
                                     }
@@ -510,13 +510,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"
@@ -541,6 +534,13 @@ None
                                         "fvRsCons": {
                                             "attributes": {
                                                 "tnVzBrCPName": "kube-api"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all"
                                             }
                                         }
                                     }

--- a/provision/testdata/vlan_case.apic.txt
+++ b/provision/testdata/vlan_case.apic.txt
@@ -297,13 +297,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"

--- a/provision/testdata/with_comments.apic.txt
+++ b/provision/testdata/with_comments.apic.txt
@@ -270,13 +270,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"

--- a/provision/testdata/with_interface_mtu.apic.txt
+++ b/provision/testdata/with_interface_mtu.apic.txt
@@ -270,13 +270,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"
@@ -445,13 +438,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"
@@ -492,13 +478,6 @@ None
                                         "fvRsCons": {
                                             "attributes": {
                                                 "tnVzBrCPName": "dns"
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
                                             }
                                         }
                                     },

--- a/provision/testdata/with_overrides.apic.txt
+++ b/provision/testdata/with_overrides.apic.txt
@@ -270,13 +270,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"

--- a/provision/testdata/with_tenant_l3out.apic.txt
+++ b/provision/testdata/with_tenant_l3out.apic.txt
@@ -270,13 +270,6 @@ None
                                         }
                                     },
                                     {
-                                        "fvRsCons": {
-                                            "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "health-check"


### PR DESCRIPTION
External pod connectivity enabled only when allow_pods_kube_api_access is true

(cherry picked from commit 599317f42ed9a11eeaeeb7da6ee49f1155114a9c)