### PR TITLE
Config for max nodes in snat svc graph; default-32

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -184,6 +184,7 @@ def config_default():
                     "ports_per_node": 3000,
                 },
             },
+            "max_nodes_svc_graph": 32
         },
         "registry": {
             "image_prefix": "noiro",
@@ -459,6 +460,20 @@ def is_valid_refreshtime(xval):
     raise(Exception("Must be integer between %d and %d" % (xmin, xmax)))
 
 
+def is_valid_max_nodes_svc_graph(xval):
+    if xval is None:
+        return True
+    xmin = 1
+    xmax = 64
+    try:
+        x = int(xval)
+        if xmin <= x <= xmax:
+            return True
+    except ValueError:
+        pass
+    raise(Exception("Must be integer between %d and %d" % (xmin, xmax)))
+
+
 def config_validate(flavor_opts, config):
     def Raise(exception):
         raise exception
@@ -490,6 +505,10 @@ def config_validate(flavor_opts, config):
                                   required),
         "aci_config/l3out/external-networks":
         (get(("aci_config", "l3out", "external_networks")), required),
+
+        # Kubernetes config
+        "kube_config/max_nodes_svc_graph": (get(("kube_config", "max_nodes_svc_graph")),
+                                            is_valid_max_nodes_svc_graph),
 
         # Network Config
         "net_config/infra_vlan": (get(("net_config", "infra_vlan")),

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -222,6 +222,7 @@ data:
             "policy-space": {{config.kube_config.default_endpoint_group.tenant|json}},
             "name": {{(config.kube_config.default_endpoint_group.app_profile ~ "|" ~ config.kube_config.default_endpoint_group.group)|json}}
         },
+        "max-nodes-svc-graph": {{ config.kube_config.max_nodes_svc_graph|json }},
         "namespace-default-endpoint-group": {
             {% for ns, val in config.kube_config.namespace_default_endpoint_group.items() %}
             "{{ns}}": {

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/base_case_snat.inp.yaml
+++ b/provision/testdata/base_case_snat.inp.yaml
@@ -46,6 +46,7 @@ kube_config:
       start: 6000
       end: 62000
       ports_per_node: 500
+  max_nodes_svc_graph: 64
 
 registry:
   image_prefix: noiro

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 64,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -207,6 +207,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "aci-containers-system": {
                 "policy-space": "kube",

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "mykube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "mykube",

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -169,6 +169,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -168,6 +168,7 @@ data:
             "policy-space": "kube",
             "name": "kubernetes|kube-default"
         },
+        "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
             "kube-system": {
                 "policy-space": "kube",


### PR DESCRIPTION
Set option to configure the maximum number of nodes allowed per service graph 