### PR TITLE
Enable PBR Tracking by default

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -159,7 +159,7 @@ def config_default():
             "node_svc_subnet": None,
             "kubeapi_vlan": None,
             "service_vlan": None,
-            "service_monitor_interval": 0,
+            "service_monitor_interval": 5,
             "interface_mtu": None,
         },
         "kube_config": {

--- a/provision/acc_provision/templates/provision-config.yaml
+++ b/provision/acc_provision/templates/provision-config.yaml
@@ -53,8 +53,9 @@ net_config:
   service_vlan: 4003            # The VLAN used by LoadBalancer services
   infra_vlan: 4093              # The VLAN used by ACI infra
   #interface_mtu: 1600          # min = 1280 for ipv6, max = 8900 for VXLAN
+  #service_monitor_interval: 5  # IPSLA interval probe time for PBR tracking
+                                # default is 5, set to 0 to disable, max: 65535
 
-#
 # Configuration for container registry
 # Update if a custom container registry has been setup
 #

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -196,7 +196,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-1022",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "kube",
         "aci-l3out": "l3out-v1",
         "aci-ext-networks": [

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "mykube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "mykube_l3out",
         "aci-ext-networks": [

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kubernetes-control",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -158,7 +158,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -157,7 +157,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 0,
+        "aci-service-monitor-interval": 5,
         "aci-vrf-tenant": "kube",
         "aci-l3out": "l3out",
         "aci-ext-networks": [


### PR DESCRIPTION
- Set IPSLA interval to 5, this enables PBR tracking
- User can disable PBR tracking by setting the interval to 0

This is mainly done for SNAT feature as all compute-nodes are added as service endpoints and it is important to make sure the reachability of these nodes.