### PR TITLE
ENV variable for controlling opflex-agent reboot

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -174,6 +174,7 @@ def config_default():
             "kubectl": "kubectl",
             "system_namespace": "kube-system",
             "ovs_memory_limit": "10Gi",
+            "reboot_opflex_with_ovs": "true",
             "snat_operator": {
                 "name": "snat-operator",
                 "watch_namespace": "",

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -687,6 +687,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "{{ config.kube_config.reboot_opflex_with_ovs }}"
           image: {{ config.registry.image_prefix }}/opflex:{{ config.registry.opflex_agent_version }}
           imagePullPolicy: {{ config.kube_config.image_pull_policy }}
           securityContext:

--- a/provision/acc_provision/templates/provision-config.yaml
+++ b/provision/acc_provision/templates/provision-config.yaml
@@ -65,3 +65,4 @@ registry:
 
 #kube_config:
   # ovs_memory_limit: "20Gi"            # override if needed, default is "10Gi"
+  # reboot_opflex_with_ovs: "false"     # override if needed, default is "true"

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -544,6 +544,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -544,6 +544,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -544,6 +544,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -582,6 +582,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noirolabs/opflex:latest
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -592,6 +592,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -544,6 +544,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -544,6 +544,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -544,6 +544,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -544,6 +544,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -544,6 +544,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -544,6 +544,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -544,6 +544,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -544,6 +544,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -545,6 +545,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -581,6 +581,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -546,6 +546,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -544,6 +544,9 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
           image: noiro/opflex:4.1.1.5.r21
           imagePullPolicy: Always
           securityContext:


### PR DESCRIPTION
Introducing an env vairable which will control the behavior of whether opflex-agent reboots when OVS boots-up.

(cherry picked from commit 3d58874eb25bc6d574c013c8960f6f1e9cca6a7b)