### PR TITLE
Option to enable PBR-Tracking for non-snat services

### DIFF
--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -214,6 +214,7 @@ data:
         "aci-service-phys-dom": {{config.aci_config.physical_domain.domain|json}},
         "aci-service-encap": {{ ("vlan-" ~ config.net_config.service_vlan)|json }},
         "aci-service-monitor-interval": {{ config.net_config.service_monitor_interval|json }},
+        "aci-pbr-tracking-non-snat": {{ config.net_config.pbr_tracking_non_snat|json }},
         "aci-vrf-tenant": {{config.aci_config.vrf.tenant|json}},
         "aci-l3out": {{config.aci_config.l3out.name|json}},
         "aci-ext-networks": {{ config.aci_config.l3out.external_networks|json|indent(width=8) }},

--- a/provision/acc_provision/templates/provision-config.yaml
+++ b/provision/acc_provision/templates/provision-config.yaml
@@ -55,6 +55,8 @@ net_config:
   #interface_mtu: 1600          # min = 1280 for ipv6, max = 8900 for VXLAN
   #service_monitor_interval: 5  # IPSLA interval probe time for PBR tracking
                                 # default is 5, set to 0 to disable, max: 65535
+  #pbr_tracking_non_snat: true  # Default is false, set to true for IPSLA to
+                                # be effective with non-snat services
 
 #
 # Configuration for container registry

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -197,6 +197,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-1022",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "kube",
         "aci-l3out": "l3out-v1",
         "aci-ext-networks": [

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "mykube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "mykube_l3out",
         "aci-ext-networks": [

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kubernetes-control",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -159,6 +159,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -158,6 +158,7 @@ data:
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
         "aci-vrf-tenant": "kube",
         "aci-l3out": "l3out",
         "aci-ext-networks": [


### PR DESCRIPTION
When IPSLA is set to non-zero value, it takes effect only for SNAT services and the user is required to enable "pbr_tracking_non_snat" explicitly for non-snat services.

This is for not taking a chance of breaking any existing functionality during ACC upgrade.