### PR TITLE
Setting OVS container resource limit to 1Gi

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -174,7 +174,7 @@ def config_default():
             "image_pull_policy": "Always",
             "kubectl": "kubectl",
             "system_namespace": "kube-system",
-            "ovs_memory_limit": "10Gi",
+            "ovs_memory_limit": "1Gi",
             "reboot_opflex_with_ovs": "true",
             "snat_operator": {
                 "name": "snat-operator",

--- a/provision/acc_provision/templates/provision-config.yaml
+++ b/provision/acc_provision/templates/provision-config.yaml
@@ -67,5 +67,5 @@ registry:
   # image_pull_secret: secret_name      # (if needed)
 
 #kube_config:
-  # ovs_memory_limit: "20Gi"            # override if needed, default is "10Gi"
+  # ovs_memory_limit: "20Gi"            # override if needed, default is "1Gi"
   # reboot_opflex_with_ovs: "false"     # override if needed, default is "true"

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -643,7 +643,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -643,7 +643,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -643,7 +643,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -696,7 +696,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -694,7 +694,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             privileged: true
             capabilities:

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -643,7 +643,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -643,7 +643,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -643,7 +643,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -643,7 +643,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -643,7 +643,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -643,7 +643,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -643,7 +643,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -643,7 +643,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -644,7 +644,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -683,7 +683,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             privileged: true
             capabilities:

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -645,7 +645,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -643,7 +643,7 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "10Gi"
+              memory: "1Gi"
           securityContext:
             capabilities:
               add:


### PR DESCRIPTION
Per observation that the memory footprint is not as much,
and 10Gi is very large number in comparison.