### PR TITLE
Add snat namespace field to host config

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -185,6 +185,7 @@ def config_default():
                     "end": 65000,
                     "ports_per_node": 3000,
                 },
+                "snat_namespace": "aci-containers-system",
             },
             "max_nodes_svc_graph": 32
         },

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -245,6 +245,7 @@ data:
   host-agent-config: |-
     {
         "log-level": {{config.logging.hostagent_log_level|json}},
+        "aci-snat-namespace": "{{ config.kube_config.snat_operator.snat_namespace }}",
         "aci-vmm-type": {{config.aci_config.vmm_domain.type|json}},
         "aci-vmm-domain": {{config.aci_config.vmm_domain.domain|json}},
         "aci-vmm-controller": {{config.aci_config.vmm_domain.controller|json}},
@@ -915,7 +916,7 @@ spec:
             - name: WATCH_NAMESPACE
               value: "{{ config.kube_config.snat_operator.watch_namespace }}"
             - name: ACI_SNAT_NAMESPACE
-              value: "aci-containers-system"
+              value: "{{ config.kube_config.snat_operator.snat_namespace }}"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "{{ config.kube_config.snat_operator.globalinfo_name }}"
             - name: POD_NAME

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -208,6 +208,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -208,6 +208,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",

--- a/provision/testdata/base_case_snat.inp.yaml
+++ b/provision/testdata/base_case_snat.inp.yaml
@@ -46,6 +46,7 @@ kube_config:
       start: 6000
       end: 62000
       ports_per_node: 500
+    snat_namespace: test_namespace
   max_nodes_svc_graph: 64
 
 registry:

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -208,6 +208,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "test_namespace",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",
@@ -726,7 +727,7 @@ spec:
             - name: WATCH_NAMESPACE
               value: ""
             - name: ACI_SNAT_NAMESPACE
-              value: "aci-containers-system"
+              value: "test_namespace"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "test_snatglobalinfo"
             - name: POD_NAME

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -247,6 +247,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "debug",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -209,6 +209,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "OpenShift",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -208,6 +208,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -208,6 +208,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -208,6 +208,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -208,6 +208,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -208,6 +208,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -208,6 +208,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "mykube",
         "aci-vmm-controller": "mykube",

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -208,6 +208,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -208,6 +208,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -208,6 +208,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -209,6 +209,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "debug",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kubernetes1",
         "aci-vmm-controller": "kubernetes1",

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -209,6 +209,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -208,6 +208,7 @@ data:
   host-agent-config: |-
     {
         "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",


### PR DESCRIPTION
Complementing https://github.com/noironetworks/aci-containers/pull/339
Set to "aci-containers-sytem" by default. Can be overridden by changing kube_config/snat_operator/snat_namespace field

(cherry picked from commit 32480463e9aeaf95695ea0a1b403dfe9d12dcb5f)