### PR TITLE
Initial version of acc-retrieve-cert

### DIFF
--- a/provision/acc_provision/acc_retrieve_cert.py
+++ b/provision/acc_provision/acc_retrieve_cert.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+import base64
+import json
+import subprocess
+
+
+def kubectl(kind, name, namespace=None):
+    ret = None
+    cmd = ['kubectl', 'get', '-o', 'json']
+    cmd.extend([kind, name])
+    if namespace:
+        cmd.extend(['-n', namespace])
+    retstr = subprocess.check_output(cmd)
+    if retstr:
+        ret = json.loads(retstr).get('data')
+    return ret
+
+
+def get_secret(name, namespace, *keys):
+    ret = []
+    data = kubectl('secret', name, namespace)
+    decode = lambda k: data.get(k) and base64.b64decode(data[k].decode("ascii"))
+    if keys:
+        ret = map(decode, keys)
+    return ret
+
+
+def get_sysid(name, namespace):
+    ret = None
+    data = kubectl('configmap', name, namespace)
+    if data and data.get('controller-config'):
+        config = json.loads(data.get('controller-config'))
+        if config:
+            ret = config.get('aci-prefix')
+    return ret
+
+
+def retrieve_certs(sysid, name, namespace=None):
+    key, crt = get_secret(name, namespace, 'user.key', 'user.crt')
+    for k, v in zip(['key', 'crt'], [key, crt]):
+        if v:
+            fname = 'user-%s.%s' % (sysid, k)
+            with open(fname, "w") as fd:
+                fd.write(v)
+
+
+def main():
+    namespace = 'aci-containers-system'
+    config_name = 'aci-containers-config'
+    secret_name = 'aci-user-cert'
+
+    try:
+        sysid = get_sysid(config_name, namespace)
+        if sysid:
+            retrieve_certs(sysid, secret_name, namespace)
+    except Exception as e:
+        print(e)
+
+
+if __name__ == '__main__':
+    main()

--- a/provision/rpm/acc-provision.spec.in
+++ b/provision/rpm/acc-provision.spec.in
@@ -34,7 +34,7 @@ mkdir -p %{buildroot}/var/lib/aci-containers/kubectl/plugins/aci
 cat > %{buildroot}/var/lib/aci-containers/kubectl/plugins/aci/plugin.yaml <<-EOF
 name: "aci"
 shortDesc: "CLI plugin for acikubectl commands"
-command: "acikubectl" 
+command: "acikubectl"
 EOF
 chmod 0755 %{buildroot}/var/lib/aci-containers/kubectl/plugins/aci/plugin.yaml
 
@@ -44,6 +44,7 @@ chmod 0755 %{buildroot}/var/lib/aci-containers/kubectl/plugins/aci/plugin.yaml
 %{python2_sitelib}/acc_provision-%%{version}*.egg-info
 %{python2_sitelib}/gitversion
 %{_bindir}/acc-provision
+%{_bindir}/acc-retrieve-cert
 %{_bindir}/acikubectl
 /var/lib/aci-containers/kubectl/plugins/aci/plugin.yaml
 

--- a/provision/setup.py
+++ b/provision/setup.py
@@ -18,6 +18,7 @@ setup(
     entry_points={
         'console_scripts': [
             'acc-provision=acc_provision.acc_provision:main',
+            'acc-retrieve-cert=acc_provision.acc_retrieve_cert:main',
         ]
     },
     install_requires=[


### PR DESCRIPTION
acc-retrieve-cert retrieves the key/cert being currently used.
It requires that the host running the script should have access
to kubectl command as admin to the cluster being managed (as the
default context).

(cherry picked from commit 3c311058f3b7df447f7d6f4bd4dd363ba3f09e8c)