### PR TITLE
Fix Refresh-timer format to be a string.

### DIFF
--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -201,7 +201,7 @@ data:
         "apic-hosts": {{config.aci_config.apic_hosts|json|indent(width=8)}},
         "apic-username": {{config.aci_config.sync_login.username|json}},
         {% if config.aci_config.apic_refreshtime %}
-        "apic-refreshtime": {{config.aci_config.apic_refreshtime|json}},
+        "apic-refreshtime": "{{config.aci_config.apic_refreshtime|json}}",
         {% endif %}
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
         "apic-use-inst-tag": {{config.aci_config.use_inst_tag|json}},

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -147,7 +147,7 @@ data:
             "10.30.120.100"
         ],
         "apic-username": "kube",
-        "apic-refreshtime": 1200,
+        "apic-refreshtime": "1200",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
         "apic-use-inst-tag": true,
         "aci-prefix": "kube",

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -147,7 +147,7 @@ data:
             "10.30.120.100"
         ],
         "apic-username": "kube",
-        "apic-refreshtime": 1200,
+        "apic-refreshtime": "1200",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
         "apic-use-inst-tag": true,
         "aci-prefix": "kube",


### PR DESCRIPTION
ACC expects refresh-timer value in string format.

(cherry picked from commit 16649961528a8a9262225c3418ecb63b3eff7a17)