### PR TITLE
Fixing validation for service_monitor_interval

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -459,7 +459,7 @@ def is_valid_ipsla_interval(xval):
         # use default configured on this host
         return True
 
-    xmin = 1
+    xmin = 0
     xmax = 65535
     try:
         x = int(xval)


### PR DESCRIPTION
Such that it allows setting to zero (which will
disable PBR tracking, if required).