### PR TITLE
Remove default flavor option from acc-provision

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -65,7 +65,6 @@ with open(FLAVORS_PATH, 'r') as stream:
         doc = yaml.safe_load(stream)
     except yaml.YAMLError as exc:
         print(exc)
-    DEFAULT_FLAVOR = doc['default_flavor']
     DEFAULT_FLAVOR_OPTIONS = doc['kubeFlavorOptions']
     CfFlavorOptions = doc['cfFlavorOptions']
     FLAVORS = doc['flavors']
@@ -1054,9 +1053,7 @@ def provision(args, apic_file, no_random):
 
     deep_merge(config, user_config)
 
-    flavor = DEFAULT_FLAVOR
-    if args.flavor:
-        flavor = args.flavor
+    flavor = args.flavor
     if flavor in FLAVORS:
         info("Using configuration flavor " + flavor)
         deep_merge(config, {"flavor": flavor})
@@ -1149,6 +1146,11 @@ def main(args=None, apic_file=None, no_random=False):
                     desc = desc + " [" + FLAVORS[flavor]["status"] + "]"
                 info(flavor + ":\t" + desc)
         return
+
+    if args.flavor is None:
+        err("Flavor not provided. Use -f to pass a flavor name, --list-flavors to see a list of supported flavors")
+        sys.exit(1)
+
     if args.flavor is not None and args.flavor not in FLAVORS:
         err("Invalid configuration flavor: " + args.flavor)
         sys.exit(1)

--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -1,4 +1,3 @@
-default_flavor: kubernetes-1.12
 
 # Known Flavor options:
 # - template_generator: Function that generates the output config

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -340,7 +340,7 @@ def get_args(**overrides):
         "timeout": None,
         "debug": True,
         "list_flavors": False,
-        "flavor": None,
+        "flavor": "kubernetes-1.15",
         "version_token": "dummy",
         "release": False,
         # infra_vlan is not part of command line input, but we do

--- a/provision/testdata/devnull.stderr.txt
+++ b/provision/testdata/devnull.stderr.txt
@@ -1,4 +1,4 @@
-INFO: Using configuration flavor kubernetes-1.12
+INFO: Using configuration flavor kubernetes-1.15
 ERR:  Invalid configuration for aci_config/aep: Missing option
 ERR:  Invalid configuration for aci_config/apic_host: Missing option
 ERR:  Invalid configuration for aci_config/l3out/external-networks: Missing option

--- a/provision/testdata/overlapping_subnets.stdout.txt
+++ b/provision/testdata/overlapping_subnets.stdout.txt
@@ -1,3 +1,3 @@
 INFO: Loading configuration from "with_overlapping_subnets.inp.yaml"
-INFO: Using configuration flavor kubernetes-1.12
+INFO: Using configuration flavor kubernetes-1.15
 ERR:  overlapping subnets found in configuration input file


### PR DESCRIPTION
Return an error if no flavor provided.

(cherry picked from commit b62301191aa6729aa1e6c876dfdb5c3f163f8673)