### PR TITLE
Annotate acc_provision objects

### DIFF
--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -362,12 +362,12 @@ def run_provision(inpfile, expectedkube=None, expectedapic=None,
         args = get_args(config=inpfile, output=output.name, **overrides)
         acc_provision.main(args, apicfile.name, no_random=True)
         if expectedkube is not None:
-            if debug:
+            if args.debug:
                 shutil.copyfile(output.name, '/tmp/generated_kube.yaml')
             with open(expectedkube, "r") as expected:
                 assert output.read() == expected.read()
         if expectedapic is not None:
-            if debug:
+            if args.debug:
                 shutil.copyfile(apicfile.name, '/tmp/generated_apic.txt')
             with open(expectedapic, "r") as expected:
                 assert apicfile.read() == expected.read()

--- a/provision/testdata/base_case.apic.txt
+++ b/provision/testdata/base_case.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,14 +35,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.2.1.1",
-                        "to": "225.2.255.255"
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -51,13 +56,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -73,7 +80,8 @@
             "enfPref": "sw",
             "encapMode": "vxlan",
             "prefEncapMode": "vxlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -82,14 +90,16 @@
                         "name": "kube",
                         "mode": "k8s",
                         "scope": "kubernetes",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -100,27 +110,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -128,14 +142,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -145,14 +161,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -173,7 +191,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -188,13 +207,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -204,7 +225,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -212,13 +234,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -240,53 +264,61 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -296,62 +328,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -361,41 +402,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -403,14 +450,16 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -420,41 +469,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "group1"
+                                    "name": "group1",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -464,41 +519,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "group2"
+                                    "name": "group2",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -512,28 +573,32 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.1.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -543,20 +608,23 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ip": "10.2.0.1/16"
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -566,7 +634,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -574,7 +643,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -583,7 +653,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -593,7 +664,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -603,7 +675,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -613,7 +686,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -623,7 +697,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -633,7 +708,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -643,7 +719,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -656,7 +733,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -666,7 +744,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -678,7 +757,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -691,7 +771,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -701,7 +782,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -709,13 +791,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -728,7 +812,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -737,19 +822,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -759,13 +847,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -781,7 +871,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -789,13 +880,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -808,7 +901,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -816,13 +910,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -840,7 +936,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -852,20 +949,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -879,14 +979,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/base_case_ipv6.apic.txt
+++ b/provision/testdata/base_case_ipv6.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,14 +35,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.2.1.1",
-                        "to": "225.2.255.255"
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -51,13 +56,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -73,7 +80,8 @@
             "enfPref": "sw",
             "encapMode": "vxlan",
             "prefEncapMode": "vxlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -82,14 +90,16 @@
                         "name": "kube",
                         "mode": "k8s",
                         "scope": "kubernetes",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -100,27 +110,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -128,14 +142,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -145,14 +161,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -173,7 +191,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -188,13 +207,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -204,7 +225,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -212,13 +234,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -240,53 +264,61 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -296,62 +328,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -361,41 +402,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -403,14 +450,16 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -424,7 +473,8 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -432,13 +482,15 @@ None
                                 "attributes": {
                                     "ip": "1:1:1:1::1/64",
                                     "scope": "public",
-                                    "ctrl": "nd"
+                                    "ctrl": "nd",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsNdPfxPol": {
                                             "attributes": {
-                                                "tnNdPfxPolName": "kube-nd-ra-policy"
+                                                "tnNdPfxPolName": "kube-nd-ra-policy",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -448,14 +500,16 @@ None
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -465,20 +519,23 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "1:2:1:1::1/64",
-                                    "ctrl": "nd"
+                                    "ctrl": "nd",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsNdPfxPol": {
                                             "attributes": {
-                                                "tnNdPfxPolName": "kube-nd-ra-policy"
+                                                "tnNdPfxPolName": "kube-nd-ra-policy",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -488,7 +545,8 @@ None
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -498,7 +556,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -506,7 +565,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -515,7 +575,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -525,7 +586,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -535,7 +597,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -545,7 +608,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -555,7 +619,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -565,7 +630,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -575,7 +641,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -588,7 +655,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -598,7 +666,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -610,7 +679,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -623,7 +693,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -633,7 +704,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -641,13 +713,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -660,7 +734,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -669,19 +744,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -691,13 +769,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -713,7 +793,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -721,13 +802,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -740,7 +823,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -748,13 +832,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -770,7 +856,8 @@ None
                         "ctrl": "on-link,router-address",
                         "lifetime": "2592000",
                         "name": "kube-nd-ra-policy",
-                        "prefLifetime": "604800"
+                        "prefLifetime": "604800",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -782,7 +869,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -794,20 +882,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -821,14 +912,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/flavor_cf_10.apic.txt
+++ b/provision/testdata/flavor_cf_10.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "mycf0-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -23,14 +25,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "mycf0-mpool",
-            "dn": "uni/infra/maddrns-mycf0-mpool"
+            "dn": "uni/infra/maddrns-mycf0-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.2.1.1",
-                        "to": "225.2.255.255"
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -42,13 +46,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-mycf0-pdom",
-            "name": "mycf0-pdom"
+            "name": "mycf0-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[mycf0-pool]-static"
+                        "tDn": "uni/infra/vlanns-[mycf0-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -64,7 +70,8 @@
             "enfPref": "sw",
             "encapMode": "vxlan",
             "prefEncapMode": "vxlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -73,14 +80,16 @@
                         "name": "mycf0",
                         "mode": "cf",
                         "scope": "cloudfoundry",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-mycf0-mpool"
+                        "tDn": "uni/infra/maddrns-mycf0-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -92,14 +101,16 @@
     "vmmUsrCustomAggr": {
         "attributes": {
             "name": "mycf0",
-            "promMode": "Disabled"
+            "promMode": "Disabled",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4093",
-                        "to": "vlan-4093"
+                        "to": "vlan-4093",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -107,7 +118,8 @@
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -118,27 +130,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "cf-aep"
+            "name": "cf-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-CloudFoundry/dom-mycf0"
+                        "tDn": "uni/vmmp-CloudFoundry/dom-mycf0",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-mycf0-pdom"
+                        "tDn": "uni/phys-mycf0-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -146,14 +162,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -163,7 +181,8 @@
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-VMware/dom-myvmware"
+                        "tDn": "uni/vmmp-VMware/dom-myvmware",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -181,7 +200,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -196,13 +216,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "mycf0-allow-all-filter"
+                        "name": "mycf0-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -212,7 +234,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "mycf0-l3out-allow-all"
+                        "name": "mycf0-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -220,13 +243,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "mycf0-allow-all-filter"
+                                                "tnVzFilterName": "mycf0-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -928,7 +953,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "mycf0-l3out-allow-all"
+            "tnVzBrCPName": "mycf0-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -940,20 +966,23 @@ None
         "attributes": {
             "name": "mycf0",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -967,14 +996,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "mycf0"
+            "name": "mycf0",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "mycf0.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/flavor_dockerucp.apic.txt
+++ b/provision/testdata/flavor_dockerucp.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,14 +35,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.2.1.1",
-                        "to": "225.2.255.255"
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -51,13 +56,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -73,7 +80,8 @@
             "enfPref": "sw",
             "encapMode": "vxlan",
             "prefEncapMode": "vxlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -82,14 +90,16 @@
                         "name": "kube",
                         "mode": "k8s",
                         "scope": "kubernetes",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -100,27 +110,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -128,14 +142,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -145,14 +161,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -173,7 +191,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -188,13 +207,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -204,7 +225,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -212,13 +234,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -240,53 +264,61 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -296,62 +328,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -361,41 +402,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -403,14 +450,16 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -420,41 +469,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "group1"
+                                    "name": "group1",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -464,41 +519,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "group2"
+                                    "name": "group2",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -512,28 +573,32 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.1.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -543,20 +608,23 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ip": "10.2.0.1/16"
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -566,7 +634,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -574,7 +643,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -583,7 +653,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -593,7 +664,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -603,7 +675,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -613,7 +686,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -623,7 +697,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -633,7 +708,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -643,7 +719,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -656,7 +733,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -666,7 +744,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -678,7 +757,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -691,7 +771,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -704,7 +785,8 @@ None
                                     "dFromPort": "443",
                                     "dToPort": "443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -717,7 +799,8 @@ None
                                     "dFromPort": "12376",
                                     "dToPort": "12376",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -730,7 +813,8 @@ None
                                     "dFromPort": "10250",
                                     "dToPort": "10250",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -743,7 +827,8 @@ None
                                     "dFromPort": "12378",
                                     "dToPort": "12388",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -753,7 +838,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -761,13 +847,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -780,7 +868,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -789,19 +878,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -811,13 +903,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -833,7 +927,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -841,13 +936,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -860,7 +957,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -868,13 +966,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -892,7 +992,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -904,20 +1005,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -931,14 +1035,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/flavor_openshift.apic.txt
+++ b/provision/testdata/flavor_openshift.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,14 +35,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.2.1.1",
-                        "to": "225.2.255.255"
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -51,13 +56,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -73,7 +80,8 @@
             "enfPref": "sw",
             "encapMode": "vxlan",
             "prefEncapMode": "vxlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -82,14 +90,16 @@
                         "name": "kube",
                         "mode": "openshift",
                         "scope": "openshift",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -100,27 +110,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-OpenShift/dom-kube"
+                        "tDn": "uni/vmmp-OpenShift/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -128,14 +142,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -145,14 +161,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -173,7 +191,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -188,13 +207,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -204,7 +225,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -212,13 +234,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -240,74 +264,85 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-OpenShift/dom-kube"
+                                                "tDn": "uni/vmmp-OpenShift/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring"
+                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring"
+                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -317,97 +352,111 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-OpenShift/dom-kube"
+                                                "tDn": "uni/vmmp-OpenShift/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog"
+                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring"
+                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring"
+                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -417,41 +466,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -459,28 +514,32 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog"
+                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring"
+                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -490,62 +549,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "group1"
+                                    "name": "group1",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-OpenShift/dom-kube"
+                                                "tDn": "uni/vmmp-OpenShift/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring"
+                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring"
+                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -555,62 +623,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "group2"
+                                    "name": "group2",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-OpenShift/dom-kube"
+                                                "tDn": "uni/vmmp-OpenShift/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring"
+                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring"
+                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -624,28 +701,32 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.1.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -655,20 +736,23 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ip": "10.2.0.1/16"
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -678,7 +762,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -686,7 +771,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -695,7 +781,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -705,7 +792,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -715,7 +803,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -725,7 +814,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -735,7 +825,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -745,7 +836,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -755,7 +847,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -768,7 +861,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -778,7 +872,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -790,7 +885,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -803,7 +899,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -813,7 +910,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -821,13 +919,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -840,7 +940,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -849,19 +950,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -871,13 +975,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -893,7 +999,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -901,13 +1008,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -920,7 +1029,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -928,13 +1038,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -947,7 +1059,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog"
+                        "name": "openshift-svc-catalog",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -955,13 +1068,15 @@ None
                                 "attributes": {
                                     "name": "openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter"
+                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -974,7 +1089,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring"
+                        "name": "openshift-monitoring",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -982,13 +1098,15 @@ None
                                 "attributes": {
                                     "name": "openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter"
+                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -1001,7 +1119,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter"
+                        "name": "openshift-svc-catalog-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -1013,7 +1132,8 @@ None
                                     "dFromPort": "2379",
                                     "dToPort": "2379",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -1023,7 +1143,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter"
+                        "name": "openshift-monitoring-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -1035,7 +1156,8 @@ None
                                     "dFromPort": "9091",
                                     "dToPort": "9091",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -1048,7 +1170,8 @@ None
                                     "dFromPort": "9094",
                                     "dToPort": "9094",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -1063,7 +1186,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -1075,20 +1199,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -1102,14 +1229,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/nested-elag.apic.txt
+++ b/provision/testdata/nested-elag.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,7 +35,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-vpool",
-            "allocMode": "dynamic"
+            "allocMode": "dynamic",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -40,7 +44,8 @@
                     "attributes": {
                         "allocMode": "dynamic",
                         "from": "vlan-1000",
-                        "to": "vlan-2000"
+                        "to": "vlan-2000",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -52,14 +57,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.20.1.1",
-                        "to": "225.20.255.255"
+                        "to": "225.20.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -71,13 +78,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -93,7 +102,8 @@
             "enfPref": "sw",
             "encapMode": "vlan",
             "prefEncapMode": "vlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -102,21 +112,24 @@
                         "name": "kube",
                         "mode": "k8s",
                         "scope": "kubernetes",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-vpool]-dynamic"
+                        "tDn": "uni/infra/vlanns-[kube-vpool]-dynamic",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -128,14 +141,16 @@
     "vmmUsrCustomAggr": {
         "attributes": {
             "name": "kube-test",
-            "promMode": "Enabled"
+            "promMode": "Enabled",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4093",
-                        "to": "vlan-4093"
+                        "to": "vlan-4093",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -143,7 +158,8 @@
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -151,7 +167,8 @@
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -159,7 +176,8 @@
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-1000",
-                        "to": "vlan-2000"
+                        "to": "vlan-2000",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -167,7 +185,8 @@
                 "vmmRsUsrAggrLagPolAtt": {
                     "attributes": {
                         "status": "",
-                        "tDn": "uni/vmmp-VMware/dom-myvmware/vswitchpolcont/enlacplagp-my-elag"
+                        "tDn": "uni/vmmp-VMware/dom-myvmware/vswitchpolcont/enlacplagp-my-elag",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -178,27 +197,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -206,14 +229,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -223,14 +248,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -251,7 +278,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -266,13 +294,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -282,7 +312,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -290,13 +321,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -318,53 +351,61 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -374,62 +415,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -439,41 +489,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -481,14 +537,16 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -502,28 +560,32 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.1.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -533,20 +595,23 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ip": "10.2.0.1/16"
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -556,7 +621,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -564,7 +630,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -573,7 +640,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -583,7 +651,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -593,7 +662,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -603,7 +673,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -613,7 +684,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -623,7 +695,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -633,7 +706,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -646,7 +720,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -656,7 +731,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -668,7 +744,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -681,7 +758,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -691,7 +769,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -699,13 +778,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -718,7 +799,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -727,19 +809,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -749,13 +834,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -771,7 +858,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -779,13 +867,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -798,7 +888,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -806,13 +897,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -830,7 +923,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -842,20 +936,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -869,14 +966,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/nested-portgroup.apic.txt
+++ b/provision/testdata/nested-portgroup.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,7 +35,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-vpool",
-            "allocMode": "dynamic"
+            "allocMode": "dynamic",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -40,7 +44,8 @@
                     "attributes": {
                         "allocMode": "dynamic",
                         "from": "vlan-1000",
-                        "to": "vlan-2000"
+                        "to": "vlan-2000",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -52,14 +57,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.20.1.1",
-                        "to": "225.20.255.255"
+                        "to": "225.20.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -71,13 +78,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -93,7 +102,8 @@
             "enfPref": "sw",
             "encapMode": "vlan",
             "prefEncapMode": "vlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -102,21 +112,24 @@
                         "name": "kube",
                         "mode": "k8s",
                         "scope": "kubernetes",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-vpool]-dynamic"
+                        "tDn": "uni/infra/vlanns-[kube-vpool]-dynamic",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -128,14 +141,16 @@
     "vmmUsrCustomAggr": {
         "attributes": {
             "name": "kube-test",
-            "promMode": "Enabled"
+            "promMode": "Enabled",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4093",
-                        "to": "vlan-4093"
+                        "to": "vlan-4093",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -143,7 +158,8 @@
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -151,7 +167,8 @@
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -159,7 +176,8 @@
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-1000",
-                        "to": "vlan-2000"
+                        "to": "vlan-2000",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -170,27 +188,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -198,14 +220,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -215,14 +239,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -243,7 +269,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -258,13 +285,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -274,7 +303,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -282,13 +312,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -310,53 +342,61 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -366,62 +406,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -431,41 +480,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -473,14 +528,16 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -494,28 +551,32 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.1.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -525,20 +586,23 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ip": "10.2.0.1/16"
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -548,7 +612,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -556,7 +621,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -565,7 +631,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -575,7 +642,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -585,7 +653,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -595,7 +664,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -605,7 +675,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -615,7 +686,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -625,7 +697,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -638,7 +711,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -648,7 +722,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -660,7 +735,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -673,7 +749,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -683,7 +760,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -691,13 +769,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -710,7 +790,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -719,19 +800,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -741,13 +825,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -763,7 +849,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -771,13 +858,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -790,7 +879,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -798,13 +888,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -822,7 +914,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -834,20 +927,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -861,14 +957,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/nested-vlan.apic.txt
+++ b/provision/testdata/nested-vlan.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,7 +35,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-vpool",
-            "allocMode": "dynamic"
+            "allocMode": "dynamic",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -40,7 +44,8 @@
                     "attributes": {
                         "allocMode": "dynamic",
                         "from": "vlan-1000",
-                        "to": "vlan-2000"
+                        "to": "vlan-2000",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -52,14 +57,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.20.1.1",
-                        "to": "225.20.255.255"
+                        "to": "225.20.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -71,13 +78,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -93,7 +102,8 @@
             "enfPref": "sw",
             "encapMode": "vlan",
             "prefEncapMode": "vlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -102,21 +112,24 @@
                         "name": "kube",
                         "mode": "k8s",
                         "scope": "kubernetes",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-vpool]-dynamic"
+                        "tDn": "uni/infra/vlanns-[kube-vpool]-dynamic",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -128,14 +141,16 @@
     "vmmUsrCustomAggr": {
         "attributes": {
             "name": "kube",
-            "promMode": "Enabled"
+            "promMode": "Enabled",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4093",
-                        "to": "vlan-4093"
+                        "to": "vlan-4093",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -143,7 +158,8 @@
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -151,7 +167,8 @@
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -159,7 +176,8 @@
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-1000",
-                        "to": "vlan-2000"
+                        "to": "vlan-2000",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -170,27 +188,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -198,14 +220,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -215,14 +239,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -243,7 +269,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -258,13 +285,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -274,7 +303,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -282,13 +312,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -310,53 +342,61 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -366,62 +406,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -431,41 +480,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -473,14 +528,16 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -494,28 +551,32 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.1.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -525,20 +586,23 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ip": "10.2.0.1/16"
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -548,7 +612,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -556,7 +621,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -565,7 +631,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -575,7 +642,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -585,7 +653,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -595,7 +664,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -605,7 +675,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -615,7 +686,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -625,7 +697,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -638,7 +711,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -648,7 +722,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -660,7 +735,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -673,7 +749,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -683,7 +760,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -691,13 +769,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -710,7 +790,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -719,19 +800,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -741,13 +825,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -763,7 +849,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -771,13 +858,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -790,7 +879,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -798,13 +888,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -822,7 +914,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -834,20 +927,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -861,14 +957,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/nested-vxlan.apic.txt
+++ b/provision/testdata/nested-vxlan.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,14 +35,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.2.1.1",
-                        "to": "225.2.255.255"
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -51,13 +56,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -73,7 +80,8 @@
             "enfPref": "sw",
             "encapMode": "vxlan",
             "prefEncapMode": "vxlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -82,14 +90,16 @@
                         "name": "kube",
                         "mode": "k8s",
                         "scope": "kubernetes",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -101,14 +111,16 @@
     "vmmUsrCustomAggr": {
         "attributes": {
             "name": "kube",
-            "promMode": "Disabled"
+            "promMode": "Disabled",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4093",
-                        "to": "vlan-4093"
+                        "to": "vlan-4093",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -116,7 +128,8 @@
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -124,7 +137,8 @@
                 "fvnsEncapBlk": {
                     "attributes": {
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -135,27 +149,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -163,14 +181,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -180,14 +200,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -208,7 +230,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -223,13 +246,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -239,7 +264,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -247,13 +273,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -275,53 +303,61 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -331,62 +367,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -396,41 +441,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -438,14 +489,16 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -459,28 +512,32 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.1.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -490,20 +547,23 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ip": "10.2.0.1/16"
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -513,7 +573,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -521,7 +582,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -530,7 +592,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -540,7 +603,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -550,7 +614,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -560,7 +625,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -570,7 +636,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -580,7 +647,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -590,7 +658,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -603,7 +672,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -613,7 +683,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -625,7 +696,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -638,7 +710,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -648,7 +721,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -656,13 +730,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -675,7 +751,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -684,19 +761,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -706,13 +786,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -728,7 +810,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -736,13 +819,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -755,7 +840,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -763,13 +849,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -787,7 +875,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -799,20 +888,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -826,14 +918,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/pod_ext_access.apic.txt
+++ b/provision/testdata/pod_ext_access.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,14 +35,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.2.1.1",
-                        "to": "225.2.255.255"
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -51,13 +56,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -73,7 +80,8 @@
             "enfPref": "sw",
             "encapMode": "vxlan",
             "prefEncapMode": "vxlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -82,14 +90,16 @@
                         "name": "kube",
                         "mode": "k8s",
                         "scope": "kubernetes",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -100,27 +110,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -128,14 +142,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -145,14 +161,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -173,7 +191,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -188,13 +207,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -204,7 +225,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -212,13 +234,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -240,67 +264,77 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -310,62 +344,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -375,41 +418,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -417,14 +466,16 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -434,55 +485,63 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "group1"
+                                    "name": "group1",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -492,55 +551,63 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "group2"
+                                    "name": "group2",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -554,28 +621,32 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.1.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -585,28 +656,32 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.2.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -616,7 +691,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -624,7 +700,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -633,7 +710,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -643,7 +721,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -653,7 +732,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -663,7 +743,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -673,7 +754,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -683,7 +765,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -693,7 +776,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -706,7 +790,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -716,7 +801,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -728,7 +814,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -741,7 +828,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -751,7 +839,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -759,13 +848,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -778,7 +869,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -787,19 +879,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -809,13 +904,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -831,7 +928,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -839,13 +937,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -858,7 +958,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -866,13 +967,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -890,7 +993,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -902,20 +1006,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -929,14 +1036,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/vlan_case.apic.txt
+++ b/provision/testdata/vlan_case.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,7 +35,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-vpool",
-            "allocMode": "dynamic"
+            "allocMode": "dynamic",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -40,7 +44,8 @@
                     "attributes": {
                         "allocMode": "dynamic",
                         "from": "vlan-200",
-                        "to": "vlan-299"
+                        "to": "vlan-299",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -52,14 +57,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.2.1.1",
-                        "to": "225.2.255.255"
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -71,13 +78,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -93,7 +102,8 @@
             "enfPref": "sw",
             "encapMode": "vlan",
             "prefEncapMode": "vlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -102,21 +112,24 @@
                         "name": "kube",
                         "mode": "k8s",
                         "scope": "kubernetes",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-vpool]-dynamic"
+                        "tDn": "uni/infra/vlanns-[kube-vpool]-dynamic",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -127,27 +140,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -155,14 +172,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -172,14 +191,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -200,7 +221,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -215,13 +237,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -231,7 +255,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -239,13 +264,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -267,53 +294,61 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -323,62 +358,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -388,41 +432,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -430,14 +480,16 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -451,28 +503,32 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.1.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -482,20 +538,23 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ip": "10.2.0.1/16"
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -505,7 +564,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -513,7 +573,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -522,7 +583,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -532,7 +594,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -542,7 +605,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -552,7 +616,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -562,7 +627,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -572,7 +638,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -582,7 +649,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -595,7 +663,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -605,7 +674,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -617,7 +687,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -630,7 +701,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -640,7 +712,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -648,13 +721,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -667,7 +742,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -676,19 +752,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -698,13 +777,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -720,7 +801,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -728,13 +810,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -747,7 +831,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -755,13 +840,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -779,7 +866,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -791,20 +879,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -818,14 +909,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/with_comments.apic.txt
+++ b/provision/testdata/with_comments.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,14 +35,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.2.1.1",
-                        "to": "225.2.255.255"
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -51,13 +56,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -73,7 +80,8 @@
             "enfPref": "sw",
             "encapMode": "vxlan",
             "prefEncapMode": "vxlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -82,14 +90,16 @@
                         "name": "kube",
                         "mode": "k8s",
                         "scope": "kubernetes",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -100,27 +110,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -128,14 +142,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -145,14 +161,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -173,7 +191,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -188,13 +207,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -204,7 +225,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -212,13 +234,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -240,53 +264,61 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -296,62 +328,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -361,41 +402,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -403,14 +450,16 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -424,28 +473,32 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.1.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -455,20 +508,23 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ip": "10.2.0.1/16"
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -478,7 +534,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -486,7 +543,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -495,7 +553,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -505,7 +564,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -515,7 +575,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -525,7 +586,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -535,7 +597,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -545,7 +608,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -555,7 +619,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -568,7 +633,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -578,7 +644,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -590,7 +657,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -603,7 +671,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -613,7 +682,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -621,13 +691,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -640,7 +712,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -649,19 +722,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -671,13 +747,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -693,7 +771,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -701,13 +780,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -720,7 +801,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -728,13 +810,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -752,7 +836,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -764,20 +849,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -791,14 +879,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/with_interface_mtu.apic.txt
+++ b/provision/testdata/with_interface_mtu.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,14 +35,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.2.1.1",
-                        "to": "225.2.255.255"
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -51,13 +56,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -73,7 +80,8 @@
             "enfPref": "sw",
             "encapMode": "vxlan",
             "prefEncapMode": "vxlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -82,14 +90,16 @@
                         "name": "kube",
                         "mode": "k8s",
                         "scope": "kubernetes",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -100,27 +110,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -128,14 +142,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -145,14 +161,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -173,7 +191,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -188,13 +207,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -204,7 +225,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -212,13 +234,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -240,53 +264,61 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -296,62 +328,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -361,41 +402,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -403,14 +450,16 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -420,41 +469,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "group1"
+                                    "name": "group1",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -464,41 +519,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "group2"
+                                    "name": "group2",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -512,28 +573,32 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.1.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -543,20 +608,23 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ip": "10.2.0.1/16"
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -566,7 +634,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -574,7 +643,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -583,7 +653,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -593,7 +664,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -603,7 +675,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -613,7 +686,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -623,7 +697,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -633,7 +708,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -643,7 +719,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -656,7 +733,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -666,7 +744,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -678,7 +757,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -691,7 +771,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -701,7 +782,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -709,13 +791,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -728,7 +812,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -737,19 +822,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -759,13 +847,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -781,7 +871,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -789,13 +880,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -808,7 +901,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -816,13 +910,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -840,7 +936,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -852,20 +949,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -879,14 +979,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/with_overrides.apic.txt
+++ b/provision/testdata/with_overrides.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,14 +35,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.2.1.1",
-                        "to": "225.2.255.255"
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -51,13 +56,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kubernetes-control",
-            "name": "kubernetes-control"
+            "name": "kubernetes-control",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -73,7 +80,8 @@
             "enfPref": "sw",
             "encapMode": "vxlan",
             "prefEncapMode": "vxlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -82,14 +90,16 @@
                         "name": "kubernetes1",
                         "mode": "k8s",
                         "scope": "kubernetes",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -100,27 +110,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kubernetes1"
+                        "tDn": "uni/vmmp-Kubernetes/dom-kubernetes1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kubernetes-control"
+                        "tDn": "uni/phys-kubernetes-control",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -128,14 +142,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -145,14 +161,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-demo/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -173,7 +191,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "no"
+            "opflexpUseSsl": "no",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -188,13 +207,15 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -204,7 +225,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -212,13 +234,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -240,60 +264,69 @@ None
     "fvTenant": {
         "attributes": {
             "name": "demo",
-            "dn": "uni/tn-demo"
+            "dn": "uni/tn-demo",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kubernetes1"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kubernetes1",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -303,62 +336,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kubernetes1"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kubernetes1",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -368,41 +410,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -410,14 +458,16 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kubernetes-control"
+                                                "tDn": "uni/phys-kubernetes-control",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -431,28 +481,32 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.1.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kubernetes-vrf"
+                                    "tnFvCtxName": "kubernetes-vrf",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -462,20 +516,23 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ip": "10.2.0.1/16"
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kubernetes-vrf"
+                                    "tnFvCtxName": "kubernetes-vrf",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -485,7 +542,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -493,7 +551,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -502,7 +561,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -512,7 +572,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -522,7 +583,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -532,7 +594,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -542,7 +605,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -552,7 +616,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -562,7 +627,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -575,7 +641,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -585,7 +652,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -597,7 +665,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -610,7 +679,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -620,7 +690,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -628,13 +699,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -647,7 +720,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -656,19 +730,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -678,13 +755,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -700,7 +779,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -708,13 +788,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -727,7 +809,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -735,13 +818,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -759,7 +844,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -771,20 +857,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -798,14 +887,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }

--- a/provision/testdata/with_tenant_l3out.apic.txt
+++ b/provision/testdata/with_tenant_l3out.apic.txt
@@ -3,7 +3,8 @@
     "fvnsVlanInstP": {
         "attributes": {
             "name": "kube-pool",
-            "allocMode": "static"
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -11,7 +12,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4001",
-                        "to": "vlan-4001"
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
@@ -20,7 +22,8 @@
                     "attributes": {
                         "allocMode": "static",
                         "from": "vlan-4003",
-                        "to": "vlan-4003"
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -32,14 +35,16 @@
     "fvnsMcastAddrInstP": {
         "attributes": {
             "name": "kube-mpool",
-            "dn": "uni/infra/maddrns-kube-mpool"
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvnsMcastAddrBlk": {
                     "attributes": {
                         "from": "225.2.1.1",
-                        "to": "225.2.255.255"
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -51,13 +56,15 @@
     "physDomP": {
         "attributes": {
             "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom"
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsVlanNs": {
                     "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static"
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -73,7 +80,8 @@
             "enfPref": "sw",
             "encapMode": "vxlan",
             "prefEncapMode": "vxlan",
-            "mcastAddr": "225.1.2.3"
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
@@ -82,14 +90,16 @@
                         "name": "kube",
                         "mode": "k8s",
                         "scope": "kubernetes",
-                        "hostOrIp": "1.1.1.1"
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "vmmRsDomMcastAddrNs": {
                     "attributes": {
-                        "tDn": "uni/infra/maddrns-kube-mpool"
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }
@@ -100,27 +110,31 @@
 {
     "infraAttEntityP": {
         "attributes": {
-            "name": "kube-aep"
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraRsDomP": {
                     "attributes": {
-                        "tDn": "uni/phys-kube-pdom"
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             },
             {
                 "infraProvAcc": {
                     "attributes": {
-                        "name": "provacc"
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -128,14 +142,16 @@
                                 "attributes": {
                                     "encap": "vlan-4093",
                                     "mode": "regular",
-                                    "tDn": "uni/tn-infra/ap-access/epg-default"
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "dhcpInfraProvP": {
                                 "attributes": {
-                                    "mode": "controller"
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -145,14 +161,16 @@
             {
                 "infraGeneric": {
                     "attributes": {
-                        "name": "default"
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
                                     "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
-                                    "encap": "vlan-4001"
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -173,7 +191,8 @@ None
     "infraSetPol": {
         "attributes": {
             "opflexpAuthenticateClients": "no",
-            "opflexpUseSsl": "yes"
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -182,19 +201,22 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-allow-all-filter"
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "allow-all"
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -204,7 +226,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-l3out-allow-all"
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -212,13 +235,15 @@ None
                                 "attributes": {
                                     "name": "allow-all-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-allow-all-filter"
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -240,53 +265,61 @@ None
     "fvTenant": {
         "attributes": {
             "name": "kube",
-            "dn": "uni/tn-kube"
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "fvAp": {
                     "attributes": {
-                        "name": "kubernetes"
+                        "name": "kubernetes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-default"
+                                    "name": "kube-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -296,62 +329,71 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-system"
+                                    "name": "kube-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsDomAtt": {
                                             "attributes": {
-                                                "tDn": "uni/vmmp-Kubernetes/dom-kube"
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-pod-bd"
+                                                "tnFvBDName": "kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -361,41 +403,47 @@ None
                         {
                             "fvAEPg": {
                                 "attributes": {
-                                    "name": "kube-nodes"
+                                    "name": "kube-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-api"
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "icmp"
+                                                "tnVzBrCPName": "icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "health-check"
+                                                "tnVzBrCPName": "health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "kube-l3out-allow-all"
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
@@ -403,14 +451,16 @@ None
                                         "fvRsDomAtt": {
                                             "attributes": {
                                                 "encap": "vlan-4001",
-                                                "tDn": "uni/phys-kube-pdom"
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "kube-node-bd"
+                                                "tnFvBDName": "kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -424,28 +474,32 @@ None
                 "fvBD": {
                     "attributes": {
                         "name": "kube-node-bd",
-                        "arpFlood": "yes"
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.1.0.1/16",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsBDToOut": {
                                 "attributes": {
-                                    "tnL3extOutName": "l3out"
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -455,20 +509,23 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "name": "kube-pod-bd"
+                        "name": "kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ip": "10.2.0.1/16"
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
                         {
                             "fvRsCtx": {
                                 "attributes": {
-                                    "tnFvCtxName": "kube"
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -478,7 +535,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "icmp-filter"
+                        "name": "icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -486,7 +544,8 @@ None
                                 "attributes": {
                                     "name": "icmp",
                                     "etherT": "ipv4",
-                                    "prot": "icmp"
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -495,7 +554,8 @@ None
                                 "attributes": {
                                     "name": "icmp6",
                                     "etherT": "ipv6",
-                                    "prot": "icmpv6"
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -505,7 +565,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-in"
+                        "name": "health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -515,7 +576,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -525,7 +587,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "health-check-filter-out"
+                        "name": "health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -535,7 +598,8 @@ None
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
-                                    "tcpRules": "est"
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -545,7 +609,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "dns-filter"
+                        "name": "dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -555,7 +620,8 @@ None
                                     "etherT": "ip",
                                     "prot": "udp",
                                     "dFromPort": "dns",
-                                    "dToPort": "dns"
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -568,7 +634,8 @@ None
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -578,7 +645,8 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "kube-api-filter"
+                        "name": "kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -590,7 +658,8 @@ None
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         },
@@ -603,7 +672,8 @@ None
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
                                     "stateful": "no",
-                                    "tcpRules": ""
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -613,7 +683,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "kube-api"
+                        "name": "kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -621,13 +692,15 @@ None
                                 "attributes": {
                                     "name": "kube-api-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "kube-api-filter"
+                                                "tnVzFilterName": "kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -640,7 +713,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "health-check"
+                        "name": "health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -649,19 +723,22 @@ None
                                     "name": "health-check-subj",
                                     "revFltPorts": "yes",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzOutTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-out"
+                                                            "tnVzFilterName": "health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -671,13 +748,15 @@ None
                                     {
                                         "vzInTerm": {
                                             "attributes": {
-                                                "name": ""
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             },
                                             "children": [
                                                 {
                                                     "vzRsFiltAtt": {
                                                         "attributes": {
-                                                            "tnVzFilterName": "health-check-filter-in"
+                                                            "tnVzFilterName": "health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
                                                         }
                                                     }
                                                 }
@@ -693,7 +772,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "dns"
+                        "name": "dns",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -701,13 +781,15 @@ None
                                 "attributes": {
                                     "name": "dns-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "dns-filter"
+                                                "tnVzFilterName": "dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -720,7 +802,8 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "icmp"
+                        "name": "icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
@@ -728,13 +811,15 @@ None
                                 "attributes": {
                                     "name": "icmp-subj",
                                     "consMatchT": "AtleastOne",
-                                    "provMatchT": "AtleastOne"
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 },
                                 "children": [
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "icmp-filter"
+                                                "tnVzFilterName": "icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
                                     }
@@ -752,7 +837,8 @@ None
     "fvRsProv": {
         "attributes": {
             "matchT": "AtleastOne",
-            "tnVzBrCPName": "kube-l3out-allow-all"
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
         }
     }
 }
@@ -764,20 +850,23 @@ None
         "attributes": {
             "name": "kube",
             "accountStatus": "active",
-            "pwd": "NotRandom!"
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserDomain": {
                     "attributes": {
-                        "name": "all"
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "aaaUserRole": {
                                 "attributes": {
                                     "name": "admin",
-                                    "privType": "writePriv"
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
                         }
@@ -791,14 +880,16 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "name": "kube"
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
         },
         "children": [
             {
                 "aaaUserCert": {
                     "attributes": {
                         "name": "kube.crt",
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
                     }
                 }
             }


### PR DESCRIPTION
The field "annotation" for acc-provision objects is set to orchestrator:aci-containers-controller.

(cherry picked from commit 6227bcbb03ad9f7117ef0454c4858ddecefa9c5d)