### PR TITLE
Move to 4.2.2.1

### DIFF
--- a/provision/acc_provision/versions.yaml
+++ b/provision/acc_provision/versions.yaml
@@ -14,10 +14,10 @@ versions:
     openvswitch_version: 4.1.1.5.r16
     opflex_agent_version: 4.1.1.5.r21
   4.2:
-    aci_containers_controller_version: 4.2.1.1.r22
-    aci_containers_host_version: 4.2.1.1.r22
-    snat_operator_version: 4.2.1.1.r1
-    cnideploy_version: 4.2.1.1.r22
-    openvswitch_version: 4.2.1.1.r18
-    opflex_agent_version: 4.2.1.1.r23
+    aci_containers_controller_version: 4.2.2.1.r27
+    aci_containers_host_version: 4.2.2.1.r27
+    snat_operator_version: 4.2.2.1.r3
+    cnideploy_version: 4.2.2.1.r27
+    openvswitch_version: 4.2.2.1.r23
+    opflex_agent_version: 4.2.2.1.r28
 

--- a/provision/setup.py
+++ b/provision/setup.py
@@ -6,7 +6,7 @@ from gitversion.gitversion import get_git_version
 
 setup(
     name='acc_provision',
-    version='4.2.1.1',
+    version='4.2.2.1',
     description='Tool to provision ACI for ACI Containers Controller  Build info: ' + get_git_version(),
     author="Cisco Systems, Inc.",
     author_email="apicapi@noironetworks.com",

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -514,7 +514,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -549,7 +549,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -567,7 +567,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -640,7 +640,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -719,7 +719,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -737,7 +737,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -514,7 +514,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -549,7 +549,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -567,7 +567,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -640,7 +640,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -719,7 +719,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -737,7 +737,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -514,7 +514,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -549,7 +549,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -567,7 +567,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -640,7 +640,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -719,7 +719,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: test_snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -737,7 +737,7 @@ spec:
             - name: OPERATOR_NAME
               value: "test_snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -778,7 +778,7 @@ spec:
             - name: kubeconfig
               mountPath: /kube
         - name: snat-operator
-          image: noirolabs/snat-operator:4.2.1.1.r1
+          image: noirolabs/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -549,7 +549,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: cnideploy
-          image: noiro/cnideploy:4.2.1.1.r22
+          image: noiro/cnideploy:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -561,7 +561,7 @@ spec:
               mountPath: /mnt/cni-bin
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -597,7 +597,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -616,7 +616,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -691,7 +691,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -771,7 +771,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -789,7 +789,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -514,7 +514,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -549,7 +549,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -567,7 +567,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -640,7 +640,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -719,7 +719,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -737,7 +737,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -514,7 +514,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -549,7 +549,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -567,7 +567,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -640,7 +640,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -719,7 +719,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -737,7 +737,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -514,7 +514,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -549,7 +549,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -567,7 +567,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -640,7 +640,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -719,7 +719,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -737,7 +737,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -514,7 +514,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -549,7 +549,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -567,7 +567,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -640,7 +640,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -719,7 +719,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -737,7 +737,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -514,7 +514,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -549,7 +549,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -567,7 +567,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -640,7 +640,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -719,7 +719,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -737,7 +737,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -514,7 +514,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -549,7 +549,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -567,7 +567,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -640,7 +640,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -719,7 +719,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -737,7 +737,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -514,7 +514,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -549,7 +549,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -567,7 +567,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -640,7 +640,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -719,7 +719,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -737,7 +737,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -514,7 +514,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -549,7 +549,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -567,7 +567,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -640,7 +640,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -719,7 +719,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -737,7 +737,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -515,7 +515,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -550,7 +550,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -568,7 +568,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -641,7 +641,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -720,7 +720,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -738,7 +738,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -550,7 +550,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -586,7 +586,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -605,7 +605,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -680,7 +680,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -760,7 +760,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -778,7 +778,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -516,7 +516,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -551,7 +551,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -569,7 +569,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -642,7 +642,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -721,7 +721,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -739,7 +739,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -516,7 +516,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -551,7 +551,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -569,7 +569,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -642,7 +642,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -721,7 +721,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -739,7 +739,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -514,7 +514,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:4.2.1.1.r22
+          image: noiro/aci-containers-host:4.2.2.1.r27
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -549,7 +549,7 @@ spec:
           env:
             - name: REBOOT_WITH_OVS
               value: "true"
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -567,7 +567,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:4.2.1.1.r23
+          image: noiro/opflex:4.2.2.1.r28
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -640,7 +640,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
-          image: noiro/openvswitch:4.2.1.1.r18
+          image: noiro/openvswitch:4.2.2.1.r23
           imagePullPolicy: Always
           resources:
             limits:
@@ -719,7 +719,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: snat-operator
-          image: noiro/snat-operator:4.2.1.1.r1
+          image: noiro/snat-operator:4.2.2.1.r3
           imagePullPolicy: Always
           command:
           - snat-operator
@@ -737,7 +737,7 @@ spec:
             - name: OPERATOR_NAME
               value: "snat-operator"
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.1.1.r22
+          image: noiro/aci-containers-controller:4.2.2.1.r27
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume


### PR DESCRIPTION
New versions:
    aci_containers_controller_version: 4.2.2.1.r27
    aci_containers_host_version: 4.2.2.1.r27
    snat_operator_version: 4.2.2.1.r3
    cnideploy_version: 4.2.2.1.r27
    openvswitch_version: 4.2.2.1.r23
    opflex_agent_version: 4.2.2.1.r28