### PR TITLE
Remove namespace label for k8s flavors

### DIFF
--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -17,7 +17,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "{{ config.registry.configuration_version }}"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
-    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---


### PR DESCRIPTION
Fix for https://cdetsng.cisco.com/webui/#view=CSCvr88382
Remove the label network-plugin: aci-containers from aci-containers-system created for non-openshift flavors, as it was breaking acikubectl cluster-report functionality