### PR TITLE
Blocking eviction of acc and host-agent

### DIFF
--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -682,6 +682,7 @@ spec:
             - name: cni-bin
               mountPath: /mnt/cni-bin
       {% endif %}
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: {{ config.registry.image_prefix }}/aci-containers-host:{{ config.registry.aci_containers_host_version }}
@@ -937,6 +938,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         {% if config.kube_config.run_gbp_container %}
         - name: aci-gbpserver

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -513,6 +513,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -719,6 +720,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -513,6 +513,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -719,6 +720,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -513,6 +513,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -719,6 +720,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: test_snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -524,6 +524,7 @@ spec:
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -730,6 +731,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/flavor_eks.kube.yaml
+++ b/provision/testdata/flavor_eks.kube.yaml
@@ -587,6 +587,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noirolabs/aci-containers-host:latest
@@ -812,6 +813,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-gbpserver
           image: noirolabs/gbpserver:latest

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -587,6 +587,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noirolabs/aci-containers-host:latest
@@ -812,6 +813,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-gbpserver
           image: noirolabs/gbpserver:latest

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -561,6 +561,7 @@ spec:
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -772,6 +773,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -513,6 +513,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -719,6 +720,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -513,6 +513,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -719,6 +720,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -513,6 +513,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -719,6 +720,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -513,6 +513,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -719,6 +720,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -513,6 +513,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -719,6 +720,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -513,6 +513,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -719,6 +720,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -513,6 +513,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -719,6 +720,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -513,6 +513,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -719,6 +720,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -514,6 +514,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -720,6 +721,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -549,6 +549,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -760,6 +761,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -515,6 +515,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -721,6 +722,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -515,6 +515,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -721,6 +722,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -513,6 +513,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.1.r27
@@ -719,6 +720,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.1.r3


### PR DESCRIPTION
Mark containers in acc and host-agent pods with:
priorityClassName: system-node-critical
This wouldn't help in all scenarios [kubernetes/kubernetes#63005]

(cherry picked from commit 700468c445374ca61e5819f8d2b17b9c621ed132)