### PR TITLE
Making priorityClassName attribute conditional

### DIFF
--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -61,12 +61,18 @@ flavors:
     status: null
     hidden: true
     order: 10
+    config:
+      kube_config:
+        no_priority_class: True
   kubernetes-1.10:
     desc: Kubernetes 1.10
     default_version: 1.9
     status: null
     hidden: true
     order: 11
+    config:
+      kube_config:
+        no_priority_class: True
   openshift-3.11:
     desc: Red Hat OpenShift Container Platform 3.11
     default_version: 4.2
@@ -79,6 +85,7 @@ flavors:
         allow_kube_api_default_epg: True
         kubectl: oc
         system_namespace: aci-containers-system
+        no_priority_class: True
       aci_config:
         items:
           - name: openshift-svc-catalog
@@ -118,6 +125,7 @@ flavors:
         allow_kube_api_default_epg: True
         kubectl: oc
         system_namespace: aci-containers-system
+        no_priority_class: True
       aci_config:
         items:
           - name: openshift-svc-catalog
@@ -157,6 +165,7 @@ flavors:
         allow_kube_api_default_epg: True
         kubectl: oc
         system_namespace: aci-containers-system
+        no_priority_class: True
       aci_config:
         items:
           - name: openshift-svc-catalog
@@ -192,6 +201,7 @@ flavors:
     hidden: false
     config:
       kube_config:
+        no_priority_class: True
         use_cnideploy_initcontainer: True
       aci_config:
   #https://docs.docker.com/ee/ucp/admin/install/system-requirements/

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -682,7 +682,9 @@ spec:
             - name: cni-bin
               mountPath: /mnt/cni-bin
       {% endif %}
+      {% if not config.kube_config.no_priority_class %}
       priorityClassName: system-node-critical
+      {% endif %}
       containers:
         - name: aci-containers-host
           image: {{ config.registry.image_prefix }}/aci-containers-host:{{ config.registry.aci_containers_host_version }}
@@ -852,7 +854,9 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      {% if not config.kube_config.no_priority_class %}
       priorityClassName: system-node-critical
+      {% endif %}
       containers:
         - name: aci-containers-openvswitch
           image: {{ config.registry.image_prefix }}/openvswitch:{{ config.registry.openvswitch_version }}
@@ -939,7 +943,9 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+      {% if not config.kube_config.no_priority_class %}
       priorityClassName: system-node-critical
+      {% endif %}
       containers:
         {% if config.kube_config.run_gbp_container %}
         - name: aci-gbpserver

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -524,7 +524,6 @@ spec:
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin
-      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -652,7 +651,6 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26
@@ -732,7 +730,6 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.2.r4

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -561,7 +561,6 @@ spec:
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin
-      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -693,7 +692,6 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26
@@ -774,7 +772,6 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
       containers:
         - name: snat-operator
           image: noiro/snat-operator:4.2.2.2.r4


### PR DESCRIPTION
Since k8s versions prior to 1.12 only allow adding it
to pods in kube-system namespace. It works starting
with k8s version 1.12.

(cherry picked from commit d92f665e13df5a4e05af90760fbce40430dc5dc3)