### PR TITLE
Ability to add a cluster to a pre-existing tenant

### DIFF
--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -95,8 +95,8 @@ flavors:
             etherT: ip
             prot: tcp
             stateful: "no"
-            consumed: ["kube-system"]
-            provided: ["kube-nodes"]
+            consumed: ["system"]
+            provided: ["nodes"]
           - name: openshift-monitoring
             range:
               -
@@ -106,8 +106,8 @@ flavors:
             etherT: ip
             prot: tcp
             stateful: "no"
-            provided: ["kube-system","kube-default","kube-nodes"]
-            consumed: ["kube-system","kube-default"]
+            provided: ["system","default","nodes"]
+            consumed: ["system","default"]
         vmm_domain:
           type: OpenShift
     status: null
@@ -135,8 +135,8 @@ flavors:
             etherT: ip
             prot: tcp
             stateful: "no"
-            consumed: ["kube-system"]
-            provided: ["kube-nodes"]
+            consumed: ["system"]
+            provided: ["nodes"]
           - name: openshift-monitoring
             range:
               -
@@ -146,8 +146,8 @@ flavors:
             etherT: ip
             prot: tcp
             stateful: "no"
-            provided: ["kube-system","kube-default","kube-nodes"]
-            consumed: ["kube-system","kube-default"]
+            provided: ["system","default","nodes"]
+            consumed: ["system","default"]
         vmm_domain:
           type: OpenShift
     status: null
@@ -175,8 +175,8 @@ flavors:
             etherT: ip
             prot: tcp
             stateful: "no"
-            consumed: ["kube-system"]
-            provided: ["kube-nodes"]
+            consumed: ["system"]
+            provided: ["nodes"]
           - name: openshift-monitoring
             range:
               -
@@ -186,8 +186,8 @@ flavors:
             etherT: ip
             prot: tcp
             stateful: "no"
-            provided: ["kube-system","kube-default","kube-nodes"]
-            consumed: ["kube-system","kube-default"]
+            provided: ["system","default","nodes"]
+            consumed: ["system","default"]
         vmm_domain:
           type: OpenShift
     status: null

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -1,26 +1,15 @@
-{% if config.kube_config.system_namespace != "kube-system" %}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ config.kube_config.system_namespace }}
-  labels:
-    aci-containers-config-version: "{{ config.registry.configuration_version }}"
-    network-plugin: aci-containers
-  annotations:
-    openshift.io/node-selector: ''
----
-{% endif %}
-{% if config.kube_config.system_namespace != "aci-containers-system" %}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "{{ config.registry.configuration_version }}"
+{% if config.kube_config.system_namespace == "aci-containers-system" %}
+    network-plugin: aci-containers
+{% endif %}
   annotations:
     openshift.io/node-selector: ''
 ---
-{% endif %}
 {% if config.kube_config.use_aci_anywhere_crd %}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -947,7 +936,7 @@ spec:
               mountPath: /mnt/cni-bin
       {% endif %}
       {% if not config.kube_config.no_priority_class %}
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       {% endif %}
       containers:
         - name: aci-containers-host
@@ -974,7 +963,7 @@ spec:
               value: "kube-nodes"
             {% else %}
             - name: NODE_EPG
-              value: "kubernetes|kube-nodes"
+              value: "{{ config.aci_config.app_profile }}|{{ config.aci_config.nodes_epg }}"
             {% endif %}
           volumeMounts:
             - name: cni-bin
@@ -1126,7 +1115,7 @@ spec:
         - operator: Exists
           effect: NoSchedule
       {% if not config.kube_config.no_priority_class %}
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       {% endif %}
       containers:
         - name: aci-containers-openvswitch

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -243,6 +243,24 @@ def test_with_no_istio():
 
 
 @in_testdir
+def test_new_naming_convention():
+    run_provision(
+        "with_new_naming_convention.inp.yaml",
+        "with_new_naming_convention.kube.yaml",
+        "with_new_naming_convention.apic.txt"
+    )
+
+
+@in_testdir
+def test_preexisting_tenant():
+    run_provision(
+        "with_preexisting_tenant.inp.yaml",
+        "with_preexisting_tenant.kube.yaml",
+        "with_preexisting_tenant.apic.txt"
+    )
+
+
+@in_testdir
 def test_sample():
     with tempfile.NamedTemporaryFile("wb") as tmpout:
         sys.stdout = tmpout
@@ -343,6 +361,27 @@ def test_overlapping_subnets():
             sys.stderr = sys.__stderr__
             tmperr.seek(0)
         with open("overlapping_subnets.stdout.txt", "r") as stderr:
+            assert tmperr.read() == stderr.read()
+
+
+@in_testdir
+def test_preexisting_kube_convention():
+    with tempfile.NamedTemporaryFile("w+") as tmperr:
+        sys.stderr = tmperr
+        try:
+            run_provision(
+                "with_preexisting_kube_convention.inp.yaml",
+                None,
+                None
+            )
+        except SystemExit:
+            # expected to exit with errors
+            pass
+        finally:
+            tmperr.flush()
+            sys.stderr = sys.__stderr__
+            tmperr.seek(0)
+        with open("error_preexisting_kube_convention.stdout.txt", "r") as stderr:
             assert tmperr.read() == stderr.read()
 
 

--- a/provision/testdata/base_case.inp.yaml
+++ b/provision/testdata/base_case.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -731,7 +731,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -863,7 +863,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/base_case_snat.inp.yaml
+++ b/provision/testdata/base_case_snat.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -731,7 +731,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -863,7 +863,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/conflicting_infravlan.inp.yaml
+++ b/provision/testdata/conflicting_infravlan.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/error_preexisting_kube_convention.stdout.txt
+++ b/provision/testdata/error_preexisting_kube_convention.stdout.txt
@@ -1,0 +1,2 @@
+INFO: Loading configuration from "with_preexisting_kube_convention.inp.yaml"
+ERR:  Not allowed to set tenant and use_legacy_kube_naming_convention fields at the same time

--- a/provision/testdata/flavor_eks.inp.yaml
+++ b/provision/testdata/flavor_eks.inp.yaml
@@ -3,6 +3,7 @@
 #
 aci_config:
   system_id: kube                       # Every opflex cluster on the same fabric must have a distict ID
+  use_legacy_kube_naming_convention: True
   apic_hosts:                           # List of APIC hosts to connect to for APIC API access
     - 127.0.0.1
   vmm_domain:                           # Kubernetes VMM domain configuration

--- a/provision/testdata/flavor_eks.kube.yaml
+++ b/provision/testdata/flavor_eks.kube.yaml
@@ -4,6 +4,7 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---
@@ -851,7 +852,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noirolabs/aci-containers-host:latest
@@ -1002,7 +1003,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noirolabs/openvswitch:latest

--- a/provision/testdata/flavor_localhost.inp.yaml
+++ b/provision/testdata/flavor_localhost.inp.yaml
@@ -3,6 +3,7 @@
 #
 aci_config:
   system_id: kube                       # Every opflex cluster on the same fabric must have a distict ID
+  use_legacy_kube_naming_convention: True
   apic_hosts:                           # List of APIC hosts to connect to for APIC API access
     - 127.0.0.1
   vmm_domain:                           # Kubernetes VMM domain configuration

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -805,7 +805,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noirolabs/aci-containers-host:latest
@@ -956,7 +956,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noirolabs/openvswitch:latest

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -389,6 +389,26 @@ data:
             "istio-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-istio"
+            },
+            "kube-service-catalog": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            },
+            "kube-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            },
+            "openshift-console": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            },
+            "openshift-monitoring": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            },
+            "openshift-web-console": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
             }        },
         "service-ip-pool": [
             {
@@ -463,6 +483,26 @@ data:
             "istio-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-istio"
+            },
+            "kube-service-catalog": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            },
+            "kube-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            },
+            "openshift-console": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            },
+            "openshift-monitoring": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            },
+            "openshift-web-console": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
             }        }
     }
   opflex-agent-config: |-

--- a/provision/testdata/nested-elag.inp.yaml
+++ b/provision/testdata/nested-elag.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -731,7 +731,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -863,7 +863,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/nested-portgroup.inp.yaml
+++ b/provision/testdata/nested-portgroup.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -731,7 +731,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -863,7 +863,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/nested-vlan.inp.yaml
+++ b/provision/testdata/nested-vlan.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -731,7 +731,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -863,7 +863,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/nested-vxlan.inp.yaml
+++ b/provision/testdata/nested-vxlan.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -731,7 +731,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -863,7 +863,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/pod_ext_access.inp.yaml
+++ b/provision/testdata/pod_ext_access.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -731,7 +731,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -863,7 +863,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -4,6 +4,7 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---
@@ -341,7 +342,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: aci-containers-config
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
@@ -373,10 +374,14 @@ data:
         "aci-vrf": "mykube-vrf",
         "default-endpoint-group": {
             "policy-space": "mykube",
-            "name": "kubernetes|kube-default"
+            "name": "aci-containers-mykube|aci-containers-default"
         },
         "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
+            "aci-containers-system": {
+                "policy-space": "mykube",
+                "name": "aci-containers-mykube|aci-containers-system"
+            },
             "istio-operator": {
                 "policy-space": "mykube",
                 "name": "kubernetes|kube-istio"
@@ -387,7 +392,7 @@ data:
             },
             "kube-system": {
                 "policy-space": "mykube",
-                "name": "kubernetes|kube-system"
+                "name": "aci-containers-mykube|aci-containers-system"
             }        },
         "service-ip-pool": [
             {
@@ -447,9 +452,13 @@ data:
         ],
         "default-endpoint-group": {
             "policy-space": "mykube",
-            "name": "kubernetes|kube-default"
+            "name": "aci-containers-mykube|aci-containers-default"
         },
         "namespace-default-endpoint-group": {
+            "aci-containers-system": {
+                "policy-space": "mykube",
+                "name": "aci-containers-mykube|aci-containers-system"
+            },
             "istio-operator": {
                 "policy-space": "mykube",
                 "name": "kubernetes|kube-istio"
@@ -460,7 +469,7 @@ data:
             },
             "kube-system": {
                 "policy-space": "mykube",
-                "name": "kubernetes|kube-system"
+                "name": "aci-containers-mykube|aci-containers-system"
             }        }
     }
   opflex-agent-config: |-
@@ -489,7 +498,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: aci-user-cert
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
 data:
@@ -500,7 +509,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aci-containers-controller
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
 ---
@@ -508,7 +517,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aci-containers-host-agent
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
 ---
@@ -684,7 +693,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aci-containers-controller
-  namespace: kube-system
+  namespace: aci-containers-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -699,13 +708,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aci-containers-host-agent
-  namespace: kube-system
+  namespace: aci-containers-system
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: aci-containers-host
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
@@ -731,7 +740,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -750,7 +759,7 @@ spec:
             - name: TENANT
               value: "mykube"
             - name: NODE_EPG
-              value: "kubernetes|kube-nodes"
+              value: "aci-containers-mykube|aci-containers-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin
@@ -837,7 +846,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: aci-containers-openvswitch
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
@@ -863,7 +872,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26
@@ -915,7 +924,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: aci-containers-controller
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
@@ -931,7 +940,7 @@ spec:
   template:
     metadata:
       name: aci-containers-controller
-      namespace: kube-system
+      namespace: aci-containers-system
       labels:
         name: aci-containers-controller
         network-plugin: aci-containers

--- a/provision/testdata/version_wrong_url.inp.yaml
+++ b/provision/testdata/version_wrong_url.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/vlan_case.inp.yaml
+++ b/provision/testdata/vlan_case.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -731,7 +731,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -863,7 +863,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/with_comments.inp.yaml
+++ b/provision/testdata/with_comments.inp.yaml
@@ -3,6 +3,7 @@
 #
 aci_config:
   system_id: kube                       # Every opflex cluster on the same fabric must have a distict ID
+  use_legacy_kube_naming_convention: True
   apic_hosts:                           # List of APIC hosts to connect to for APIC API access
     - 10.30.120.140
   apic_login:                           # Login credentials for APIC

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -731,7 +731,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -863,7 +863,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/with_interface_mtu.inp.yaml
+++ b/provision/testdata/with_interface_mtu.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -732,7 +732,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -864,7 +864,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/with_new_naming_convention.apic.txt
+++ b/provision/testdata/with_new_naming_convention.apic.txt
@@ -1,0 +1,1005 @@
+/api/mo/uni/infra/vlanns-[kube-pool]-static.json
+{
+    "fvnsVlanInstP": {
+        "attributes": {
+            "name": "kube-pool",
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvnsEncapBlk": {
+                    "attributes": {
+                        "allocMode": "static",
+                        "from": "vlan-4001",
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "fvnsEncapBlk": {
+                    "attributes": {
+                        "allocMode": "static",
+                        "from": "vlan-4003",
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra/maddrns-kube-mpool.json
+{
+    "fvnsMcastAddrInstP": {
+        "attributes": {
+            "name": "kube-mpool",
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvnsMcastAddrBlk": {
+                    "attributes": {
+                        "from": "225.2.1.1",
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/vmmp-Kubernetes/dom-kube.json
+{
+    "vmmDomP": {
+        "attributes": {
+            "name": "kube",
+            "mode": "k8s",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "vmmCtrlrP": {
+                    "attributes": {
+                        "name": "kube",
+                        "mode": "k8s",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "vmmRsDomMcastAddrNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra.json
+{
+    "infraAttEntityP": {
+        "attributes": {
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsDomP": {
+                    "attributes": {
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "infraRsDomP": {
+                    "attributes": {
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "infraProvAcc": {
+                    "attributes": {
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "infraRsFuncToEpg": {
+                                "attributes": {
+                                    "encap": "vlan-4093",
+                                    "mode": "regular",
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "dhcpInfraProvP": {
+                                "attributes": {
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "infraGeneric": {
+                    "attributes": {
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "infraRsFuncToEpg": {
+                                "attributes": {
+                                    "tDn": "uni/tn-kube/ap-aci-containers-kube/epg-aci-containers-nodes",
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/vmmp-Kubernetes/dom-kube].json
+None
+/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/phys-kube-pdom].json
+None
+/api/mo/uni/infra/attentp-kube-aep/gen-default/rsfuncToEpg-[uni/tn-kube/ap-aci-containers-kube/epg-aci-containers-nodes].json
+None
+/api/mo/uni/infra.json
+{
+    "infraSetPol": {
+        "attributes": {
+            "opflexpAuthenticateClients": "no",
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/mo/uni/tn-common.json
+{
+    "fvTenant": {
+        "attributes": {
+            "name": "common",
+            "dn": "uni/tn-common"
+        },
+        "children": [
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common/flt-kube-allow-all-filter.json
+None
+/api/mo/uni/tn-common/brc-kube-l3out-allow-all.json
+None
+/api/mo/uni/tn-kube.json
+{
+    "fvTenant": {
+        "attributes": {
+            "name": "kube",
+            "dn": "uni/tn-kube",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvAp": {
+                    "attributes": {
+                        "name": "aci-containers-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "encap": "vlan-4001",
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "group1",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "group2",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "fvBD": {
+                    "attributes": {
+                        "name": "aci-containers-kube-node-bd",
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "10.1.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsCtx": {
+                                "attributes": {
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsBDToOut": {
+                                "attributes": {
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "fvBD": {
+                    "attributes": {
+                        "name": "aci-containers-kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsCtx": {
+                                "attributes": {
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-kube-icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "icmp",
+                                    "etherT": "ipv4",
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "icmp6",
+                                    "etherT": "ipv6",
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-kube-health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "health-check",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-kube-health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "health-check",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "stateful": "no",
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-kube-dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "dns-udp",
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "6443",
+                                    "dToPort": "6443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "8443",
+                                    "dToPort": "8443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "aci-containers-api-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-kube-health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "health-check-subj",
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzOutTerm": {
+                                            "attributes": {
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            },
+                                            "children": [
+                                                {
+                                                    "vzRsFiltAtt": {
+                                                        "attributes": {
+                                                            "tnVzFilterName": "aci-containers-kube-health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "vzInTerm": {
+                                            "attributes": {
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            },
+                                            "children": [
+                                                {
+                                                    "vzRsFiltAtt": {
+                                                        "attributes": {
+                                                            "tnVzFilterName": "aci-containers-kube-health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-kube-dns",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-kube-dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-kube-icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-kube-icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-default.json
+{
+    "fvRsProv": {
+        "attributes": {
+            "matchT": "AtleastOne",
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-kube-l3out-allow-all.json
+None
+/api/node/mo/uni/userext/user-kube.json
+{
+    "aaaUser": {
+        "attributes": {
+            "name": "kube",
+            "accountStatus": "active",
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "aaaUserDomain": {
+                    "attributes": {
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "aaaUserRole": {
+                                "attributes": {
+                                    "name": "admin",
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/node/mo/uni/userext/user-kube.json
+{
+    "aaaUser": {
+        "attributes": {
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "aaaUserCert": {
+                    "attributes": {
+                        "name": "kube.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/provision/testdata/with_new_naming_convention.inp.yaml
+++ b/provision/testdata/with_new_naming_convention.inp.yaml
@@ -1,6 +1,5 @@
 aci_config:
   system_id: kube
-  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:
@@ -22,13 +21,16 @@ aci_config:
     mcast_range:
         start: 225.2.1.1
         end: 225.2.255.255
+  custom_epgs:
+    - group1
+    - group2
 
 net_config:
-  node_subnet: 1:1:1:1::1/64
-  pod_subnet: 1:2:1:1::1/64
-  extern_dynamic: 1:3:1:1::1/96
-  extern_static: 1:4:1:1::1/96
-  node_svc_subnet: 1:5:1:1::1/96
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
   kubeapi_vlan: 4001
   service_vlan: 4003
   infra_vlan: 4093

--- a/provision/testdata/with_new_naming_convention.kube.yaml
+++ b/provision/testdata/with_new_naming_convention.kube.yaml
@@ -4,6 +4,7 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---
@@ -341,7 +342,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: aci-containers-config
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
@@ -373,10 +374,14 @@ data:
         "aci-vrf": "kube",
         "default-endpoint-group": {
             "policy-space": "kube",
-            "name": "kubernetes|kube-default"
+            "name": "aci-containers-kube|aci-containers-default"
         },
         "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
+            "aci-containers-system": {
+                "policy-space": "kube",
+                "name": "aci-containers-kube|aci-containers-system"
+            },
             "istio-operator": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-istio"
@@ -387,35 +392,35 @@ data:
             },
             "kube-system": {
                 "policy-space": "kube",
-                "name": "kubernetes|kube-system"
+                "name": "aci-containers-kube|aci-containers-system"
             }        },
         "service-ip-pool": [
             {
-                "end": "1:3:1:1::ffff:fffe",
-                "start": "1:3:1:1::2"
+                "end": "10.3.0.254",
+                "start": "10.3.0.2"
             }
         ],
         "static-service-ip-pool": [
             {
-                "end": "1:4:1:1::ffff:fffe",
-                "start": "1:4:1:1::2"
+                "end": "10.4.0.254",
+                "start": "10.4.0.2"
             }
         ],
         "pod-ip-pool": [
             {
-                "end": "1:2:1:1:ffff:ffff:ffff:fffe",
-                "start": "1:2:1:1::2"
+                "end": "10.2.255.254",
+                "start": "10.2.0.2"
             }
         ],
         "pod-subnet-chunk-size": 32,
         "node-service-ip-pool": [
             {
-                "end": "1:5:1:1::ffff:fffe",
-                "start": "1:5:1:1::2"
+                "end": "10.5.0.254",
+                "start": "10.5.0.2"
             }
         ],
         "node-service-subnets": [
-            "1:5:1:1::1/96"
+            "10.5.0.1/24"
         ]
     }
   host-agent-config: |-
@@ -435,21 +440,25 @@ data:
         "aci-infra-vlan": 4093,
         "cni-netconfig": [
             {
-                "gateway": "1:2:1:1::1",
+                "gateway": "10.2.0.1",
                 "routes": [
                     {
-                        "dst": "::/0",
-                        "gw": "1:2:1:1::1"
+                        "dst": "0.0.0.0/0",
+                        "gw": "10.2.0.1"
                     }
                 ],
-                "subnet": "1:2:1:1::/64"
+                "subnet": "10.2.0.0/16"
             }
         ],
         "default-endpoint-group": {
             "policy-space": "kube",
-            "name": "kubernetes|kube-default"
+            "name": "aci-containers-kube|aci-containers-default"
         },
         "namespace-default-endpoint-group": {
+            "aci-containers-system": {
+                "policy-space": "kube",
+                "name": "aci-containers-kube|aci-containers-system"
+            },
             "istio-operator": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-istio"
@@ -460,7 +469,7 @@ data:
             },
             "kube-system": {
                 "policy-space": "kube",
-                "name": "kubernetes|kube-system"
+                "name": "aci-containers-kube|aci-containers-system"
             }        }
     }
   opflex-agent-config: |-
@@ -489,7 +498,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: aci-user-cert
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
 data:
@@ -500,7 +509,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aci-containers-controller
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
 ---
@@ -508,7 +517,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aci-containers-host-agent
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
 ---
@@ -684,7 +693,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aci-containers-controller
-  namespace: kube-system
+  namespace: aci-containers-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -699,13 +708,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aci-containers-host-agent
-  namespace: kube-system
+  namespace: aci-containers-system
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: aci-containers-host
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
@@ -750,7 +759,7 @@ spec:
             - name: TENANT
               value: "kube"
             - name: NODE_EPG
-              value: "kubernetes|kube-nodes"
+              value: "aci-containers-kube|aci-containers-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin
@@ -837,7 +846,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: aci-containers-openvswitch
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
@@ -915,7 +924,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: aci-containers-controller
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
@@ -931,7 +940,7 @@ spec:
   template:
     metadata:
       name: aci-containers-controller
-      namespace: kube-system
+      namespace: aci-containers-system
       labels:
         name: aci-containers-controller
         network-plugin: aci-containers

--- a/provision/testdata/with_no_install_istio.inp.yaml
+++ b/provision/testdata/with_no_install_istio.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/with_no_install_istio.kube.yaml
+++ b/provision/testdata/with_no_install_istio.kube.yaml
@@ -481,7 +481,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -613,7 +613,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/with_overlapping_subnets.inp.yaml
+++ b/provision/testdata/with_overlapping_subnets.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/with_overrides.inp.yaml
+++ b/provision/testdata/with_overrides.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   cluster_tenant: demo
   apic_hosts:
     - 10.30.120.100

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -767,7 +767,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -903,7 +903,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/with_pbr_non_snat.inp.yaml
+++ b/provision/testdata/with_pbr_non_snat.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_refreshtime: 1200
   apic_hosts:
     - 10.30.120.100

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -733,7 +733,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -865,7 +865,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/with_preexisting_kube_convention.inp.yaml
+++ b/provision/testdata/with_preexisting_kube_convention.inp.yaml
@@ -1,6 +1,8 @@
 aci_config:
-  system_id: kube
+  system_id: system_id
   use_legacy_kube_naming_convention: True
+  tenant:
+    name: old_tenant
   apic_hosts:
     - 10.30.120.100
   apic_login:
@@ -22,13 +24,16 @@ aci_config:
     mcast_range:
         start: 225.2.1.1
         end: 225.2.255.255
+  custom_epgs:
+    - group1
+    - group2
 
 net_config:
-  node_subnet: 1:1:1:1::1/64
-  pod_subnet: 1:2:1:1::1/64
-  extern_dynamic: 1:3:1:1::1/96
-  extern_static: 1:4:1:1::1/96
-  node_svc_subnet: 1:5:1:1::1/96
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
   kubeapi_vlan: 4001
   service_vlan: 4003
   infra_vlan: 4093

--- a/provision/testdata/with_preexisting_tenant.apic.txt
+++ b/provision/testdata/with_preexisting_tenant.apic.txt
@@ -1,0 +1,1004 @@
+/api/mo/uni/infra/vlanns-[kube-pool]-static.json
+{
+    "fvnsVlanInstP": {
+        "attributes": {
+            "name": "kube-pool",
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvnsEncapBlk": {
+                    "attributes": {
+                        "allocMode": "static",
+                        "from": "vlan-4001",
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "fvnsEncapBlk": {
+                    "attributes": {
+                        "allocMode": "static",
+                        "from": "vlan-4003",
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra/maddrns-kube-mpool.json
+{
+    "fvnsMcastAddrInstP": {
+        "attributes": {
+            "name": "kube-mpool",
+            "dn": "uni/infra/maddrns-kube-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvnsMcastAddrBlk": {
+                    "attributes": {
+                        "from": "225.2.1.1",
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/vmmp-Kubernetes/dom-kube.json
+{
+    "vmmDomP": {
+        "attributes": {
+            "name": "kube",
+            "mode": "k8s",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "vmmCtrlrP": {
+                    "attributes": {
+                        "name": "kube",
+                        "mode": "k8s",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "vmmRsDomMcastAddrNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/maddrns-kube-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra.json
+{
+    "infraAttEntityP": {
+        "attributes": {
+            "name": "kube-aep",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsDomP": {
+                    "attributes": {
+                        "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "infraRsDomP": {
+                    "attributes": {
+                        "tDn": "uni/phys-kube-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "infraProvAcc": {
+                    "attributes": {
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "infraRsFuncToEpg": {
+                                "attributes": {
+                                    "encap": "vlan-4093",
+                                    "mode": "regular",
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "dhcpInfraProvP": {
+                                "attributes": {
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "infraGeneric": {
+                    "attributes": {
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "infraRsFuncToEpg": {
+                                "attributes": {
+                                    "tDn": "uni/tn-old_tenant/ap-aci-containers-kube/epg-aci-containers-nodes",
+                                    "encap": "vlan-4001",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/vmmp-Kubernetes/dom-kube].json
+None
+/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/phys-kube-pdom].json
+None
+/api/mo/uni/infra/attentp-kube-aep/gen-default/rsfuncToEpg-[uni/tn-old_tenant/ap-aci-containers-kube/epg-aci-containers-nodes].json
+None
+/api/mo/uni/infra.json
+{
+    "infraSetPol": {
+        "attributes": {
+            "opflexpAuthenticateClients": "no",
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/mo/uni/tn-common.json
+{
+    "fvTenant": {
+        "attributes": {
+            "name": "common",
+            "dn": "uni/tn-common"
+        },
+        "children": [
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "kube-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "kube-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "kube-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common/flt-kube-allow-all-filter.json
+None
+/api/mo/uni/tn-common/brc-kube-l3out-allow-all.json
+None
+/api/mo/uni/tn-old_tenant.json
+{
+    "fvTenant": {
+        "attributes": {
+            "name": "old_tenant",
+            "dn": "uni/tn-old_tenant"
+        },
+        "children": [
+            {
+                "fvAp": {
+                    "attributes": {
+                        "name": "aci-containers-kube",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "encap": "vlan-4001",
+                                                "tDn": "uni/phys-kube-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-kube-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "group1",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "group2",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-kube",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-kube-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "fvBD": {
+                    "attributes": {
+                        "name": "aci-containers-kube-node-bd",
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "10.1.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsCtx": {
+                                "attributes": {
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsBDToOut": {
+                                "attributes": {
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "fvBD": {
+                    "attributes": {
+                        "name": "aci-containers-kube-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "10.2.0.1/16",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsCtx": {
+                                "attributes": {
+                                    "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-kube-icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "icmp",
+                                    "etherT": "ipv4",
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "icmp6",
+                                    "etherT": "ipv6",
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-kube-health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "health-check",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-kube-health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "health-check",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "stateful": "no",
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-kube-dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "dns-udp",
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-kube-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "6443",
+                                    "dToPort": "6443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "8443",
+                                    "dToPort": "8443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-kube-api",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "aci-containers-api-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-kube-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-kube-health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "health-check-subj",
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzOutTerm": {
+                                            "attributes": {
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            },
+                                            "children": [
+                                                {
+                                                    "vzRsFiltAtt": {
+                                                        "attributes": {
+                                                            "tnVzFilterName": "aci-containers-kube-health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "vzInTerm": {
+                                            "attributes": {
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            },
+                                            "children": [
+                                                {
+                                                    "vzRsFiltAtt": {
+                                                        "attributes": {
+                                                            "tnVzFilterName": "aci-containers-kube-health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-kube-dns",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-kube-dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-kube-icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-kube-icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-default.json
+{
+    "fvRsProv": {
+        "attributes": {
+            "matchT": "AtleastOne",
+            "tnVzBrCPName": "kube-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-kube-l3out-allow-all.json
+None
+/api/node/mo/uni/userext/user-kube.json
+{
+    "aaaUser": {
+        "attributes": {
+            "name": "kube",
+            "accountStatus": "active",
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "aaaUserDomain": {
+                    "attributes": {
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "aaaUserRole": {
+                                "attributes": {
+                                    "name": "admin",
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/node/mo/uni/userext/user-kube.json
+{
+    "aaaUser": {
+        "attributes": {
+            "name": "kube",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "aaaUserCert": {
+                    "attributes": {
+                        "name": "kube.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/provision/testdata/with_preexisting_tenant.inp.yaml
+++ b/provision/testdata/with_preexisting_tenant.inp.yaml
@@ -1,6 +1,7 @@
 aci_config:
   system_id: kube
-  use_legacy_kube_naming_convention: True
+  tenant:
+    name: old_tenant
   apic_hosts:
     - 10.30.120.100
   apic_login:
@@ -22,13 +23,16 @@ aci_config:
     mcast_range:
         start: 225.2.1.1
         end: 225.2.255.255
+  custom_epgs:
+    - group1
+    - group2
 
 net_config:
-  node_subnet: 1:1:1:1::1/64
-  pod_subnet: 1:2:1:1::1/64
-  extern_dynamic: 1:3:1:1::1/96
-  extern_static: 1:4:1:1::1/96
-  node_svc_subnet: 1:5:1:1::1/96
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
   kubeapi_vlan: 4001
   service_vlan: 4003
   infra_vlan: 4093

--- a/provision/testdata/with_preexisting_tenant.kube.yaml
+++ b/provision/testdata/with_preexisting_tenant.kube.yaml
@@ -4,6 +4,7 @@ metadata:
   name: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
   annotations:
     openshift.io/node-selector: ''
 ---
@@ -341,7 +342,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: aci-containers-config
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
@@ -359,7 +360,7 @@ data:
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
         "aci-vmm-controller": "kube",
-        "aci-policy-tenant": "kube",
+        "aci-policy-tenant": "old_tenant",
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
@@ -372,50 +373,54 @@ data:
         ],
         "aci-vrf": "kube",
         "default-endpoint-group": {
-            "policy-space": "kube",
-            "name": "kubernetes|kube-default"
+            "policy-space": "old_tenant",
+            "name": "aci-containers-kube|aci-containers-default"
         },
         "max-nodes-svc-graph": 32,
         "namespace-default-endpoint-group": {
+            "aci-containers-system": {
+                "policy-space": "old_tenant",
+                "name": "aci-containers-kube|aci-containers-system"
+            },
             "istio-operator": {
-                "policy-space": "kube",
+                "policy-space": "old_tenant",
                 "name": "kubernetes|kube-istio"
             },
             "istio-system": {
-                "policy-space": "kube",
+                "policy-space": "old_tenant",
                 "name": "kubernetes|kube-istio"
             },
             "kube-system": {
-                "policy-space": "kube",
-                "name": "kubernetes|kube-system"
+                "policy-space": "old_tenant",
+                "name": "aci-containers-kube|aci-containers-system"
             }        },
         "service-ip-pool": [
             {
-                "end": "1:3:1:1::ffff:fffe",
-                "start": "1:3:1:1::2"
+                "end": "10.3.0.254",
+                "start": "10.3.0.2"
             }
         ],
         "static-service-ip-pool": [
             {
-                "end": "1:4:1:1::ffff:fffe",
-                "start": "1:4:1:1::2"
+                "end": "10.4.0.254",
+                "start": "10.4.0.2"
             }
         ],
         "pod-ip-pool": [
             {
-                "end": "1:2:1:1:ffff:ffff:ffff:fffe",
-                "start": "1:2:1:1::2"
+                "end": "10.2.255.254",
+                "start": "10.2.0.2"
             }
         ],
         "pod-subnet-chunk-size": 32,
         "node-service-ip-pool": [
             {
-                "end": "1:5:1:1::ffff:fffe",
-                "start": "1:5:1:1::2"
+                "end": "10.5.0.254",
+                "start": "10.5.0.2"
             }
         ],
         "node-service-subnets": [
-            "1:5:1:1::1/96"
+            "10.5.0.1/24"
         ]
     }
   host-agent-config: |-
@@ -435,32 +440,36 @@ data:
         "aci-infra-vlan": 4093,
         "cni-netconfig": [
             {
-                "gateway": "1:2:1:1::1",
+                "gateway": "10.2.0.1",
                 "routes": [
                     {
-                        "dst": "::/0",
-                        "gw": "1:2:1:1::1"
+                        "dst": "0.0.0.0/0",
+                        "gw": "10.2.0.1"
                     }
                 ],
-                "subnet": "1:2:1:1::/64"
+                "subnet": "10.2.0.0/16"
             }
         ],
         "default-endpoint-group": {
-            "policy-space": "kube",
-            "name": "kubernetes|kube-default"
+            "policy-space": "old_tenant",
+            "name": "aci-containers-kube|aci-containers-default"
         },
         "namespace-default-endpoint-group": {
+            "aci-containers-system": {
+                "policy-space": "old_tenant",
+                "name": "aci-containers-kube|aci-containers-system"
+            },
             "istio-operator": {
-                "policy-space": "kube",
+                "policy-space": "old_tenant",
                 "name": "kubernetes|kube-istio"
             },
             "istio-system": {
-                "policy-space": "kube",
+                "policy-space": "old_tenant",
                 "name": "kubernetes|kube-istio"
             },
             "kube-system": {
-                "policy-space": "kube",
-                "name": "kubernetes|kube-system"
+                "policy-space": "old_tenant",
+                "name": "aci-containers-kube|aci-containers-system"
             }        }
     }
   opflex-agent-config: |-
@@ -489,7 +498,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: aci-user-cert
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
 data:
@@ -500,7 +509,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aci-containers-controller
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
 ---
@@ -508,7 +517,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aci-containers-host-agent
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
 ---
@@ -684,7 +693,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aci-containers-controller
-  namespace: kube-system
+  namespace: aci-containers-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -699,13 +708,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aci-containers-host-agent
-  namespace: kube-system
+  namespace: aci-containers-system
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: aci-containers-host
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
@@ -748,9 +757,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: TENANT
-              value: "kube"
+              value: "old_tenant"
             - name: NODE_EPG
-              value: "kubernetes|kube-nodes"
+              value: "aci-containers-kube|aci-containers-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin
@@ -837,7 +846,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: aci-containers-openvswitch
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
@@ -915,7 +924,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: aci-containers-controller
-  namespace: kube-system
+  namespace: aci-containers-system
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
@@ -931,7 +940,7 @@ spec:
   template:
     metadata:
       name: aci-containers-controller
-      namespace: kube-system
+      namespace: aci-containers-system
       labels:
         name: aci-containers-controller
         network-plugin: aci-containers

--- a/provision/testdata/with_refreshtime.inp.yaml
+++ b/provision/testdata/with_refreshtime.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_refreshtime: 1200
   apic_hosts:
     - 10.30.120.100

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -733,7 +733,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -865,7 +865,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26

--- a/provision/testdata/with_tenant_l3out.inp.yaml
+++ b/provision/testdata/with_tenant_l3out.inp.yaml
@@ -1,5 +1,6 @@
 aci_config:
   system_id: kube
+  use_legacy_kube_naming_convention: True
   apic_hosts:
     - 10.30.120.100
   apic_login:

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -731,7 +731,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:4.2.2.2.r32
@@ -863,7 +863,7 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:4.2.2.2.r26


### PR DESCRIPTION
1. Introduce a new (dictionary)field called "tenant" in acc-provision input file to provision cluster in an existing tenant, like this:
aci_config:
  tenant:
    name: existing_tenant

2. The cluster will be provisioned with a new naming convention, most apic objects that were named kube-, will be now called aci-containers-<system_id>- to avoid ambiguity.

3. For supporting existing clusters with the kube convention, a boolean field is introduced inside aci_config like this:
aci_config:
  use_legacy_kube_naming_convention: True
However, pre-existing tenant and use_kube_naming_convention can't be set at the same time. 

4. Code changes to run all the ACI CNI pods in the namespace aci-containers-system instead of kube-system.