### PR TITLE
Istio: NS/EPG Configmap fix

### DIFF
--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -493,8 +493,8 @@ data:
             "{{ns}}": {
                 "policy-space": {{val['tenant']|json}},
                 "name": {{(val['app_profile'] ~ "|" ~ val['group'])|json}}
-            },
-            {% endfor %}
+            }{% if not loop.last %},
+            {% endif %}{% endfor %}
         },
         "service-ip-pool": {{ config.kube_config.service_ip_pool|json|indent(width=8) }},
         "static-service-ip-pool": {{ config.kube_config.static_service_ip_pool|json|indent(width=8) }},
@@ -534,8 +534,8 @@ data:
             "{{ns}}": {
                 "policy-space": {{val['tenant']|json}},
                 "name": {{(val['app_profile'] ~ "|" ~ val['group'])|json}}
-            },
-            {% endfor %}
+            }{% if not loop.last %},
+            {% endif %}{% endfor %}
         }
     }
   opflex-agent-config: |-

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -505,8 +504,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "1:3:1:1::ffff:fffe",
@@ -505,8 +504,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -505,8 +504,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -505,8 +504,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/flavor_eks.kube.yaml
+++ b/provision/testdata/flavor_eks.kube.yaml
@@ -485,8 +485,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.63.254",
@@ -559,8 +558,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -485,8 +485,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.63.254",
@@ -559,8 +558,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -432,8 +432,7 @@ data:
             "istio-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-istio"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -507,8 +506,7 @@ data:
             "istio-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-istio"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -505,8 +504,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -505,8 +504,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -505,8 +504,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -505,8 +504,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -505,8 +504,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "mykube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -505,8 +504,7 @@ data:
             "kube-system": {
                 "policy-space": "mykube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -505,8 +504,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -505,8 +504,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -506,8 +505,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.4.255.254",
@@ -506,8 +505,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -432,8 +432,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -507,8 +506,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -432,8 +432,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -507,8 +506,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -431,8 +431,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        },
+            }        },
         "service-ip-pool": [
             {
                 "end": "10.3.0.254",
@@ -505,8 +504,7 @@ data:
             "kube-system": {
                 "policy-space": "kube",
                 "name": "kubernetes|kube-system"
-            },
-        }
+            }        }
     }
   opflex-agent-config: |-
     {


### PR DESCRIPTION
Fixing a minor issue where the last element of NS/EPG annotation shall not contain a comma.
This was resulting ACC container boot-up failure.