### PR TITLE
Changes for new snat design

### DIFF
--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -94,20 +94,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -165,35 +151,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -454,11 +411,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - {{ config.kube_config.snat_operator.name }}
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -469,11 +425,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -549,7 +502,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -561,6 +514,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -960,11 +914,9 @@ spec:
             - name: GBP_SERVER_CONF
               value: /usr/local/etc/aci-containers/gbp-server.conf
         {% endif %}
-        - name: {{ config.kube_config.snat_operator.name }}
-          image: {{ config.registry.image_prefix }}/snat-operator:{{ config.registry.snat_operator_version }}
+        - name: aci-containers-controller
+          image: {{ config.registry.image_prefix }}/aci-containers-controller:{{ config.registry.aci_containers_controller_version }}
           imagePullPolicy: {{ config.kube_config.image_pull_policy }}
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: "{{ config.kube_config.snat_operator.watch_namespace }}"
@@ -972,15 +924,6 @@ spec:
               value: "{{ config.kube_config.snat_operator.snat_namespace }}"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "{{ config.kube_config.snat_operator.globalinfo_name }}"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "{{ config.kube_config.snat_operator.name }}"
-        - name: aci-containers-controller
-          image: {{ config.registry.image_prefix }}/aci-containers-controller:{{ config.registry.aci_containers_controller_version }}
-          imagePullPolicy: {{ config.kube_config.image_pull_policy }}
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -359,11 +316,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -374,11 +330,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -437,7 +390,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -449,6 +402,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -723,11 +677,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -735,15 +687,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -359,11 +316,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -374,11 +330,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -437,7 +390,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -449,6 +402,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -723,11 +677,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -735,15 +687,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -359,11 +316,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - test_snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -374,11 +330,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -437,7 +390,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -449,6 +402,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -723,11 +677,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: test_snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -735,15 +687,6 @@ spec:
               value: "test_namespace"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "test_snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "test_snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -359,11 +316,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -374,11 +330,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -437,7 +390,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -449,6 +402,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -731,11 +685,9 @@ spec:
         - operator: Exists
           effect: NoSchedule
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -743,15 +695,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/flavor_eks.kube.yaml
+++ b/provision/testdata/flavor_eks.kube.yaml
@@ -78,20 +78,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -149,35 +135,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -436,11 +393,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -451,11 +407,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -511,7 +464,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -523,6 +476,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -827,11 +781,9 @@ spec:
           env:
             - name: GBP_SERVER_CONF
               value: /usr/local/etc/aci-containers/gbp-server.conf
-        - name: snat-operator
-          image: noirolabs/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noirolabs/aci-containers-controller:latest
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -839,15 +791,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noirolabs/aci-containers-controller:latest
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -78,20 +78,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -149,35 +135,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -436,11 +393,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -451,11 +407,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -511,7 +464,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -523,6 +476,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -827,11 +781,9 @@ spec:
           env:
             - name: GBP_SERVER_CONF
               value: /usr/local/etc/aci-containers/gbp-server.conf
-        - name: snat-operator
-          image: noirolabs/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noirolabs/aci-containers-controller:latest
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -839,15 +791,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noirolabs/aci-containers-controller:latest
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -25,20 +25,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -96,35 +82,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -361,11 +318,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -376,11 +332,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -439,7 +392,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -451,6 +404,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -773,11 +727,9 @@ spec:
         - operator: Exists
           effect: NoSchedule
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -785,15 +737,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -359,11 +316,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -374,11 +330,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -437,7 +390,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -449,6 +402,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -723,11 +677,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -735,15 +687,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -359,11 +316,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -374,11 +330,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -437,7 +390,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -449,6 +402,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -723,11 +677,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -735,15 +687,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -359,11 +316,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -374,11 +330,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -437,7 +390,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -449,6 +402,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -723,11 +677,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -735,15 +687,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -359,11 +316,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -374,11 +330,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -437,7 +390,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -449,6 +402,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -723,11 +677,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -735,15 +687,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -359,11 +316,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -374,11 +330,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -437,7 +390,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -449,6 +402,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -723,11 +677,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -735,15 +687,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -359,11 +316,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -374,11 +330,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -437,7 +390,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -449,6 +402,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -723,11 +677,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -735,15 +687,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -359,11 +316,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -374,11 +330,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -437,7 +390,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -449,6 +402,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -723,11 +677,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -735,15 +687,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -359,11 +316,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -374,11 +330,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -437,7 +390,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -449,6 +402,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -723,11 +677,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -735,15 +687,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -360,11 +317,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -375,11 +331,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -438,7 +391,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -450,6 +403,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -724,11 +678,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -736,15 +688,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -361,11 +318,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -376,11 +332,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -439,7 +392,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -451,6 +404,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -764,11 +718,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -776,15 +728,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -361,11 +318,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -376,11 +332,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -439,7 +392,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -451,6 +404,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -725,11 +679,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -737,15 +689,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -361,11 +318,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -376,11 +332,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -439,7 +392,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -451,6 +404,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -725,11 +679,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -737,15 +689,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -359,11 +316,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -374,11 +330,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -437,7 +390,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -449,6 +402,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -723,11 +677,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -735,15 +687,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/


### PR DESCRIPTION
Remove snatlocalinfo and move the snat-operator container logic into the aci-containers-controller container.

(cherry picked from commit c50d765d3d7932ff60990d296c0e41d18cec6fc0)