### PR TITLE
Changes for new snat design

### DIFF
--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -94,20 +94,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -165,35 +151,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -764,11 +721,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - {{ config.kube_config.snat_operator.name }}
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -779,11 +735,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -859,7 +812,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -871,6 +824,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -1274,12 +1228,9 @@ spec:
             - name: GBP_SERVER_CONF
               value: /usr/local/etc/aci-containers/gbp-server.conf
         {% endif %}
-        {% if not config.kube_config.exclude_snat_container %}
-        - name: {{ config.kube_config.snat_operator.name }}
-          image: {{ config.registry.image_prefix }}/snat-operator:{{ config.registry.snat_operator_version }}
+        - name: aci-containers-controller
+          image: {{ config.registry.image_prefix }}/aci-containers-controller:{{ config.registry.aci_containers_controller_version }}
           imagePullPolicy: {{ config.kube_config.image_pull_policy }}
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: "{{ config.kube_config.snat_operator.watch_namespace }}"
@@ -1287,16 +1238,6 @@ spec:
               value: "{{ config.kube_config.snat_operator.snat_namespace }}"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "{{ config.kube_config.snat_operator.globalinfo_name }}"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "{{ config.kube_config.snat_operator.name }}"
-        {% endif %}
-        - name: aci-containers-controller
-          image: {{ config.registry.image_prefix }}/aci-containers-controller:{{ config.registry.aci_containers_controller_version }}
-          imagePullPolicy: {{ config.kube_config.image_pull_policy }}
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -623,11 +580,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -638,11 +594,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -701,7 +654,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -713,6 +666,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -987,11 +941,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -999,15 +951,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -623,11 +580,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -638,11 +594,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -701,7 +654,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -713,6 +666,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -987,11 +941,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -999,15 +951,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -623,11 +580,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - test_snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -638,11 +594,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -701,7 +654,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -713,6 +666,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -987,11 +941,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: test_snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -999,15 +951,6 @@ spec:
               value: "test_namespace"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "test_snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "test_snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -623,11 +580,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -638,11 +594,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -701,7 +654,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -713,6 +666,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -995,11 +949,9 @@ spec:
         - operator: Exists
           effect: NoSchedule
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -1007,15 +959,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -78,20 +78,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -149,35 +135,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -700,11 +657,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -715,11 +671,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -775,7 +728,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -787,6 +740,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -1091,11 +1045,9 @@ spec:
           env:
             - name: GBP_SERVER_CONF
               value: /usr/local/etc/aci-containers/gbp-server.conf
-        - name: snat-operator
-          image: noirolabs/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noirolabs/aci-containers-controller:latest
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -1103,15 +1055,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noirolabs/aci-containers-controller:latest
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -25,20 +25,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -96,35 +82,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -625,11 +582,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -640,11 +596,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -703,7 +656,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -715,6 +668,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -1037,11 +991,9 @@ spec:
         - operator: Exists
           effect: NoSchedule
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -1049,15 +1001,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -623,11 +580,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -638,11 +594,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -701,7 +654,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -713,6 +666,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -987,11 +941,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -999,15 +951,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -623,11 +580,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -638,11 +594,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -701,7 +654,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -713,6 +666,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -987,11 +941,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -999,15 +951,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -623,11 +580,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -638,11 +594,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -701,7 +654,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -713,6 +666,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -987,11 +941,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -999,15 +951,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -623,11 +580,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -638,11 +594,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -701,7 +654,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -713,6 +666,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -987,11 +941,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -999,15 +951,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -623,11 +580,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -638,11 +594,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -701,7 +654,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -713,6 +666,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -987,11 +941,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -999,15 +951,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -623,11 +580,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -638,11 +594,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -701,7 +654,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -713,6 +666,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -987,11 +941,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -999,15 +951,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -623,11 +580,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -638,11 +594,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -701,7 +654,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -713,6 +666,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -987,11 +941,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -999,15 +951,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -623,11 +580,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -638,11 +594,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -701,7 +654,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -713,6 +666,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -987,11 +941,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -999,15 +951,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -624,11 +581,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -639,11 +595,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -702,7 +655,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -714,6 +667,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -988,11 +942,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -1000,15 +952,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/with_no_install_istio.kube.yaml
+++ b/provision/testdata/with_no_install_istio.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -373,11 +330,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -388,11 +344,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -451,7 +404,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -463,6 +416,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -737,11 +691,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -749,15 +701,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -625,11 +582,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -640,11 +596,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -703,7 +656,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -715,6 +668,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -1028,11 +982,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -1040,15 +992,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -625,11 +582,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -640,11 +596,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -703,7 +656,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -715,6 +668,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -989,11 +943,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -1001,15 +953,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -625,11 +582,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -640,11 +596,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -703,7 +656,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -715,6 +668,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -989,11 +943,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -1001,15 +953,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -24,20 +24,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snatlocalinfos.aci.snat
-spec:
-  group: aci.snat
-  names:
-    kind: SnatLocalInfo
-    listKind: SnatLocalInfoList
-    plural: snatlocalinfos
-    singular: snatlocalinfo
-  scope: Namespaced
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: snatpolicies.aci.snat
 spec:
   group: aci.snat
@@ -95,35 +81,6 @@ spec:
     plural: nodeinfos
     singular: nodeinfo
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            macaddress:
-              type: string
-            nodename:
-              type: string
-          required:
-          - nodename
-          - macaddress
-          type: object
-        status:
-          type: object
   version: v1
   versions:
   - name: v1
@@ -623,11 +580,10 @@ rules:
   - create
 - apiGroups:
   - "aci.snat"
-  resourceNames:
-  - snat-operator
   resources:
   - snatpolicies/finalizers
   - snatpolicies/status
+  - nodeinfos
   verbs:
   - update
   - create
@@ -638,11 +594,8 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
   - snatglobalinfos
   - snatpolicies
-  - snatpolicies/finalizers
-  - snatpolicies/status
   - nodeinfos
   verbs:
   - list
@@ -701,7 +654,7 @@ rules:
 - apiGroups:
   - "aci.snat"
   resources:
-  - snatlocalinfos
+  - snatpolicies
   - snatglobalinfos
   verbs:
   - list
@@ -713,6 +666,7 @@ rules:
   - nodeinfos
   verbs:
   - create
+  - update
   - list
   - watch
   - get
@@ -987,11 +941,9 @@ spec:
           effect: NoSchedule
       priorityClassName: system-node-critical
       containers:
-        - name: snat-operator
-          image: noiro/snat-operator:4.2.2.2.r4
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:4.2.2.2.r32
           imagePullPolicy: Always
-          command:
-          - snat-operator
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -999,15 +951,6 @@ spec:
               value: "aci-containers-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "snat-operator"
-        - name: aci-containers-controller
-          image: noiro/aci-containers-controller:4.2.2.2.r32
-          imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume
               mountPath: /usr/local/etc/aci-containers/


### PR DESCRIPTION
Remove snatlocalinfo and move the snat-operator container logic into the aci-containers-controller container.