### PR TITLE
Using variants of POST for apic vs capic

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -966,9 +966,10 @@ def get_apic(config):
     apic_password = config["aci_config"]["apic_login"]["password"]
     timeout = config["aci_config"]["apic_login"]["timeout"]
     debug = config["provision"]["debug_apic"]
+    capic = config["aci_config"]["capic"]
     apic = Apic(
         apic_host, apic_username, apic_password,
-        timeout=timeout, debug=debug)
+        timeout=timeout, debug=debug, capic=capic)
     if apic.cookies is None:
         return None
     return apic
@@ -1214,11 +1215,13 @@ def provision(args, apic_file, no_random):
         key_data, cert_data = generate_cert(username, certfile, keyfile)
     config["aci_config"]["sync_login"]["key_data"] = key_data
     config["aci_config"]["sync_login"]["cert_data"] = cert_data
+    config["aci_config"]["capic"] = False
 
     if flavor == "eks":
         if prov_apic is None:
             return True
         print("Configuring cAPIC")
+        config["aci_config"]["capic"] = True
         apic = get_apic(config)
         if apic is None:
             print("APIC login failed")

--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -72,6 +72,7 @@ class Apic(object):
         verify=False,
         timeout=None,
         debug=False,
+        capic=False
     ):
         global apic_debug
         apic_debug = debug
@@ -84,6 +85,7 @@ class Apic(object):
         self.verify = verify
         self.timeout = timeout if timeout else apic_default_timeout
         self.debug = debug
+        self.capic = capic
 
         if self.cookies is None:
             self.login()
@@ -102,7 +104,11 @@ class Apic(object):
         return requests.get(self.url(path), **args)
 
     def post(self, path, data):
-        args = dict(json=data, cookies=self.cookies, verify=self.verify)
+        if self.capic:
+            args = dict(json=data, cookies=self.cookies, verify=self.verify)
+        else:
+            # APIC seems to accept request body as form-encoded
+            args = dict(data=data, cookies=self.cookies, verify=self.verify)
         args.update(timeout=self.timeout)
         print("posting {}".format(json.dumps(args)))
         return requests.post(self.url(path), **args)


### PR DESCRIPTION
The commit 858e9b1caab098bb5aea9e55a47dee2ac24a1a30
started sending the POST by assigning the request body
to the json argument. However, this breaks the POST
to the APIC which expects the dict to be form-encoded
and thus requires setting the data argument.

This is being fixed here by using the relevant variant
of the POST depending on whether the POST is being made
to APIC or CAPIC. Ideally the same variant should work
for both and it should be investigated further.