### PR TITLE
Set policy-space and epg env vars for host-agent

### DIFF
--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -967,11 +967,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            {% if config.kube_config.run_gbp_container %}
             - name: TENANT
               value: {{config.kube_config.default_endpoint_group.tenant|json}}
+            {% if config.kube_config.run_gbp_container %}
             - name: NODE_EPG
               value: "kube-nodes"
+            {% else %}
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
             {% endif %}
           volumeMounts:
             - name: cni-bin

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -747,6 +747,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -747,6 +747,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -747,6 +747,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -757,6 +757,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -795,6 +795,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -747,6 +747,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -747,6 +747,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -747,6 +747,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -747,6 +747,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -747,6 +747,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -747,6 +747,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "mykube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -747,6 +747,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -747,6 +747,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -748,6 +748,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/with_no_install_istio.kube.yaml
+++ b/provision/testdata/with_no_install_istio.kube.yaml
@@ -497,6 +497,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -784,6 +784,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -749,6 +749,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -749,6 +749,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -747,6 +747,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
           volumeMounts:
             - name: cni-bin
               mountPath: /mnt/cni-bin


### PR DESCRIPTION
These are now needed by all flavors of deployments to
correctly populate the veth_host_ac endpoint file.