### PR TITLE
CSCvq96281 Add warn message if VRF config is inconsistent

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -778,6 +778,13 @@ def config_validate_preexisting(config, prov_apic):
             if l3out is None:
                 warn("L3out not defined in the APIC: %s/%s" %
                      (vrf_tenant, l3out_name))
+            else:
+                # get l3out context and check if it's the same as vrf in
+                # input config
+                result = apic.check_l3out_vrf(vrf_tenant, l3out_name, vrf_name)
+                if not result:
+                    warn("L3out %s/%s not configured in the correct VRF %s/%s" %
+                         (vrf_tenant, l3out_name, vrf_tenant, vrf_name))
 
             # Following code is to detect a legacy cluster
             # kube_ap = apic.get_ap(config["aci_config"]["system_id"])

--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -188,6 +188,17 @@ class Apic(object):
         path = "/api/mo/uni/tn-%s/out-%s.json" % (tenant, name)
         return self.get_path(path)
 
+    def check_l3out_vrf(self, tenant, name, vrf_name):
+        path = "/api/mo/uni/tn-%s/out-%s/rsectx.json?query-target=self" % (tenant, name)
+        res = False
+        try:
+            tDn = self.get_path(path)["l3extRsEctx"]["attributes"]["tDn"]
+            vrf_dn = "uni/tn-%s/ctx-%s" % (tenant, vrf_name)
+            res = (tDn == vrf_dn)
+        except Exception as e:
+            err("Error in getting configured vrf for %s/%s: %s" % (tenant, name, str(e)))
+        return res
+
     def get_user(self, name):
         path = "/api/node/mo/uni/userext/user-%s.json" % name
         return self.get_path(path)


### PR DESCRIPTION
If the VRF selected for the cluster is not the same as the one for the L3OUT, add a warning message.