### PR TITLE
Support for netflow on APIC VMM

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -165,6 +165,14 @@ def config_default():
             "client_cert": False,
             "client_ssl": True,
             "use_inst_tag": True,
+            "netflow_exporter": {
+                "enable": False,
+                "name": None,
+                "dstPort": None,
+                "dstAddr": None,
+                "srcAddr": None,
+                "activeFlowTimeOut": None,
+            },
         },
         "net_config": {
             "node_subnet": None,
@@ -635,7 +643,6 @@ def config_validate(flavor_opts, config):
         "aci_config/vrf/name": (get(("aci_config", "vrf", "name")), required),
         "aci_config/vrf/tenant": (get(("aci_config", "vrf", "tenant")),
                                   required),
-
         # Istio config
         "istio_config/install_profile": (get(("istio_config", "install_profile")),
                                          is_valid_istio_install_profile),
@@ -687,6 +694,13 @@ def config_validate(flavor_opts, config):
         if flavor_opts.get("apic", {}).get("use_kubeapi_vlan", True):
             checks["net_config/kubeapi_vlan"] = (
                 get(("net_config", "kubeapi_vlan")), required)
+        if (config["aci_config"]["netflow_exporter"]["enable"]):
+            checks["aci_config/netflow_exporter/dstAddr"] = (
+                get(("aci_config", "netflow_exporter", "dstAddr")), required)
+            checks["aci_config/netflow_exporter/dstPort"] = (
+                get(("aci_config", "netflow_exporter", "dstPort")), required)
+            checks["aci_config/netflow_exporter/name"] = (
+                get(("aci_config", "netflow_exporter", "name")), required)
 
     # Allow deletion of resources without isname check
     if get(("provision", "prov_apic")) is False:
@@ -1213,6 +1227,8 @@ def provision(args, apic_file, no_random):
             get_versions(versions_url)
 
     deep_merge(config, user_config)
+    if "netflow_exporter" in config["aci_config"]:
+        config["aci_config"]["netflow_exporter"]["enable"] = True
 
     flavor = args.flavor
     if flavor in FLAVORS:

--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -433,6 +433,9 @@ class ApicKubeConfig(object):
 
         update(data, self.kube_user())
         update(data, self.kube_cert())
+        if self.config["aci_config"]["netflow_exporter"]["enable"]:
+            update(data, self.netflow_exporter())
+            update(data, self.netflow_cont())
         return data
 
     def annotateApicObjects(self, data, pre_existing_tenant=False):
@@ -653,6 +656,90 @@ class ApicKubeConfig(object):
                                         ]
                                     )
                                 ],
+                            ),
+                        ]
+                    ),
+                )
+            ]
+        )
+        self.annotateApicObjects(data)
+        return path, data
+
+    def netflow_exporter(self):
+        exp_name = self.config["aci_config"]["netflow_exporter"]["name"]
+        dstAddr = self.config["aci_config"]["netflow_exporter"]["dstAddr"]
+        dstPort = self.config["aci_config"]["netflow_exporter"]["dstPort"]
+        srcAddr = self.config["aci_config"]["netflow_exporter"]["srcAddr"]
+
+        path = "api/mo/uni/infra/vmmexporterpol-%s.json" % exp_name
+        data = collections.OrderedDict(
+            [
+                (
+                    "netflowVmmExporterPol",
+                    collections.OrderedDict(
+                        [
+                            (
+                                "attributes",
+                                collections.OrderedDict(
+                                    [
+                                        ("name", exp_name),
+                                        ("dstAddr", dstAddr),
+                                        ("dstPort", dstPort),
+                                        ("srcAddr", srcAddr),
+                                    ]
+                                ),
+                            ),
+                        ]
+                    ),
+                )
+            ]
+        )
+        self.annotateApicObjects(data)
+        return path, data
+
+    def netflow_cont(self):
+        exp_name = self.config["aci_config"]["netflow_exporter"]["name"]
+        vmm_name = self.config["aci_config"]["vmm_domain"]["domain"]
+        activeFlowTimeOut = self.config["aci_config"]["netflow_exporter"]["activeFlowTimeOut"]
+
+        path = "api/node/mo/uni/vmmp-Kubernetes/dom-%s/vswitchpolcont.json" % vmm_name
+        data = collections.OrderedDict(
+            [
+                (
+                    "vmmVSwitchPolicyCont",
+                    collections.OrderedDict(
+                        [
+                            (
+                                "attributes",
+                                collections.OrderedDict(
+                                    [
+                                    ]
+                                ),
+                            ),
+                            (
+                                "children",
+                                [
+                                    collections.OrderedDict(
+                                        [
+                                            (
+                                                "vmmRsVswitchExporterPol",
+                                                collections.OrderedDict(
+                                                    [
+                                                        (
+                                                            "attributes",
+                                                            collections.OrderedDict(
+                                                                [
+                                                                    ("activeFlowTimeOut", activeFlowTimeOut),
+                                                                    ("tDn", "/uni/infra/vmmexporterpol-%s" % exp_name),
+                                                                ]
+                                                            ),
+                                                        )
+                                                    ]
+                                                ),
+                                            )
+                                        ]
+                                    ),
+                                ]
                             ),
                         ]
                     ),

--- a/provision/testdata/with_overlapping_subnets.inp.yaml
+++ b/provision/testdata/with_overlapping_subnets.inp.yaml
@@ -25,6 +25,10 @@ aci_config:
   custom_epgs:
     - group1
     - group2
+  netflow_exporter:
+    name: test-exporter
+    dstAddr: 10.30.120.111
+    dstPort: 2055
 
 net_config:
   node_subnet: 10.1.0.1/16

--- a/provision/testdata/with_overrides.apic.txt
+++ b/provision/testdata/with_overrides.apic.txt
@@ -1081,3 +1081,34 @@ None
         ]
     }
 }
+api/mo/uni/infra/vmmexporterpol-test-exporter.json
+{
+    "netflowVmmExporterPol": {
+        "attributes": {
+            "name": "test-exporter",
+            "dstAddr": "10.30.120.111",
+            "dstPort": 2055,
+            "srcAddr": null,
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+api/node/mo/uni/vmmp-Kubernetes/dom-kubernetes1/vswitchpolcont.json
+{
+    "vmmVSwitchPolicyCont": {
+        "attributes": {
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "vmmRsVswitchExporterPol": {
+                    "attributes": {
+                        "activeFlowTimeOut": null,
+                        "tDn": "/uni/infra/vmmexporterpol-test-exporter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/provision/testdata/with_overrides.inp.yaml
+++ b/provision/testdata/with_overrides.inp.yaml
@@ -28,6 +28,10 @@ aci_config:
         start: 225.2.1.1
         end: 225.2.255.255
   client_ssl: false
+  netflow_exporter:
+    name: test-exporter
+    dstAddr: 10.30.120.111
+    dstPort: 2055
 
 net_config:
   node_subnet: 10.1.0.1/16


### PR DESCRIPTION
Enable netflow by adding the following option to config:
```

  aci_config:
    netflow_exporter:
      name: <name> - mandatory
      dstAddr: <dst_addr> - mandatory
      dstPort: <port_value> - mandatory
      srcAddr: <src_addr> - optional
```
      

