### PR TITLE
Add version field to netflow exporter config

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -168,6 +168,7 @@ def config_default():
             "netflow_exporter": {
                 "enable": False,
                 "name": None,
+                "ver": "v5",
                 "dstPort": None,
                 "dstAddr": None,
                 "srcAddr": None,
@@ -608,6 +609,19 @@ def is_valid_istio_install_profile(xval):
     raise(Exception("Must be one of the profile in this List: ", validProfiles))
 
 
+def is_valid_netflow_version(xval):
+    if xval is None:
+        # Not a required field - default will be set to demo
+        return True
+    validVersions = ['v5', 'v9']
+    try:
+        if xval in validVersions:
+            return True
+    except ValueError:
+        pass
+    raise(Exception("Must be one of the versions in this List: ", validVersions))
+
+
 def isOverlay(flavor):
     flav = SafeDict(FLAVORS[flavor])
     ovl = flav["overlay"]
@@ -701,6 +715,8 @@ def config_validate(flavor_opts, config):
                 get(("aci_config", "netflow_exporter", "dstPort")), required)
             checks["aci_config/netflow_exporter/name"] = (
                 get(("aci_config", "netflow_exporter", "name")), required)
+            checks["aci_config/netflow_exporter/ver"] = (
+                get(("aci_config", "netflow_exporter", "ver")), is_valid_netflow_version)
 
     # Allow deletion of resources without isname check
     if get(("provision", "prov_apic")) is False:

--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -667,6 +667,7 @@ class ApicKubeConfig(object):
 
     def netflow_exporter(self):
         exp_name = self.config["aci_config"]["netflow_exporter"]["name"]
+        version = self.config["aci_config"]["netflow_exporter"]["ver"]
         dstAddr = self.config["aci_config"]["netflow_exporter"]["dstAddr"]
         dstPort = self.config["aci_config"]["netflow_exporter"]["dstPort"]
         srcAddr = self.config["aci_config"]["netflow_exporter"]["srcAddr"]
@@ -683,6 +684,7 @@ class ApicKubeConfig(object):
                                 collections.OrderedDict(
                                     [
                                         ("name", exp_name),
+                                        ("ver", version),
                                         ("dstAddr", dstAddr),
                                         ("dstPort", dstPort),
                                         ("srcAddr", srcAddr),

--- a/provision/testdata/with_overrides.apic.txt
+++ b/provision/testdata/with_overrides.apic.txt
@@ -1086,6 +1086,7 @@ api/mo/uni/infra/vmmexporterpol-test-exporter.json
     "netflowVmmExporterPol": {
         "attributes": {
             "name": "test-exporter",
+            "ver": "v9",
             "dstAddr": "10.30.120.111",
             "dstPort": 2055,
             "srcAddr": null,

--- a/provision/testdata/with_overrides.inp.yaml
+++ b/provision/testdata/with_overrides.inp.yaml
@@ -30,6 +30,7 @@ aci_config:
   client_ssl: false
   netflow_exporter:
     name: test-exporter
+    ver: v9
     dstAddr: 10.30.120.111
     dstPort: 2055
 


### PR DESCRIPTION
When creating netflowVmmExporterPol, version can be specified in the acc_provision input file like:

```
 aci_config:
   netflow_exporter:
     name:
     ver:
     dstAddr:
     dstPort:

```
The valid values for "ver" are v5 and v9. Default is set to v5.