### PR TITLE
Restrict jinja2 version to < 3.0.0

### DIFF
--- a/provision/setup.py
+++ b/provision/setup.py
@@ -24,7 +24,7 @@ setup(
     install_requires=[
           'requests',
           'pyyaml',
-          'jinja2==2.11.1',
+          'jinja2<3.0.0',
           'pyopenssl',
           'ipaddr',
     ],


### PR DESCRIPTION
To keep supporting python2.7, we need to use older version of jinja2