### PR TITLE
Option to configure SNAT svc graph contract value

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -211,6 +211,7 @@ def config_default():
                     "ports_per_node": 3000,
                 },
                 "snat_namespace": "aci-containers-system",
+                "contract_scope": "global",
             },
             "max_nodes_svc_graph": 32,
             "ep_registry": None,
@@ -622,6 +623,19 @@ def is_valid_netflow_version(xval):
     raise(Exception("Must be one of the versions in this List: ", validVersions))
 
 
+def is_valid_contract_scope(xval):
+    if xval is None:
+        # Not a required field - default will be set to demo
+        return True
+    validVersions = ['global', 'tenant', 'context']
+    try:
+        if xval in validVersions:
+            return True
+    except ValueError:
+        pass
+    raise(Exception("Must be one of the contract scopes in this List: ", validVersions))
+
+
 def isOverlay(flavor):
     flav = SafeDict(FLAVORS[flavor])
     ovl = flav["overlay"]
@@ -682,6 +696,9 @@ def config_validate(flavor_opts, config):
             # Kubernetes config
             "kube_config/max_nodes_svc_graph": (get(("kube_config", "max_nodes_svc_graph")),
                                                 is_valid_max_nodes_svc_graph),
+
+            "kube_config/snat_operator/contract_scope": (get(("kube_config", "snat_operator", "contract_scope")),
+                                                         is_valid_contract_scope),
 
             # Network Config
             "net_config/infra_vlan": (get(("net_config", "infra_vlan")),

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -460,6 +460,7 @@ data:
             {% endif %}{% endfor %}
         },
         "service-ip-pool": {{ config.kube_config.service_ip_pool|json|indent(width=8) }},
+        "snat-contract-scope": {{ config.kube_config.snat_operator.contract_scope|json }},
         "static-service-ip-pool": {{ config.kube_config.static_service_ip_pool|json|indent(width=8) }},
         {% if config.kube_config.use_external_service_ip_allocator %}
         "allocate-service-ips": false,

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "1:3:1:1::2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "1:4:1:1::ffff:fffe",

--- a/provision/testdata/base_case_snat.inp.yaml
+++ b/provision/testdata/base_case_snat.inp.yaml
@@ -48,6 +48,7 @@ kube_config:
       end: 62000
       ports_per_node: 500
     snat_namespace: test_namespace
+    contract_scope: tenant
   max_nodes_svc_graph: 64
 
 registry:

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "tenant",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -449,6 +449,7 @@ data:
                 "start": "10.3.56.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.63.254",

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -416,6 +416,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -400,6 +400,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/with_new_naming_convention.kube.yaml
+++ b/provision/testdata/with_new_naming_convention.kube.yaml
@@ -400,6 +400,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/with_no_install_istio.kube.yaml
+++ b/provision/testdata/with_no_install_istio.kube.yaml
@@ -145,6 +145,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "10.4.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.3.0.254",

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -396,6 +396,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/with_preexisting_tenant.kube.yaml
+++ b/provision/testdata/with_preexisting_tenant.kube.yaml
@@ -400,6 +400,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -396,6 +396,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -395,6 +395,7 @@ data:
                 "start": "10.3.0.2"
             }
         ],
+        "snat-contract-scope": "global",
         "static-service-ip-pool": [
             {
                 "end": "10.4.0.254",


### PR DESCRIPTION
Can be set as a field in input yaml file like:
```
kube_config:
  snat_operator:
    contract_scope: <scope name>
```

Valid values(as allowed by APIC) are "global", "tenant" and "context". Default is set to "global".