### PR TITLE
Export pod and node BD dn names to acc

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -323,6 +323,7 @@ def config_adjust(args, config, prov_apic, no_random):
         default_endpoint_group = Apic.ACI_PREFIX + "default"
         namespace_endpoint_group = Apic.ACI_PREFIX + "system"
         config["aci_config"]["nodes_epg"] = Apic.ACI_PREFIX + "nodes"
+        bd_dn_prefix = "uni/tn-%s/BD-%s%s-" % (tenant, Apic.ACI_PREFIX, system_id)
     else:
         app_profile = "kubernetes"
         default_endpoint_group = "kube-default"
@@ -332,6 +333,7 @@ def config_adjust(args, config, prov_apic, no_random):
         else:
             config["kube_config"]["system_namespace"] = "kube-system"
         config["aci_config"]["nodes_epg"] = "kube-nodes"
+        bd_dn_prefix = "uni/tn-%s/BD-%s-" % (tenant, system_id)
 
     config["aci_config"]["app_profile"] = app_profile
     system_namespace = config["kube_config"]["system_namespace"]
@@ -361,6 +363,8 @@ def config_adjust(args, config, prov_apic, no_random):
                 "certfile": "user-%s.crt" % system_id,
                 "keyfile": "user-%s.key" % system_id,
             },
+            "node_bd_dn": bd_dn_prefix + "node-bd",
+            "pod_bd_dn": bd_dn_prefix + "pod-bd",
             "kafka": {
             },
             "subnet_dn": {

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -430,6 +430,8 @@ data:
         "apic-password": {{config.aci_config.apic_login.password|json}},
         "lb-type": "None",
         {% endif %}
+        "aci-podbd-dn": {{config.aci_config.pod_bd_dn|json}},
+        "aci-nodebd-dn": {{config.aci_config.node_bd_dn|json}},
         "aci-service-phys-dom": {{config.aci_config.physical_domain.domain|json}},
         "aci-service-encap": {{ ("vlan-" ~ config.net_config.service_vlan)|json }},
         "aci-service-monitor-interval": {{ config.net_config.service_monitor_interval|json }},

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -415,6 +415,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-1022",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -362,6 +362,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -362,6 +362,8 @@ data:
         "aci-vmm-controller": "mykube",
         "aci-policy-tenant": "mykube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-mykube/BD-aci-containers-mykube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-mykube/BD-aci-containers-mykube-node-bd",
         "aci-service-phys-dom": "mykube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/with_new_naming_convention.kube.yaml
+++ b/provision/testdata/with_new_naming_convention.kube.yaml
@@ -362,6 +362,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-aci-containers-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-aci-containers-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/with_new_naming_convention_openshift.kube.yaml
+++ b/provision/testdata/with_new_naming_convention_openshift.kube.yaml
@@ -362,6 +362,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-aci-containers-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-aci-containers-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/with_no_install_istio.kube.yaml
+++ b/provision/testdata/with_no_install_istio.kube.yaml
@@ -111,6 +111,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kubernetes1",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kubernetes-control",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -362,6 +362,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 10,

--- a/provision/testdata/with_preexisting_tenant.kube.yaml
+++ b/provision/testdata/with_preexisting_tenant.kube.yaml
@@ -362,6 +362,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "old_tenant",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-old_tenant/BD-aci-containers-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-old_tenant/BD-aci-containers-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -362,6 +362,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -361,6 +361,8 @@ data:
         "aci-vmm-controller": "kube",
         "aci-policy-tenant": "kube",
         "require-netpol-annot": false,
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
         "aci-service-monitor-interval": 5,


### PR DESCRIPTION
Construct and publish the node and pod BD dn names from acc_provision to controller pod ConfigMap to complement https://github.com/noironetworks/aci-containers/pull/426