### PR TITLE
Convert openshift-4.3 filter port numbers to string

### DIFF
--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -5118,11 +5118,11 @@ def openshift_flavor_specific_handling(data, items, system_id, old_naming, aci_p
                                                     ),
                                                     (
                                                         "dFromPort",
-                                                        entry["range"][0],
+                                                        str(entry["range"][0]),
                                                     ),
                                                     (
                                                         "dToPort",
-                                                        entry["range"][1],
+                                                        str(entry["range"][1]),
                                                     ),
                                                     (
                                                         "stateful",

--- a/provision/testdata/flavor_openshift_43.apic.txt
+++ b/provision/testdata/flavor_openshift_43.apic.txt
@@ -1008,8 +1008,8 @@ None
                                     "name": "openshift-etcd1",
                                     "etherT": "ip",
                                     "prot": "tcp",
-                                    "dFromPort": 2379,
-                                    "dToPort": 2379,
+                                    "dFromPort": "2379",
+                                    "dToPort": "2379",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1022,8 +1022,8 @@ None
                                     "name": "openshift-etcd2",
                                     "etherT": "ip",
                                     "prot": "tcp",
-                                    "dFromPort": 9979,
-                                    "dToPort": 9979,
+                                    "dFromPort": "9979",
+                                    "dToPort": "9979",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"


### PR DESCRIPTION
Need to send string values in APIC requests