### PR TITLE
Changes to add acioperator for Jenkins release builds

### DIFF
--- a/provision/acc_provision/versions.yaml
+++ b/provision/acc_provision/versions.yaml
@@ -24,7 +24,6 @@ versions:
     aci_containers_controller_version: master-test
     aci_containers_host_version: master-test
     aci_containers_operator_version: master-test
-    aci_istio_operator_version: master-test
     cnideploy_version: master-test
     openvswitch_version: master-test
     opflex_agent_version: master-test

--- a/utils/python/edit_versions_yaml.py
+++ b/utils/python/edit_versions_yaml.py
@@ -14,12 +14,13 @@ def read_yaml_file(file):
     return orig_data
 
 
-def modify_yaml(opt0, opt1, opt2, opt3, opt4, data):
+def modify_yaml(opt0, opt1, opt2, opt3, data):
     data['versions'][float(opt0)]['openvswitch_version'] = opt3
     data['versions'][float(opt0)]['opflex_agent_version'] = opt2
     data['versions'][float(opt0)]['cnideploy_version'] = opt1
     data['versions'][float(opt0)]['aci_containers_controller_version'] = opt1
     data['versions'][float(opt0)]['aci_containers_host_version'] = opt1
+    data['versions'][float(opt0)]['aci_containers_operator_version'] = opt1
     return data
 
 
@@ -34,9 +35,9 @@ def main():
     parser.add_option("--branch-id",
                       dest="release_branch",
                       help="one of them : 1.9, 4.1, 4.2, 5.0")
-    parser.add_option("--acicontainers-tools",
-                      dest="acicontainers_tools",
-                      help="last successful build for AciContainers-tools job")
+    parser.add_option("--acicontainers",
+                      dest="acicontainers",
+                      help="last successful build for AciContainers(controller, host-agent, acioperator and cnideploy) job")
     parser.add_option("--opflex-container",
                       dest="opflex_container",
                       help="last successful build for OpFlex-container")
@@ -45,11 +46,11 @@ def main():
                       help="last successful build for OVS-container")
 
     (opts, _) = parser.parse_args()
-    if (not opts.release_branch or not opts.acicontainers_tools or not opts.opflex_container or not opts.ovs_container):
+    if (not opts.release_branch or not opts.acicontainers or not opts.opflex_container or not opts.ovs_container):
         parser.error("Required parameter(s) missing")
 
     orig_data = read_yaml_file(VERSIONS_PATH)
-    data = modify_yaml(opts.release_branch, opts.acicontainers_tools, opts.opflex_container, opts.ovs_container, orig_data)
+    data = modify_yaml(opts.release_branch, opts.acicontainers, opts.opflex_container, opts.ovs_container, orig_data)
     os.remove(VERSIONS_PATH)
     create_new_yaml(VERSIONS_PATH, data)
 


### PR DESCRIPTION
Complement to https://github.com/noironetworks/support/pull/1105 and https://github.com/noironetworks/support/pull/1106
Also removed istio-operator from versions.yaml as it's a part of the acc container now

(cherry picked from commit 5e1012de2a27a676051fb3d3b5d6e14792f147e9)