### PR TITLE
Fixes for Openshift-4.3

### DIFF
--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -84,7 +84,8 @@ flavors:
     default_version: 5.0
     config:
       kube_config:
-        use_external_service_ip_allocator: True
+        use_external_service_ip_allocator: False
+        allow_pods_external_access: True
         use_privileged_containers: True
         use_openshift_security_context_constraints: False
         use_openshift_run_level: True

--- a/provision/testdata/flavor_openshift_43.apic.txt
+++ b/provision/testdata/flavor_openshift_43.apic.txt
@@ -341,6 +341,14 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
                                                 "tnVzBrCPName": "openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
@@ -694,6 +702,14 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
                                                 "tnVzBrCPName": "openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
@@ -776,6 +792,14 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
                                                 "tnVzBrCPName": "openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
@@ -842,6 +866,7 @@ None
                             "fvSubnet": {
                                 "attributes": {
                                     "ip": "10.2.0.1/16",
+                                    "scope": "public",
                                     "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }
@@ -850,6 +875,14 @@ None
                             "fvRsCtx": {
                                 "attributes": {
                                     "tnFvCtxName": "kube",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsBDToOut": {
+                                "attributes": {
+                                    "tnL3extOutName": "l3out",
                                     "annotation": "orchestrator:aci-containers-controller"
                                 }
                             }

--- a/provision/testdata/flavor_openshift_43.kube.yaml
+++ b/provision/testdata/flavor_openshift_43.kube.yaml
@@ -198,7 +198,6 @@ data:
                 "start": "10.4.0.2"
             }
         ],
-        "allocate-service-ips": false,
         "pod-ip-pool": [
             {
                 "end": "10.2.255.254",

--- a/provision/testdata/flavor_openshift_43_tar/cluster-network-09-ConfigMap-aci-containers-config.yaml
+++ b/provision/testdata/flavor_openshift_43_tar/cluster-network-09-ConfigMap-aci-containers-config.yaml
@@ -33,12 +33,11 @@ data:
     ,\n            \"start\": \"10.3.0.2\"\n        }\n    ],\n    \"snat-contract-scope\"\
     : \"global\",\n    \"static-service-ip-pool\": [\n        {\n            \"end\"\
     : \"10.4.0.254\",\n            \"start\": \"10.4.0.2\"\n        }\n    ],\n  \
-    \  \"allocate-service-ips\": false,\n    \"pod-ip-pool\": [\n        {\n     \
-    \       \"end\": \"10.2.255.254\",\n            \"start\": \"10.2.0.2\"\n    \
-    \    }\n    ],\n    \"pod-subnet-chunk-size\": 32,\n    \"node-service-ip-pool\"\
-    : [\n        {\n            \"end\": \"10.5.0.254\",\n            \"start\": \"\
-    10.5.0.2\"\n        }\n    ],\n    \"node-service-subnets\": [\n        \"10.5.0.1/24\"\
-    \n    ]\n}"
+    \  \"pod-ip-pool\": [\n        {\n            \"end\": \"10.2.255.254\",\n   \
+    \         \"start\": \"10.2.0.2\"\n        }\n    ],\n    \"pod-subnet-chunk-size\"\
+    : 32,\n    \"node-service-ip-pool\": [\n        {\n            \"end\": \"10.5.0.254\"\
+    ,\n            \"start\": \"10.5.0.2\"\n        }\n    ],\n    \"node-service-subnets\"\
+    : [\n        \"10.5.0.1/24\"\n    ]\n}"
   host-agent-config: "{\n    \"ep-registry\": null,\n    \"opflex-mode\": null,\n\
     \    \"log-level\": \"info\",\n    \"aci-snat-namespace\": \"aci-containers-system\"\
     ,\n    \"aci-vmm-type\": \"OpenShift\",\n    \"aci-vmm-domain\": \"kube\",\n \


### PR DESCRIPTION
Add use_external_service_ip_allocator: False and allow_pods_external_access: True to kube_config

(cherry picked from commit 40e41fc62415efc3522c0f54aaf66ee922cbd1aa)