### PR TITLE
Changes for Openshift-4.3

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -175,6 +175,7 @@ def config_default():
                 "srcAddr": None,
                 "activeFlowTimeOut": None,
             },
+            "kube_default_provide_kube_api": False,
         },
         "net_config": {
             "node_subnet": None,

--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -4592,6 +4592,7 @@ class ApicKubeConfig(object):
         if "items" in self.config["aci_config"].keys():
             self.editItems(self.config, old_naming)
             items = self.config["aci_config"]["items"]
+            default_provide_api = self.config["aci_config"]["kube_default_provide_kube_api"]
             kube_api_entries = []
             dns_entries = []
             if 'kube_api_entries' in self.config["aci_config"]:
@@ -4599,7 +4600,7 @@ class ApicKubeConfig(object):
             if 'dns_entries' in self.config["aci_config"]:
                 dns_entries = self.config["aci_config"]["dns_entries"]
             if vmm_type == "OpenShift":
-                openshift_flavor_specific_handling(data, items, system_id, old_naming, self.ACI_PREFIX,
+                openshift_flavor_specific_handling(data, items, system_id, old_naming, self.ACI_PREFIX, default_provide_api,
                                                    kube_api_entries, api_filter_prefix, dns_entries, filter_prefix)
             elif flavor == "docker-ucp-3.0":
                 dockerucp_flavor_specific_handling(data, items)
@@ -4786,7 +4787,7 @@ class ApicKubeConfig(object):
         return path, data
 
 
-def openshift_flavor_specific_handling(data, items, system_id, old_naming, aci_prefix,
+def openshift_flavor_specific_handling(data, items, system_id, old_naming, aci_prefix, default_provide_api,
                                        kube_api_entries, api_filter_prefix, dns_entries, dns_filter_prefix):
     if items is None or len(items) == 0:
         err("Error in getting items for flavor")
@@ -4822,6 +4823,9 @@ def openshift_flavor_specific_handling(data, items, system_id, old_naming, aci_p
         ]
     )
     data['fvTenant']['children'][0]['fvAp']['children'][1]['fvAEPg']['children'].append(provide_kube_api_contract_os)
+
+    if default_provide_api:
+        data['fvTenant']['children'][0]['fvAp']['children'][0]['fvAEPg']['children'].append(provide_kube_api_contract_os)
 
     # special case for dns contract
     consume_dns_contract_os = collections.OrderedDict(

--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -99,6 +99,7 @@ flavors:
         host_agent_cni_conf_path: /etc/kubernetes
         generate_installer_files: True
       aci_config:
+        kube_default_provide_kube_api: True
         items:
           - name: openshift-svc-catalog
             range:
@@ -115,6 +116,12 @@ flavors:
                 [9091, 9091]
               -
                 [9094, 9094]
+              -   
+                [9095, 9095]
+              -   
+                [3000, 3000]
+              -   
+                [8080, 8080]
             etherT: ip
             prot: tcp
             stateful: "no"

--- a/provision/testdata/flavor_openshift_43.apic.txt
+++ b/provision/testdata/flavor_openshift_43.apic.txt
@@ -347,6 +347,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsCons": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-monitoring",
@@ -708,6 +716,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsCons": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-monitoring",
@@ -793,6 +809,14 @@ None
                                         "fvRsCons": {
                                             "attributes": {
                                                 "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-api",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1508,6 +1532,48 @@ None
                                     "prot": "tcp",
                                     "dFromPort": "9094",
                                     "dToPort": "9094",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "openshift-monitoring-9095",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9095",
+                                    "dToPort": "9095",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "openshift-monitoring-3000",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "3000",
+                                    "dToPort": "3000",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "openshift-monitoring-8080",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "8080",
+                                    "dToPort": "8080",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"


### PR DESCRIPTION
1. Add ports 3000, 8080 and 9095 to openshift-monitoring filter
2. kube-default EPG provide kube-api contract