### PR TITLE
istio 1.5: Adding new istio-pilot ports

### DIFF
--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -4220,7 +4220,7 @@ class ApicKubeConfig(object):
                                                                                             [
                                                                                                 (
                                                                                                     "name",
-                                                                                                    "istio-pilot-15010",
+                                                                                                    "istio-pilot-15010:12",
                                                                                                 ),
                                                                                                 (
                                                                                                     "etherT",
@@ -4236,7 +4236,53 @@ class ApicKubeConfig(object):
                                                                                                 ),
                                                                                                 (
                                                                                                     "dToPort",
-                                                                                                    "15010",
+                                                                                                    "15012",
+                                                                                                ),
+                                                                                                (
+                                                                                                    "stateful",
+                                                                                                    "no",
+                                                                                                ),
+                                                                                                (
+                                                                                                    "tcpRules",
+                                                                                                    "",
+                                                                                                ),
+                                                                                            ]
+                                                                                        ),
+                                                                                    )
+                                                                                ]
+                                                                            ),
+                                                                        )
+                                                                    ]
+                                                                ),
+                                                                collections.OrderedDict(
+                                                                    [
+                                                                        (
+                                                                            "vzEntry",
+                                                                            collections.OrderedDict(
+                                                                                [
+                                                                                    (
+                                                                                        "attributes",
+                                                                                        collections.OrderedDict(
+                                                                                            [
+                                                                                                (
+                                                                                                    "name",
+                                                                                                    "istio-pilot2-15014",
+                                                                                                ),
+                                                                                                (
+                                                                                                    "etherT",
+                                                                                                    "ip",
+                                                                                                ),
+                                                                                                (
+                                                                                                    "prot",
+                                                                                                    "tcp",
+                                                                                                ),
+                                                                                                (
+                                                                                                    "dFromPort",
+                                                                                                    "15014",
+                                                                                                ),
+                                                                                                (
+                                                                                                    "dToPort",
+                                                                                                    "15014",
                                                                                                 ),
                                                                                                 (
                                                                                                     "stateful",

--- a/provision/testdata/base_case.apic.txt
+++ b/provision/testdata/base_case.apic.txt
@@ -929,11 +929,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/base_case_ipv6.apic.txt
+++ b/provision/testdata/base_case_ipv6.apic.txt
@@ -835,11 +835,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/flavor_dockerucp.apic.txt
+++ b/provision/testdata/flavor_dockerucp.apic.txt
@@ -985,11 +985,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/flavor_openshift_310.apic.txt
+++ b/provision/testdata/flavor_openshift_310.apic.txt
@@ -1057,11 +1057,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/flavor_openshift_43.apic.txt
+++ b/provision/testdata/flavor_openshift_43.apic.txt
@@ -1226,11 +1226,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/nested-elag.apic.txt
+++ b/provision/testdata/nested-elag.apic.txt
@@ -900,11 +900,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/nested-portgroup.apic.txt
+++ b/provision/testdata/nested-portgroup.apic.txt
@@ -891,11 +891,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/nested-vlan.apic.txt
+++ b/provision/testdata/nested-vlan.apic.txt
@@ -891,11 +891,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/nested-vxlan.apic.txt
+++ b/provision/testdata/nested-vxlan.apic.txt
@@ -852,11 +852,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/pod_ext_access.apic.txt
+++ b/provision/testdata/pod_ext_access.apic.txt
@@ -986,11 +986,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/vlan_case.apic.txt
+++ b/provision/testdata/vlan_case.apic.txt
@@ -843,11 +843,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/with_comments.apic.txt
+++ b/provision/testdata/with_comments.apic.txt
@@ -813,11 +813,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/with_interface_mtu.apic.txt
+++ b/provision/testdata/with_interface_mtu.apic.txt
@@ -929,11 +929,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/with_new_naming_convention.apic.txt
+++ b/provision/testdata/with_new_naming_convention.apic.txt
@@ -929,11 +929,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/with_new_naming_convention_dockerucp.apic.txt
+++ b/provision/testdata/with_new_naming_convention_dockerucp.apic.txt
@@ -985,11 +985,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/with_new_naming_convention_openshift.apic.txt
+++ b/provision/testdata/with_new_naming_convention_openshift.apic.txt
@@ -1057,11 +1057,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/with_overrides.apic.txt
+++ b/provision/testdata/with_overrides.apic.txt
@@ -821,11 +821,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/with_preexisting_tenant.apic.txt
+++ b/provision/testdata/with_preexisting_tenant.apic.txt
@@ -928,11 +928,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"

--- a/provision/testdata/with_tenant_l3out.apic.txt
+++ b/provision/testdata/with_tenant_l3out.apic.txt
@@ -814,11 +814,25 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "istio-pilot-15010",
+                                    "name": "istio-pilot-15010:12",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "15010",
-                                    "dToPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
                                     "stateful": "no",
                                     "tcpRules": "",
                                     "annotation": "orchestrator:aci-containers-controller"


### PR DESCRIPTION
+ Changes to add ports 15011,15012,15014 to istio filter on APIC so that the sidecars can comeup in user pods ([reference](https://istio.io/docs/ops/deployment/requirements/#ports-used-by-istio))