### PR TITLE
Catch for exception in unprovision code

### DIFF
--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -281,9 +281,12 @@ class Apic(object):
         self.clean_tagged_resources(system_id, tenant)
 
     def check_valid_annotation(self, path):
-        data = self.get_path(path)
-        if data['fvTenant']['attributes']['annotation'] == aciContainersOwnerAnnotation:
-            return True
+        try:
+            data = self.get_path(path)
+            if data['fvTenant']['attributes']['annotation'] == aciContainersOwnerAnnotation:
+                return True
+        except Exception as e:
+            dbg("Unable to find APIC object %s: %s" % (path, str(e)))
         return False
 
     def check_no_ap(self, path):


### PR DESCRIPTION
This exception will happen when trying to delete a tenant that doesn't exist. This isn't an error, so just add a debug statement.