### PR TITLE
Add aci.aw permissions for the operator

### DIFF
--- a/provision/acc_provision/templates/aci-operators.yaml
+++ b/provision/acc_provision/templates/aci-operators.yaml
@@ -94,6 +94,17 @@ rules:
   - list
   - watch
   - get
+{% if config.flavor == "cloud" %}
+- apiGroups:
+  - "aci.aw"
+  resources:
+  - podifs
+  - podifs/status
+  - gbpsstates
+  - gbpsstates/status
+  verbs:
+  - "*"
+{% endif %}
 - apiGroups:
   - config.openshift.io
   - operator.openshift.io

--- a/provision/testdata/cloud_tar/cluster-network-30-ClusterRole-aci-containers-operator.yaml
+++ b/provision/testdata/cloud_tar/cluster-network-30-ClusterRole-aci-containers-operator.yaml
@@ -86,6 +86,15 @@ rules:
   - watch
   - get
 - apiGroups:
+  - aci.aw
+  resources:
+  - podifs
+  - podifs/status
+  - gbpsstates
+  - gbpsstates/status
+  verbs:
+  - '*'
+- apiGroups:
   - config.openshift.io
   - operator.openshift.io
   resources:

--- a/provision/testdata/flavor_cloud.kube.yaml
+++ b/provision/testdata/flavor_cloud.kube.yaml
@@ -1072,6 +1072,15 @@ rules:
   - watch
   - get
 - apiGroups:
+  - "aci.aw"
+  resources:
+  - podifs
+  - podifs/status
+  - gbpsstates
+  - gbpsstates/status
+  verbs:
+  - "*"
+- apiGroups:
   - config.openshift.io
   - operator.openshift.io
   resources:


### PR DESCRIPTION
The aci-containers-operator needs permissions to access aci.aw CRDs.