### PR TITLE
Option to associate node EPG with a BD when node-BD creation is disabled

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -179,6 +179,7 @@ def config_default():
             },
             "kube_default_provide_kube_api": False,
             "disable_node_bd_creation": False,
+            "kube_bd_name": None,
         },
         "net_config": {
             "node_subnet": None,

--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -2695,6 +2695,7 @@ class ApicKubeConfig(object):
         kube_prefix = "kube-"
         old_naming = self.config["aci_config"]["use_legacy_kube_naming_convention"]
         disable_node_bd = self.config["aci_config"]["disable_node_bd_creation"]
+        kube_bd_name = self.config["aci_config"]["kube_bd_name"]
         if old_naming:
             contract_prefix = ""
             api_contract_prefix = kube_prefix
@@ -2717,7 +2718,10 @@ class ApicKubeConfig(object):
             v6_sub_prefix = aci_prefix
 
         if disable_node_bd:
-            node_bd_name = ""
+            if kube_bd_name:
+                node_bd_name = kube_bd_name
+            else:
+                node_bd_name = ""
         else:
             node_bd_name = "%snode-bd" % bd_prefix
 

--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -110,6 +110,7 @@ flavors:
         host_agent_cni_conf_path: /etc/kubernetes
         generate_installer_files: True
       aci_config:
+        kube_bd_name: neutron-bd-test
         disable_node_bd_creation: True
         kube_default_provide_kube_api: True
         items:

--- a/provision/testdata/flavor_openshift_44_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_44_openstack.apic.txt
@@ -525,7 +525,7 @@ None
                                     {
                                         "fvRsBd": {
                                             "attributes": {
-                                                "tnFvBDName": "",
+                                                "tnFvBDName": "neutron-bd-test",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }


### PR DESCRIPTION
Follow up on https://github.com/noironetworks/acc-provision/pull/299
If the disable_node_bd_creation is set to True but the user wants to associate the node EPG with a BD(for example neutron BD), a field called "kube_bd_name" can be set inside aci_config