### PR TITLE
Add encapMode field to vlan portgroups

### DIFF
--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -1771,10 +1771,10 @@ class ApicKubeConfig(object):
         system_id = self.config["aci_config"]["system_id"]
         kubeapi_vlan = self.config["net_config"]["kubeapi_vlan"]
         nvmm_portgroup = "%s_vlan_%d" % (system_id, kubeapi_vlan)
-        path, data = self.build_nested_dom_data(nvmm_portgroup, False, False, True)
+        path, data = self.build_nested_dom_data(nvmm_portgroup, False, False, True, "access")
         return path, data
 
-    def build_nested_dom_data(self, nvmm_portgroup, infravlan, servicevlan, kubeapivlan):
+    def build_nested_dom_data(self, nvmm_portgroup, infravlan, servicevlan, kubeapivlan, encapMode="trunk"):
         # Build a nested dom object based on the portgroup name and the
         # VLANs required(using booleans arguments for each VLAN)
         nvmm_type = self.get_nested_domain_type()
@@ -1802,6 +1802,7 @@ class ApicKubeConfig(object):
                                 "attributes",
                                 collections.OrderedDict(
                                     [("name", nvmm_portgroup),
+                                     ("encapMode", encapMode),
                                      ("promMode", promMode)]
                                 ),
                             ),

--- a/provision/testdata/flavor_openshift_44_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_44_esx.apic.txt
@@ -141,6 +141,7 @@
     "vmmUsrCustomAggr": {
         "attributes": {
             "name": "kube-test",
+            "encapMode": "trunk",
             "promMode": "Enabled",
             "annotation": "orchestrator:aci-containers-controller"
         },
@@ -189,6 +190,7 @@
     "vmmUsrCustomAggr": {
         "attributes": {
             "name": "kube_vlan_4001",
+            "encapMode": "access",
             "promMode": "Enabled",
             "annotation": "orchestrator:aci-containers-controller"
         },

--- a/provision/testdata/nested-elag.apic.txt
+++ b/provision/testdata/nested-elag.apic.txt
@@ -141,6 +141,7 @@
     "vmmUsrCustomAggr": {
         "attributes": {
             "name": "kube-test",
+            "encapMode": "trunk",
             "promMode": "Enabled",
             "annotation": "orchestrator:aci-containers-controller"
         },

--- a/provision/testdata/nested-portgroup.apic.txt
+++ b/provision/testdata/nested-portgroup.apic.txt
@@ -141,6 +141,7 @@
     "vmmUsrCustomAggr": {
         "attributes": {
             "name": "kube-test",
+            "encapMode": "trunk",
             "promMode": "Enabled",
             "annotation": "orchestrator:aci-containers-controller"
         },

--- a/provision/testdata/nested-vlan.apic.txt
+++ b/provision/testdata/nested-vlan.apic.txt
@@ -141,6 +141,7 @@
     "vmmUsrCustomAggr": {
         "attributes": {
             "name": "kube",
+            "encapMode": "trunk",
             "promMode": "Enabled",
             "annotation": "orchestrator:aci-containers-controller"
         },

--- a/provision/testdata/nested-vxlan.apic.txt
+++ b/provision/testdata/nested-vxlan.apic.txt
@@ -111,6 +111,7 @@
     "vmmUsrCustomAggr": {
         "attributes": {
             "name": "kube",
+            "encapMode": "trunk",
             "promMode": "Disabled",
             "annotation": "orchestrator:aci-containers-controller"
         },


### PR DESCRIPTION
Set to "trunk" as default, change to access for OpenShift 4.4 ESX flavor