### PR TITLE
Add a apivlan access port group to VMM domain, when the flavor is ope…

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -1643,6 +1643,12 @@ def provision(args, apic_file, no_random):
     # generate output files; and program apic if needed
     gen = flavor_opts.get("template_generator", generate_kube_yaml)
     gen(config, output_file, output_tar, operator_cr_output_file)
+
+    if (config['flavor'] == "openshift-4.4-esx"):
+        apic = get_apic(config)
+        nested_vswitch_vlanpool = apic.get_vmmdom_vlanpool_tDn(config['aci_config']['vmm_domain']['nested_inside']['name'])
+        config['aci_config']['vmm_domain']['nested_inside']['vlan_pool'] = nested_vswitch_vlanpool
+
     ret = generate_apic_config(flavor_opts, config, prov_apic, apic_file)
     return ret
 

--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -210,6 +210,13 @@ class Apic(object):
         path = "/api/mo/uni/tn-%s/out-%s.json" % (tenant, name)
         return self.get_path(path)
 
+    def get_vmmdom_vlanpool_tDn(self, vmmdom):
+        path = "/api/node/mo/uni/vmmp-VMware/dom-%s.json?query-target=children" % (vmmdom)
+        tDn = self.get_path(path)["infraRsVlanNs"]["attributes"]["tDn"]
+        return tDn
+        #vpath = "/api/node/mo/%s.json" % (tDn)
+        #vlan_pool_name = self.get_path(vpath)["attributes"]["name"]
+
     def check_l3out_vrf(self, tenant, name, vrf_name):
         path = "/api/mo/uni/tn-%s/out-%s/rsectx.json?query-target=self" % (tenant, name)
         res = False
@@ -456,7 +463,6 @@ class ApicKubeConfig(object):
         update(data, self.phys_dom())
         update(data, self.kube_dom())
         update(data, self.nested_dom())
-        update(data, self.nested_dom_second_portgroup())
         update(data, self.associate_aep())
         update(data, self.opflex_cert())
         if apic_version >= 5.0:
@@ -464,6 +470,8 @@ class ApicKubeConfig(object):
 
         update(data, self.l3out_tn())
         update(data, getattr(self, self.tenant_generator)(self.config['flavor']))
+        update(data, self.add_apivlan_for_second_portgroup())
+        update(data, self.nested_dom_second_portgroup())
         for l3out_instp in self.config["aci_config"]["l3out"]["external_networks"]:
             update(data, self.l3out_contract(l3out_instp))
 
@@ -1763,15 +1771,102 @@ class ApicKubeConfig(object):
         path, data = self.build_nested_dom_data(nvmm_portgroup, True, True, True)
         return path, data
 
+    def add_apivlan_for_second_portgroup(self):
+        nvmm_type = self.get_nested_domain_type()
+        if nvmm_type != "VMware" or not self.config["net_config"]["second_kubeapi_portgroup"] or not self.config["net_config"]["kubeapi_vlan"]:
+            return
+        
+        path, data = self.add_apivlan_to_vmm_vlanpool()
+        return path, data
+
+    def add_apivlan_to_vmm_vlanpool(self):
+        #url: https://10.30.120.180/api/node/mo/uni/infra/vlanns-[hypf-vswitch-vlan-pool]-dynamic/from-[vlan-35]-to-[vlan-35].json
+        #payload{"fvnsEncapBlk":{"attributes":{"dn":"uni/infra/vlanns-[hypf-vswitch-vlan-pool]-dynamic/from-[vlan-35]-to-[vlan-35]","from":"vlan-35","to":"vlan-35","rn":"from-[vlan-35]-to-[vlan-35]","status":"created"},"children":[]}}
+
+        nvmm_name = self.config["aci_config"]["vmm_domain"]["nested_inside"]["name"]
+        kubeapi_vlan = self.config["net_config"]["kubeapi_vlan"]
+        #vpath = apic.get_vmmdom_vlanpool_tDn(nvmm_name)
+        vpath = self.config['aci_config']['vmm_domain']['nested_inside']['vlan_pool']
+  
+        path = "/api/node/mo/%s/from-[vlan-%s]-to-[vlan-%s].json" % (vpath, kubeapi_vlan, kubeapi_vlan)
+        data = collections.OrderedDict(
+            [
+                (
+                    "fvnsEncapBlk",
+                    collections.OrderedDict(
+                        [
+                           (
+                              "attributes",
+                              collections.OrderedDict(
+                                 [
+                                   ("dn", "%s/from-[vlan-%s]-to-[vlan-%s]" % (vpath, kubeapi_vlan, kubeapi_vlan) ),
+                                   ("allocMode", "static"),
+                                   ("from", "vlan-%s" % kubeapi_vlan),
+                                   ("to", "vlan-%s" % kubeapi_vlan),
+                                   ("rn", "from-[vlan-%s]-to-[vlan-%s]" % (kubeapi_vlan, kubeapi_vlan))
+                                 ]
+                              ),
+                           ),
+                        ]
+                    ),
+                ),
+            ]
+        )
+        data["fvnsEncapBlk"]["children"] = []
+
+        #self.annotateApicObjects(data)
+        return path, data
+
     def nested_dom_second_portgroup(self):
         nvmm_type = self.get_nested_domain_type()
         if nvmm_type != "VMware" or not self.config["net_config"]["second_kubeapi_portgroup"] or not self.config["net_config"]["kubeapi_vlan"]:
             return
 
+        path, data = self.add_vmm_domain_association()
+        return path, data
+
+    def add_vmm_domain_association(self):
+        #url: https://10.30.120.180/api/node/mo/uni/tn-ocp4aci/ap-aci-containers-ocp4aci/epg-aci-containers-nodes.json
+        #payload{"fvRsDomAtt":{"attributes":{"resImedcy":"immediate","tDn":"uni/vmmp-VMware/dom-hypflex-vswitch","instrImedcy":"immediate","encap":"vlan-35","status":"created"},"children":[{"vmmSecP":{"attributes":{"status":"created"},"children":[]}}]}}
+
         system_id = self.config["aci_config"]["system_id"]
         kubeapi_vlan = self.config["net_config"]["kubeapi_vlan"]
-        nvmm_portgroup = "%s_vlan_%d" % (system_id, kubeapi_vlan)
-        path, data = self.build_nested_dom_data(nvmm_portgroup, False, False, True)
+        custom_epg_name = "%s_vlan_%d" % (system_id, kubeapi_vlan)
+        nvmm_name = self.config["aci_config"]["vmm_domain"]["nested_inside"]["name"]
+        tdn = "uni/vmmp-VMware/dom-%s" % ( nvmm_name)
+        vlan_encap = "vlan-%s" % (kubeapi_vlan)
+  
+        path = "/api/node/mo/uni/tn-%s/ap-aci-containers-%s/epg-aci-containers-nodes.json" % (
+            system_id,
+            system_id
+        )
+
+        data = collections.OrderedDict(
+            [
+                (
+                    "fvRsDomAtt",
+                    collections.OrderedDict(
+                        [
+                           (
+                              "attributes",
+                              collections.OrderedDict(
+                                 [
+                                   ("resImedcy", "immediate"),
+                                   ("tDn", tdn),
+                                   ("instrImedcy", "immediate"),
+                                   ("customEpgName", custom_epg_name),
+                                   ("encap", vlan_encap),
+                                 ]
+                              ),
+                           ),
+                        ]
+                    ),
+                ),
+            ]
+        )
+        data["fvRsDomAtt"]["children"] = []
+     
+        self.annotateApicObjects(data)
         return path, data
 
     def build_nested_dom_data(self, nvmm_portgroup, infravlan, servicevlan, kubeapivlan):


### PR DESCRIPTION
…nshift-4.4-esx.

This portgroup is required for pxe provisioning of nodes.