### PR TITLE
Add a apivlan access port group to VMM domain for openshift-4.4-esx

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -1644,7 +1644,7 @@ def provision(args, apic_file, no_random):
     gen = flavor_opts.get("template_generator", generate_kube_yaml)
     gen(config, output_file, output_tar, operator_cr_output_file)
 
-    if (config['flavor'] == "openshift-4.4-esx"):
+    if (config['flavor'] == "openshift-4.4-esx" and prov_apic is not None):
         apic = get_apic(config)
         nested_vswitch_vlanpool = apic.get_vmmdom_vlanpool_tDn(config['aci_config']['vmm_domain']['nested_inside']['name'])
         config['aci_config']['vmm_domain']['nested_inside']['vlan_pool'] = nested_vswitch_vlanpool

--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -1643,6 +1643,12 @@ def provision(args, apic_file, no_random):
     # generate output files; and program apic if needed
     gen = flavor_opts.get("template_generator", generate_kube_yaml)
     gen(config, output_file, output_tar, operator_cr_output_file)
+
+    if (config['flavor'] == "openshift-4.4-esx"):
+        apic = get_apic(config)
+        nested_vswitch_vlanpool = apic.get_vmmdom_vlanpool_tDn(config['aci_config']['vmm_domain']['nested_inside']['name'])
+        config['aci_config']['vmm_domain']['nested_inside']['vlan_pool'] = nested_vswitch_vlanpool
+
     ret = generate_apic_config(flavor_opts, config, prov_apic, apic_file)
     return ret
 

--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -214,8 +214,8 @@ class Apic(object):
         path = "/api/node/mo/uni/vmmp-VMware/dom-%s.json?query-target=children" % (vmmdom)
         tDn = self.get_path(path)["infraRsVlanNs"]["attributes"]["tDn"]
         return tDn
-        #vpath = "/api/node/mo/%s.json" % (tDn)
-        #vlan_pool_name = self.get_path(vpath)["attributes"]["name"]
+        # vpath = "/api/node/mo/%s.json" % (tDn)
+        # vlan_pool_name = self.get_path(vpath)["attributes"]["name"]
 
     def check_l3out_vrf(self, tenant, name, vrf_name):
         path = "/api/mo/uni/tn-%s/out-%s/rsectx.json?query-target=self" % (tenant, name)
@@ -1775,19 +1775,19 @@ class ApicKubeConfig(object):
         nvmm_type = self.get_nested_domain_type()
         if nvmm_type != "VMware" or not self.config["net_config"]["second_kubeapi_portgroup"] or not self.config["net_config"]["kubeapi_vlan"]:
             return
-        
+
         path, data = self.add_apivlan_to_vmm_vlanpool()
         return path, data
 
     def add_apivlan_to_vmm_vlanpool(self):
-        #url: https://10.30.120.180/api/node/mo/uni/infra/vlanns-[hypf-vswitch-vlan-pool]-dynamic/from-[vlan-35]-to-[vlan-35].json
-        #payload{"fvnsEncapBlk":{"attributes":{"dn":"uni/infra/vlanns-[hypf-vswitch-vlan-pool]-dynamic/from-[vlan-35]-to-[vlan-35]","from":"vlan-35","to":"vlan-35","rn":"from-[vlan-35]-to-[vlan-35]","status":"created"},"children":[]}}
+        # url: https://10.30.120.180/api/node/mo/uni/infra/vlanns-[hypf-vswitch-vlan-pool]-dynamic/from-[vlan-35]-to-[vlan-35].json
+        # payload{"fvnsEncapBlk":{"attributes":{"dn":"uni/infra/vlanns-[hypf-vswitch-vlan-pool]-dynamic/from-[vlan-35]-to-[vlan-35]","from":"vlan-35","to":"vlan-35","rn":"from-[vlan-35]-to-[vlan-35]","status":"created"},"children":[]}}
 
-        nvmm_name = self.config["aci_config"]["vmm_domain"]["nested_inside"]["name"]
+        # nvmm_name = self.config["aci_config"]["vmm_domain"]["nested_inside"]["name"]
         kubeapi_vlan = self.config["net_config"]["kubeapi_vlan"]
-        #vpath = apic.get_vmmdom_vlanpool_tDn(nvmm_name)
+        # vpath = apic.get_vmmdom_vlanpool_tDn(nvmm_name)
         vpath = self.config['aci_config']['vmm_domain']['nested_inside']['vlan_pool']
-  
+
         path = "/api/node/mo/%s/from-[vlan-%s]-to-[vlan-%s].json" % (vpath, kubeapi_vlan, kubeapi_vlan)
         data = collections.OrderedDict(
             [
@@ -1795,18 +1795,18 @@ class ApicKubeConfig(object):
                     "fvnsEncapBlk",
                     collections.OrderedDict(
                         [
-                           (
-                              "attributes",
-                              collections.OrderedDict(
-                                 [
-                                   ("dn", "%s/from-[vlan-%s]-to-[vlan-%s]" % (vpath, kubeapi_vlan, kubeapi_vlan) ),
-                                   ("allocMode", "static"),
-                                   ("from", "vlan-%s" % kubeapi_vlan),
-                                   ("to", "vlan-%s" % kubeapi_vlan),
-                                   ("rn", "from-[vlan-%s]-to-[vlan-%s]" % (kubeapi_vlan, kubeapi_vlan))
-                                 ]
-                              ),
-                           ),
+                            (
+                                "attributes",
+                                collections.OrderedDict(
+                                    [
+                                        ("dn", "%s/from-[vlan-%s]-to-[vlan-%s]" % (vpath, kubeapi_vlan, kubeapi_vlan)),
+                                        ("allocMode", "static"),
+                                        ("from", "vlan-%s" % kubeapi_vlan),
+                                        ("to", "vlan-%s" % kubeapi_vlan),
+                                        ("rn", "from-[vlan-%s]-to-[vlan-%s]" % (kubeapi_vlan, kubeapi_vlan))
+                                    ]
+                                ),
+                            ),
                         ]
                     ),
                 ),
@@ -1814,7 +1814,7 @@ class ApicKubeConfig(object):
         )
         data["fvnsEncapBlk"]["children"] = []
 
-        #self.annotateApicObjects(data)
+        # self.annotateApicObjects(data)
         return path, data
 
     def nested_dom_second_portgroup(self):
@@ -1826,16 +1826,16 @@ class ApicKubeConfig(object):
         return path, data
 
     def add_vmm_domain_association(self):
-        #url: https://10.30.120.180/api/node/mo/uni/tn-ocp4aci/ap-aci-containers-ocp4aci/epg-aci-containers-nodes.json
-        #payload{"fvRsDomAtt":{"attributes":{"resImedcy":"immediate","tDn":"uni/vmmp-VMware/dom-hypflex-vswitch","instrImedcy":"immediate","encap":"vlan-35","status":"created"},"children":[{"vmmSecP":{"attributes":{"status":"created"},"children":[]}}]}}
+        # url: https://10.30.120.180/api/node/mo/uni/tn-ocp4aci/ap-aci-containers-ocp4aci/epg-aci-containers-nodes.json
+        # payload{"fvRsDomAtt":{"attributes":{"resImedcy":"immediate","tDn":"uni/vmmp-VMware/dom-hypflex-vswitch","instrImedcy":"immediate","encap":"vlan-35","status":"created"},"children":[{"vmmSecP":{"attributes":{"status":"created"},"children":[]}}]}}
 
         system_id = self.config["aci_config"]["system_id"]
         kubeapi_vlan = self.config["net_config"]["kubeapi_vlan"]
         custom_epg_name = "%s_vlan_%d" % (system_id, kubeapi_vlan)
         nvmm_name = self.config["aci_config"]["vmm_domain"]["nested_inside"]["name"]
-        tdn = "uni/vmmp-VMware/dom-%s" % ( nvmm_name)
+        tdn = "uni/vmmp-VMware/dom-%s" % (nvmm_name)
         vlan_encap = "vlan-%s" % (kubeapi_vlan)
-  
+
         path = "/api/node/mo/uni/tn-%s/ap-aci-containers-%s/epg-aci-containers-nodes.json" % (
             system_id,
             system_id
@@ -1847,25 +1847,25 @@ class ApicKubeConfig(object):
                     "fvRsDomAtt",
                     collections.OrderedDict(
                         [
-                           (
-                              "attributes",
-                              collections.OrderedDict(
-                                 [
-                                   ("resImedcy", "immediate"),
-                                   ("tDn", tdn),
-                                   ("instrImedcy", "immediate"),
-                                   ("customEpgName", custom_epg_name),
-                                   ("encap", vlan_encap),
-                                 ]
-                              ),
-                           ),
+                            (
+                                "attributes",
+                                collections.OrderedDict(
+                                    [
+                                        ("resImedcy", "immediate"),
+                                        ("tDn", tdn),
+                                        ("instrImedcy", "immediate"),
+                                        ("customEpgName", custom_epg_name),
+                                        ("encap", vlan_encap),
+                                    ]
+                                ),
+                            ),
                         ]
                     ),
                 ),
             ]
         )
         data["fvRsDomAtt"]["children"] = []
-     
+
         self.annotateApicObjects(data)
         return path, data
 

--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -210,6 +210,13 @@ class Apic(object):
         path = "/api/mo/uni/tn-%s/out-%s.json" % (tenant, name)
         return self.get_path(path)
 
+    def get_vmmdom_vlanpool_tDn(self, vmmdom):
+        path = "/api/node/mo/uni/vmmp-VMware/dom-%s.json?query-target=children" % (vmmdom)
+        tDn = self.get_path(path)["infraRsVlanNs"]["attributes"]["tDn"]
+        return tDn
+        #vpath = "/api/node/mo/%s.json" % (tDn)
+        #vlan_pool_name = self.get_path(vpath)["attributes"]["name"]
+
     def check_l3out_vrf(self, tenant, name, vrf_name):
         path = "/api/mo/uni/tn-%s/out-%s/rsectx.json?query-target=self" % (tenant, name)
         res = False
@@ -456,7 +463,6 @@ class ApicKubeConfig(object):
         update(data, self.phys_dom())
         update(data, self.kube_dom())
         update(data, self.nested_dom())
-        update(data, self.nested_dom_second_portgroup())
         update(data, self.associate_aep())
         update(data, self.opflex_cert())
         if apic_version >= 5.0:
@@ -464,6 +470,8 @@ class ApicKubeConfig(object):
 
         update(data, self.l3out_tn())
         update(data, getattr(self, self.tenant_generator)(self.config['flavor']))
+        update(data, self.add_apivlan_for_second_portgroup())
+        update(data, self.nested_dom_second_portgroup())
         for l3out_instp in self.config["aci_config"]["l3out"]["external_networks"]:
             update(data, self.l3out_contract(l3out_instp))
 
@@ -1763,15 +1771,102 @@ class ApicKubeConfig(object):
         path, data = self.build_nested_dom_data(nvmm_portgroup, True, True, True)
         return path, data
 
+    def add_apivlan_for_second_portgroup(self):
+        nvmm_type = self.get_nested_domain_type()
+        if nvmm_type != "VMware" or not self.config["net_config"]["second_kubeapi_portgroup"] or not self.config["net_config"]["kubeapi_vlan"]:
+            return
+        
+        path, data = self.add_apivlan_to_vmm_vlanpool()
+        return path, data
+
+    def add_apivlan_to_vmm_vlanpool(self):
+        #url: https://10.30.120.180/api/node/mo/uni/infra/vlanns-[hypf-vswitch-vlan-pool]-dynamic/from-[vlan-35]-to-[vlan-35].json
+        #payload{"fvnsEncapBlk":{"attributes":{"dn":"uni/infra/vlanns-[hypf-vswitch-vlan-pool]-dynamic/from-[vlan-35]-to-[vlan-35]","from":"vlan-35","to":"vlan-35","rn":"from-[vlan-35]-to-[vlan-35]","status":"created"},"children":[]}}
+
+        nvmm_name = self.config["aci_config"]["vmm_domain"]["nested_inside"]["name"]
+        kubeapi_vlan = self.config["net_config"]["kubeapi_vlan"]
+        #vpath = apic.get_vmmdom_vlanpool_tDn(nvmm_name)
+        vpath = self.config['aci_config']['vmm_domain']['nested_inside']['vlan_pool']
+  
+        path = "/api/node/mo/%s/from-[vlan-%s]-to-[vlan-%s].json" % (vpath, kubeapi_vlan, kubeapi_vlan)
+        data = collections.OrderedDict(
+            [
+                (
+                    "fvnsEncapBlk",
+                    collections.OrderedDict(
+                        [
+                           (
+                              "attributes",
+                              collections.OrderedDict(
+                                 [
+                                   ("dn", "%s/from-[vlan-%s]-to-[vlan-%s]" % (vpath, kubeapi_vlan, kubeapi_vlan) ),
+                                   ("allocMode", "static"),
+                                   ("from", "vlan-%s" % kubeapi_vlan),
+                                   ("to", "vlan-%s" % kubeapi_vlan),
+                                   ("rn", "from-[vlan-%s]-to-[vlan-%s]" % (kubeapi_vlan, kubeapi_vlan))
+                                 ]
+                              ),
+                           ),
+                        ]
+                    ),
+                ),
+            ]
+        )
+        data["fvnsEncapBlk"]["children"] = []
+
+        #self.annotateApicObjects(data)
+        return path, data
+
     def nested_dom_second_portgroup(self):
         nvmm_type = self.get_nested_domain_type()
         if nvmm_type != "VMware" or not self.config["net_config"]["second_kubeapi_portgroup"] or not self.config["net_config"]["kubeapi_vlan"]:
             return
 
+        path, data = self.add_vmm_domain_association()
+        return path, data
+
+    def add_vmm_domain_association(self):
+        #url: https://10.30.120.180/api/node/mo/uni/tn-ocp4aci/ap-aci-containers-ocp4aci/epg-aci-containers-nodes.json
+        #payload{"fvRsDomAtt":{"attributes":{"resImedcy":"immediate","tDn":"uni/vmmp-VMware/dom-hypflex-vswitch","instrImedcy":"immediate","encap":"vlan-35","status":"created"},"children":[{"vmmSecP":{"attributes":{"status":"created"},"children":[]}}]}}
+
         system_id = self.config["aci_config"]["system_id"]
         kubeapi_vlan = self.config["net_config"]["kubeapi_vlan"]
-        nvmm_portgroup = "%s_vlan_%d" % (system_id, kubeapi_vlan)
-        path, data = self.build_nested_dom_data(nvmm_portgroup, False, False, True)
+        custom_epg_name = "%s_vlan_%d" % (system_id, kubeapi_vlan)
+        nvmm_name = self.config["aci_config"]["vmm_domain"]["nested_inside"]["name"]
+        tdn = "uni/vmmp-VMware/dom-%s" % ( nvmm_name)
+        vlan_encap = "vlan-%s" % (kubeapi_vlan)
+  
+        path = "/api/node/mo/uni/tn-%s/ap-aci-containers-%s/epg-aci-containers-nodes.json" % (
+            system_id,
+            system_id
+        )
+
+        data = collections.OrderedDict(
+            [
+                (
+                    "fvRsDomAtt",
+                    collections.OrderedDict(
+                        [
+                           (
+                              "attributes",
+                              collections.OrderedDict(
+                                 [
+                                   ("resImedcy", "immediate"),
+                                   ("tDn", tdn),
+                                   ("instrImedcy", "immediate"),
+                                   ("customEpgName", custom_epg_name),
+                                   ("encap", vlan_encap),
+                                 ]
+                              ),
+                           ),
+                        ]
+                    ),
+                ),
+            ]
+        )
+        data["fvRsDomAtt"]["children"] = []
+     
+        self.annotateApicObjects(data)
         return path, data
 
     def build_nested_dom_data(self, nvmm_portgroup, infravlan, servicevlan, kubeapivlan):

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -260,7 +260,7 @@ def test_flavor_openshift_44_openstack():
 @in_testdir
 def test_flavor_openshift_44_esx():
     run_provision(
-        "nested-portgroup.inp.yaml",
+        "flavor_openshift_44_esx.inp.yaml",
         "flavor_openshift_44_esx.kube.yaml",
         "flavor_openshift_44_esx_tar",
         None,

--- a/provision/testdata/flavor_openshift_44_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_44_esx.apic.txt
@@ -184,36 +184,6 @@
         ]
     }
 }
-/api/mo/uni/vmmp-VMware/dom-myvmware/usrcustomaggr-kube_vlan_4001.json
-{
-    "vmmUsrCustomAggr": {
-        "attributes": {
-            "name": "kube_vlan_4001",
-            "promMode": "Enabled",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "fvnsEncapBlk": {
-                    "attributes": {
-                        "from": "vlan-4001",
-                        "to": "vlan-4001",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            },
-            {
-                "fvnsEncapBlk": {
-                    "attributes": {
-                        "from": "vlan-1000",
-                        "to": "vlan-2000",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/infra.json
 {
     "infraAttEntityP": {
@@ -1510,6 +1480,33 @@ None
                 }
             }
         ]
+    }
+}
+/api/node/mo/vlan-pool-test/from-[vlan-4001]-to-[vlan-4001].json
+{
+    "fvnsEncapBlk": {
+        "attributes": {
+            "dn": "vlan-pool-test/from-[vlan-4001]-to-[vlan-4001]",
+            "allocMode": "static",
+            "from": "vlan-4001",
+            "to": "vlan-4001",
+            "rn": "from-[vlan-4001]-to-[vlan-4001]"
+        },
+        "children": []
+    }
+}
+/api/node/mo/uni/tn-kube/ap-aci-containers-kube/epg-aci-containers-nodes.json
+{
+    "fvRsDomAtt": {
+        "attributes": {
+            "resImedcy": "immediate",
+            "tDn": "uni/vmmp-VMware/dom-myvmware",
+            "instrImedcy": "immediate",
+            "customEpgName": "kube_vlan_4001",
+            "encap": "vlan-4001",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": []
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_44_esx.inp.yaml
+++ b/provision/testdata/flavor_openshift_44_esx.inp.yaml
@@ -1,0 +1,52 @@
+aci_config:
+  system_id: kube
+  use_legacy_kube_naming_convention: True
+  apic_hosts:
+    - 10.30.120.100
+  apic_login:
+    username: admin
+    password: noir0123
+  aep: kube-aep
+  vrf:
+    name: kube
+    tenant: common
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vlan
+    vlan_range:
+      start: 1000
+      end: 2000
+    nested_inside:
+      type: vmware
+      name: myvmware
+      portgroup: kube-test
+      vlan_pool: vlan-pool-test
+
+net_config:
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+
+kube_config:
+  controller: 1.1.1.1
+  use_cluster_role: true
+  use_ds_rolling_update: true
+
+registry:
+  image_prefix: noiro
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info


### PR DESCRIPTION
This portgroup is required for pxe provisioning of nodes.