### PR TITLE
Add upgrade option to acc-provision

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -248,6 +248,9 @@ def config_default():
         "drop_log_config": {
             "enable": True
         },
+        "provision": {
+            "upgrade_cluster": False,
+        },
     }
     return default_config
 
@@ -1345,6 +1348,9 @@ def parse_args(show_help):
     parser.add_argument(
         '--skip-kafka-certs', action='store_true', default=False,
         help='skip kafka certificate generation')
+    parser.add_argument(
+        '--upgrade', action='store_true', default=False,
+        help='generate kubernetes deployment file for cluster upgrade')
 
     # If the input has no arguments, show help output and exit
     if show_help:
@@ -1475,6 +1481,7 @@ def provision(args, apic_file, no_random):
     output_file = args.output
     output_tar = args.output_tar
     operator_cr_output_file = args.aci_operator_cr
+    upgrade_cluster = args.upgrade
 
     prov_apic = None
     if args.apic:
@@ -1518,6 +1525,10 @@ def provision(args, apic_file, no_random):
             "skip-kafka-certs": args.skip_kafka_certs,
         },
     }
+
+    if upgrade_cluster:
+        output_tar = "/dev/null"
+        config["provision"]["upgrade_cluster"] = True
 
     # infra_vlan is not part of command line input, but we do
     # pass it as a command line arg in unit tests to pass in

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -782,7 +782,11 @@ metadata:
     network-plugin: aci-containers
 spec:
   updateStrategy:
+{% if config.provision.upgrade_cluster %}
+    type: OnDelete
+{% else %}
     type: RollingUpdate
+{% endif %}
   selector:
     matchLabels:
       name: aci-containers-host
@@ -992,7 +996,11 @@ metadata:
     network-plugin: aci-containers
 spec:
   updateStrategy:
+{% if config.provision.upgrade_cluster %}
+    type: OnDelete
+{% else %}
     type: RollingUpdate
+{% endif %}
   selector:
     matchLabels:
       name: aci-containers-openvswitch

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -45,6 +45,18 @@ def test_base_case_simple():
 
 
 @in_testdir
+def test_base_case_upgrade():
+    run_provision(
+        "base_case.inp.yaml",
+        "base_case_upgrade.kube.yaml",
+        None,
+        None,
+        None,
+        overrides={"upgrade": True}
+    )
+
+
+@in_testdir
 def test_base_case_snat():
     run_provision(
         "base_case_snat.inp.yaml",
@@ -578,6 +590,7 @@ def get_args(**overrides):
         "release": False,
         "test_data_out": None,
         "skip_kafka_certs": True,
+        "upgrade": False,
         # infra_vlan is not part of command line input, but we do
         # pass it as a command line arg in unit tests to pass in
         # configuration which would otherwise be discovered from

--- a/provision/testdata/base_case_upgrade.kube.yaml
+++ b/provision/testdata/base_case_upgrade.kube.yaml
@@ -1,0 +1,1045 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: acicontainersoperators.aci.ctrl
+spec:
+  group: aci.ctrl
+  names:
+    kind: AciContainersOperator
+    listKind: AciContainersOperatorList
+    plural: acicontainersoperators
+    singular: acicontainersoperator
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+  annotations:
+    openshift.io/node-selector: ''
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: snatglobalinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatGlobalInfo
+    listKind: SnatGlobalInfoList
+    plural: snatglobalinfos
+    singular: snatglobalinfo
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: snatlocalinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatLocalInfo
+    listKind: SnatLocalInfoList
+    plural: snatlocalinfos
+    singular: snatlocalinfo
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: snatpolicies.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatPolicy
+    listKind: SnatPolicyList
+    plural: snatpolicies
+    singular: snatpolicy
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            selector:
+              properties:
+                labels:
+                  type: object
+                  properties:
+                    additionalProperties:
+                      type: string
+                namespace:
+                  type: string
+              type: object
+            snatIp:
+              type: array
+            destIp:
+              type: array
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: nodeinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: NodeInfo
+    listKind: NodeInfoList
+    plural: nodeinfos
+    singular: nodeinfo
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: rdconfigs.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: RdConfig
+    listKind: RdConfigList
+    plural: rdconfigs
+    singular: rdconfig
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: aciistiooperators.aci.istio
+spec:
+  group: aci.istio
+  names:
+    kind: AciIstioOperator
+    listKind: AciIstioOperatorList
+    plural: aciistiooperators
+    singular: aciistiooperator
+  scope: Namespaced
+  version: v1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aci-operator-config
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  spec: |-
+    {
+        "flavor": "kubernetes-1.15",
+        "config": "CmFwaVZlcnNpb246IHYxCmtpbmQ6IE5hbWVzcGFjZQptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogIGFubm90YXRpb25zOgogICAgb3BlbnNoaWZ0LmlvL25vZGUtc2VsZWN0b3I6ICcnCi0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MWJldGExCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBzbmF0Z2xvYmFsaW5mb3MuYWNpLnNuYXQKc3BlYzoKICBncm91cDogYWNpLnNuYXQKICBuYW1lczoKICAgIGtpbmQ6IFNuYXRHbG9iYWxJbmZvCiAgICBsaXN0S2luZDogU25hdEdsb2JhbEluZm9MaXN0CiAgICBwbHVyYWw6IHNuYXRnbG9iYWxpbmZvcwogICAgc2luZ3VsYXI6IHNuYXRnbG9iYWxpbmZvCiAgc2NvcGU6IE5hbWVzcGFjZWQKICB2ZXJzaW9uOiB2MQotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjFiZXRhMQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogc25hdGxvY2FsaW5mb3MuYWNpLnNuYXQKc3BlYzoKICBncm91cDogYWNpLnNuYXQKICBuYW1lczoKICAgIGtpbmQ6IFNuYXRMb2NhbEluZm8KICAgIGxpc3RLaW5kOiBTbmF0TG9jYWxJbmZvTGlzdAogICAgcGx1cmFsOiBzbmF0bG9jYWxpbmZvcwogICAgc2luZ3VsYXI6IHNuYXRsb2NhbGluZm8KICBzY29wZTogTmFtZXNwYWNlZAogIHZlcnNpb246IHYxCi0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MWJldGExCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBzbmF0cG9saWNpZXMuYWNpLnNuYXQKc3BlYzoKICBncm91cDogYWNpLnNuYXQKICBuYW1lczoKICAgIGtpbmQ6IFNuYXRQb2xpY3kKICAgIGxpc3RLaW5kOiBTbmF0UG9saWN5TGlzdAogICAgcGx1cmFsOiBzbmF0cG9saWNpZXMKICAgIHNpbmd1bGFyOiBzbmF0cG9saWN5CiAgc2NvcGU6IENsdXN0ZXIKICBzdWJyZXNvdXJjZXM6CiAgICBzdGF0dXM6IHt9CiAgdmFsaWRhdGlvbjoKICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgcHJvcGVydGllczoKICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgZGVzY3JpcHRpb246ICdBUElWZXJzaW9uIGRlZmluZXMgdGhlIHZlcnNpb25lZCBzY2hlbWEgb2YgdGhpcyByZXByZXNlbnRhdGlvbgogICAgICAgICAgICBvZiBhbiBvYmplY3QuIFNlcnZlcnMgc2hvdWxkIGNvbnZlcnQgcmVjb2duaXplZCBzY2hlbWFzIHRvIHRoZSBsYXRlc3QKICAgICAgICAgICAgaW50ZXJuYWwgdmFsdWUsIGFuZCBtYXkgcmVqZWN0IHVucmVjb2duaXplZCB2YWx1ZXMuIE1vcmUgaW5mbzogaHR0cHM6Ly9naXQuazhzLmlvL2NvbW11bml0eS9jb250cmlidXRvcnMvZGV2ZWwvYXBpLWNvbnZlbnRpb25zLm1kI3Jlc291cmNlcycKICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgIGtpbmQ6CiAgICAgICAgICBkZXNjcmlwdGlvbjogJ0tpbmQgaXMgYSBzdHJpbmcgdmFsdWUgcmVwcmVzZW50aW5nIHRoZSBSRVNUIHJlc291cmNlIHRoaXMKICAgICAgICAgICAgb2JqZWN0IHJlcHJlc2VudHMuIFNlcnZlcnMgbWF5IGluZmVyIHRoaXMgZnJvbSB0aGUgZW5kcG9pbnQgdGhlIGNsaWVudAogICAgICAgICAgICBzdWJtaXRzIHJlcXVlc3RzIHRvLiBDYW5ub3QgYmUgdXBkYXRlZC4gSW4gQ2FtZWxDYXNlLiBNb3JlIGluZm86IGh0dHBzOi8vZ2l0Lms4cy5pby9jb21tdW5pdHkvY29udHJpYnV0b3JzL2RldmVsL2FwaS1jb252ZW50aW9ucy5tZCN0eXBlcy1raW5kcycKICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgc3BlYzoKICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgIHNlbGVjdG9yOgogICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICBsYWJlbHM6CiAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICBuYW1lc3BhY2U6CiAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICBzbmF0SXA6CiAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgZGVzdElwOgogICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICB0eXBlOiBvYmplY3QKICB2ZXJzaW9uOiB2MQogIHZlcnNpb25zOgogIC0gbmFtZTogdjEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjFiZXRhMQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogbm9kZWluZm9zLmFjaS5zbmF0CnNwZWM6CiAgZ3JvdXA6IGFjaS5zbmF0CiAgbmFtZXM6CiAgICBraW5kOiBOb2RlSW5mbwogICAgbGlzdEtpbmQ6IE5vZGVJbmZvTGlzdAogICAgcGx1cmFsOiBub2RlaW5mb3MKICAgIHNpbmd1bGFyOiBub2RlaW5mbwogIHNjb3BlOiBOYW1lc3BhY2VkCiAgdmVyc2lvbjogdjEKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxYmV0YTEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IHJkY29uZmlncy5hY2kuc25hdApzcGVjOgogIGdyb3VwOiBhY2kuc25hdAogIG5hbWVzOgogICAga2luZDogUmRDb25maWcKICAgIGxpc3RLaW5kOiBSZENvbmZpZ0xpc3QKICAgIHBsdXJhbDogcmRjb25maWdzCiAgICBzaW5ndWxhcjogcmRjb25maWcKICBzY29wZTogTmFtZXNwYWNlZAogIHZlcnNpb246IHYxCi0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MWJldGExCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBhY2lpc3Rpb29wZXJhdG9ycy5hY2kuaXN0aW8Kc3BlYzoKICBncm91cDogYWNpLmlzdGlvCiAgbmFtZXM6CiAgICBraW5kOiBBY2lJc3Rpb09wZXJhdG9yCiAgICBsaXN0S2luZDogQWNpSXN0aW9PcGVyYXRvckxpc3QKICAgIHBsdXJhbDogYWNpaXN0aW9vcGVyYXRvcnMKICAgIHNpbmd1bGFyOiBhY2lpc3Rpb29wZXJhdG9yCiAgc2NvcGU6IE5hbWVzcGFjZWQKICB2ZXJzaW9uOiB2MQotLS0KYXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnTWFwCm1ldGFkYXRhOgogIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbmZpZwogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCmRhdGE6CiAgY29udHJvbGxlci1jb25maWc6IHwtCiAgICB7CiAgICAgICAgImxvZy1sZXZlbCI6ICJpbmZvIiwKICAgICAgICAiYXBpYy1ob3N0cyI6IFsKICAgICAgICAgICAgIjEwLjMwLjEyMC4xMDAiCiAgICAgICAgXSwKICAgICAgICAiYXBpYy11c2VybmFtZSI6ICJrdWJlIiwKICAgICAgICAiYXBpYy1wcml2YXRlLWtleS1wYXRoIjogIi91c3IvbG9jYWwvZXRjL2FjaS1jZXJ0L3VzZXIua2V5IiwKICAgICAgICAiYXBpYy11c2UtaW5zdC10YWciOiB0cnVlLAogICAgICAgICJhY2ktcHJlZml4IjogImt1YmUiLAogICAgICAgICJhY2ktdm1tLXR5cGUiOiAiS3ViZXJuZXRlcyIsCiAgICAgICAgImFjaS12bW0tZG9tYWluIjogImt1YmUiLAogICAgICAgICJhY2ktdm1tLWNvbnRyb2xsZXIiOiAia3ViZSIsCiAgICAgICAgImFjaS1wb2xpY3ktdGVuYW50IjogImt1YmUiLAogICAgICAgICJyZXF1aXJlLW5ldHBvbC1hbm5vdCI6IGZhbHNlLAogICAgICAgICJpbnN0YWxsLWlzdGlvIjogdHJ1ZSwKICAgICAgICAiaXN0aW8tcHJvZmlsZSI6ICJkZW1vIiwKICAgICAgICAiYWNpLXBvZGJkLWRuIjogInVuaS90bi1rdWJlL0JELWt1YmUtcG9kLWJkIiwKICAgICAgICAiYWNpLW5vZGViZC1kbiI6ICJ1bmkvdG4ta3ViZS9CRC1rdWJlLW5vZGUtYmQiLAogICAgICAgICJhY2ktc2VydmljZS1waHlzLWRvbSI6ICJrdWJlLXBkb20iLAogICAgICAgICJhY2ktc2VydmljZS1lbmNhcCI6ICJ2bGFuLTQwMDMiLAogICAgICAgICJhY2ktc2VydmljZS1tb25pdG9yLWludGVydmFsIjogNSwKICAgICAgICAiYWNpLXBici10cmFja2luZy1ub24tc25hdCI6IGZhbHNlLAogICAgICAgICJhY2ktdnJmLXRlbmFudCI6ICJjb21tb24iLAogICAgICAgICJhY2ktdnJmLWRuIjogInVuaS90bi1jb21tb24vY3R4LWt1YmUiLAogICAgICAgICJhY2ktbDNvdXQiOiAibDNvdXQiLAogICAgICAgICJhY2ktZXh0LW5ldHdvcmtzIjogWwogICAgICAgICAgICAiZGVmYXVsdCIKICAgICAgICBdLAogICAgICAgICJhY2ktdnJmIjogImt1YmUiLAogICAgICAgICJkZWZhdWx0LWVuZHBvaW50LWdyb3VwIjogewogICAgICAgICAgICAicG9saWN5LXNwYWNlIjogImt1YmUiLAogICAgICAgICAgICAibmFtZSI6ICJrdWJlcm5ldGVzfGt1YmUtZGVmYXVsdCIKICAgICAgICB9LAogICAgICAgICJtYXgtbm9kZXMtc3ZjLWdyYXBoIjogMzIsCiAgICAgICAgIm5hbWVzcGFjZS1kZWZhdWx0LWVuZHBvaW50LWdyb3VwIjogewogICAgICAgICAgICAiaXN0aW8tb3BlcmF0b3IiOiB7CiAgICAgICAgICAgICAgICAicG9saWN5LXNwYWNlIjogImt1YmUiLAogICAgICAgICAgICAgICAgIm5hbWUiOiAia3ViZXJuZXRlc3xrdWJlLWlzdGlvIgogICAgICAgICAgICB9LAogICAgICAgICAgICAiaXN0aW8tc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJrdWJlIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1pc3RpbyIKICAgICAgICAgICAgfSwKICAgICAgICAgICAgImt1YmUtc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJrdWJlIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1zeXN0ZW0iCiAgICAgICAgICAgIH0gICAgICAgIH0sCiAgICAgICAgInNlcnZpY2UtaXAtcG9vbCI6IFsKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgImVuZCI6ICIxMC4zLjAuMjU0IiwKICAgICAgICAgICAgICAgICJzdGFydCI6ICIxMC4zLjAuMiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgInNuYXQtY29udHJhY3Qtc2NvcGUiOiAiZ2xvYmFsIiwKICAgICAgICAic3RhdGljLXNlcnZpY2UtaXAtcG9vbCI6IFsKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgImVuZCI6ICIxMC40LjAuMjU0IiwKICAgICAgICAgICAgICAgICJzdGFydCI6ICIxMC40LjAuMiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgInBvZC1pcC1wb29sIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAiZW5kIjogIjEwLjIuMjU1LjI1NCIsCiAgICAgICAgICAgICAgICAic3RhcnQiOiAiMTAuMi4wLjIiCiAgICAgICAgICAgIH0KICAgICAgICBdLAogICAgICAgICJwb2Qtc3VibmV0LWNodW5rLXNpemUiOiAzMiwKICAgICAgICAibm9kZS1zZXJ2aWNlLWlwLXBvb2wiOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJlbmQiOiAiMTAuNS4wLjI1NCIsCiAgICAgICAgICAgICAgICAic3RhcnQiOiAiMTAuNS4wLjIiCiAgICAgICAgICAgIH0KICAgICAgICBdLAogICAgICAgICJub2RlLXNlcnZpY2Utc3VibmV0cyI6IFsKICAgICAgICAgICAgIjEwLjUuMC4xLzI0IgogICAgICAgIF0KICAgIH0KICBob3N0LWFnZW50LWNvbmZpZzogfC0KICAgIHsKICAgICAgICAiYXBwLXByb2ZpbGUiOiAia3ViZXJuZXRlcyIsCiAgICAgICAgImVwLXJlZ2lzdHJ5IjogbnVsbCwKICAgICAgICAib3BmbGV4LW1vZGUiOiBudWxsLAogICAgICAgICJsb2ctbGV2ZWwiOiAiaW5mbyIsCiAgICAgICAgImFjaS1zbmF0LW5hbWVzcGFjZSI6ICJhY2ktY29udGFpbmVycy1zeXN0ZW0iLAogICAgICAgICJhY2ktdm1tLXR5cGUiOiAiS3ViZXJuZXRlcyIsCiAgICAgICAgImFjaS12bW0tZG9tYWluIjogImt1YmUiLAogICAgICAgICJhY2ktdm1tLWNvbnRyb2xsZXIiOiAia3ViZSIsCiAgICAgICAgImFjaS1wcmVmaXgiOiAia3ViZSIsCiAgICAgICAgImFjaS12cmYiOiAia3ViZSIsCiAgICAgICAgImFjaS12cmYtdGVuYW50IjogImNvbW1vbiIsCiAgICAgICAgInNlcnZpY2UtdmxhbiI6IDQwMDMsCiAgICAgICAgImt1YmVhcGktdmxhbiI6IDQwMDEsCiAgICAgICAgInBvZC1zdWJuZXQiOiAiMTAuMi4wLjEvMTYiLAogICAgICAgICJub2RlLXN1Ym5ldCI6ICIxMC4xLjAuMS8xNiIsCiAgICAgICAgImVuY2FwLXR5cGUiOiAidnhsYW4iLAogICAgICAgICJhY2ktaW5mcmEtdmxhbiI6IDQwOTMsCiAgICAgICAgImNuaS1uZXRjb25maWciOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJnYXRld2F5IjogIjEwLjIuMC4xIiwKICAgICAgICAgICAgICAgICJyb3V0ZXMiOiBbCiAgICAgICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgICAgICAiZHN0IjogIjAuMC4wLjAvMCIsCiAgICAgICAgICAgICAgICAgICAgICAgICJndyI6ICIxMC4yLjAuMSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBdLAogICAgICAgICAgICAgICAgInN1Ym5ldCI6ICIxMC4yLjAuMC8xNiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgImRlZmF1bHQtZW5kcG9pbnQtZ3JvdXAiOiB7CiAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAia3ViZSIsCiAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1kZWZhdWx0IgogICAgICAgIH0sCiAgICAgICAgIm5hbWVzcGFjZS1kZWZhdWx0LWVuZHBvaW50LWdyb3VwIjogewogICAgICAgICAgICAiaXN0aW8tb3BlcmF0b3IiOiB7CiAgICAgICAgICAgICAgICAicG9saWN5LXNwYWNlIjogImt1YmUiLAogICAgICAgICAgICAgICAgIm5hbWUiOiAia3ViZXJuZXRlc3xrdWJlLWlzdGlvIgogICAgICAgICAgICB9LAogICAgICAgICAgICAiaXN0aW8tc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJrdWJlIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1pc3RpbyIKICAgICAgICAgICAgfSwKICAgICAgICAgICAgImt1YmUtc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJrdWJlIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1zeXN0ZW0iCiAgICAgICAgICAgIH0gICAgICAgIH0sCiAgICAgICAgImVuYWJsZS1kcm9wLWxvZyI6IHRydWUKICAgIH0KICBvcGZsZXgtYWdlbnQtY29uZmlnOiB8LQogICAgewogICAgICAgICJsb2ciOiB7CiAgICAgICAgICAgICJsZXZlbCI6ICJpbmZvIgogICAgICAgIH0sCiAgICAgICAgIm9wZmxleCI6IHsKICAgICAgICB9CiAgICB9Ci0tLQphcGlWZXJzaW9uOiB2MQpraW5kOiBDb25maWdNYXAKbWV0YWRhdGE6CiAgbmFtZTogc25hdC1vcGVyYXRvci1jb25maWcKICBuYW1lc3BhY2U6IGFjaS1jb250YWluZXJzLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCiAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKZGF0YToKICAgICJzdGFydCI6ICI1MDAwIgogICAgImVuZCI6ICI2NTAwMCIKICAgICJwb3J0cy1wZXItbm9kZSI6ICIzMDAwIgotLS0KYXBpVmVyc2lvbjogdjEKa2luZDogU2VjcmV0Cm1ldGFkYXRhOgogIG5hbWU6IGFjaS11c2VyLWNlcnQKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKZGF0YToKICB1c2VyLmtleTogTFMwdExTMUNSVWRKVGlCUVVrbFdRVlJGSUV0RldTMHRMUzB0Q2sxSlNVTmtaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSUlVaQlFWTkRRVzFCZDJkblNtTkJaMFZCUVc5SFFrRk9jaXRCSzJkUFMySkJWbFp5U25NS1lqTXJXbGRpWTI1V1dHOHZaMlIxZUVsVWEzWnRNRGxyWldsR1EyNHJWWEF2VTBka2NYWTJRV2dyYW14S1prWTNkWFlyUm1kRFNuUkRlRVE0TjNGWmR3b3djVFZFWTBkV1RFbGpaa1kwV2xWaU9VSTRja3BYUzBKSk5uZEtabmgwVFdaR2RWVk9XVEkwWTJkM1VYQktjWEpOVlhGQlJIb3ZUVmNyZDNKYVpXaHpDbE51Um5ONVpYZFlVak00T0dWU04wVkxha1JYWldka1NubFFZMWhCWjAxQ1FVRkZRMmRaUWpsQldHSXhXbVpDUTBKVmVFSXJWV2RGVkVkTk55czBXRGtLYWtoaWVVVXdRbXg0Ykd0bWFuSnNkMlIyYlZNNVRUYzNLekphTm1STFFXZFFNek5VVWswdlVIZEZUVTlaTjFKdVpFSnZLMWcyZUVSelZtUmpWRXBKZVFvMVZuYzRlRlZhYkhJcllYVkZUMnh6TWxwdVduZ3hNV1UxZW1nM2MxVXpUbW8xU3pNMVFsZFNPVWRVV0VvMlVFMWtjRlEwT1d4Q09XSnNiRTFxUkhKTUNqY3JOV0pEYzJSMU5qTlBPRXRoVGpsWlVVcENRVkJIVFdKd1NIQkdjM1JETVdOWFIzQlNVWGd6YVhkR0sxcE1XVUZ5UVZWaVEwdGlWMUZtWW1sYVZIQUtRMU00UkdkUGJYbFZOM1ZMVkZKTGFVTXJNbEpaVkZNemNISk1WalUzUjNabVprWjRTbXBVZDBkNWEwTlJVVVJ2UjBKM1pqVnBUM041ZFUxUlRubzNTd3BTYVhKaVJEQktOMUkyV1dWUmEwcGFLM0JEWlV0M2VTdE9lVWx4ZUdnd1RFSkViVUo1YlZOTGRsZ3dWMFZMUTJsMFQyZHdhVE15UmxkQ2IzRklhbVl6Q2sxUlp5OUJhMEpNUWt4U2NXVktkblJ6VDI4emJVdFBOR0VyZURKbE4zbFNWVXRyTVVOdlMzcEdUa0pJTUc1VlpWaEhibEIzYVZST1lpdGlNV1ptVTBZS04zWkpTbUpJWkcxTFozVktlVEJzVlU1Qk4waGFOemRZTDJsS1VrRnJRV3B1WW1WTVMxcDZiRFJyYVZBM00zQnBVR1o0VEcwek4yWlFha29yZVVSdk5BcGFjSGRWZFZwU0swTkRXR3hJU0haUFpXWndPVTFXY2xkak5XVnFZME12UjJGRE5rMVhXWGxOYW5WWFRTdDRRWEJxWTNWMlFXdEZRWHBaSzNBeE5EQkRDbmgzY0hJNU5XeHBibTUyVjJORE4wNDNNRGhCU2tacGJUTXZSbFV4TUVkRWJ6YzNlVWxQU1RWb0t6VXpOMHBpV1dSdE5UVTFhRTlsU0M5TGFsTmxhMmdLUlVZMFRXMTRVbEJ0YVhRNU9YYzlQUW90TFMwdExVVk9SQ0JRVWtsV1FWUkZJRXRGV1MwdExTMHRDZz09CiAgdXNlci5jcnQ6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUkyUkVORFFWWkZRMEZuVUc5TlFUQkhRMU54UjFOSllqTkVVVVZDUWxGVlFVMUVkM2hEZWtGS1FtZE9Wa0pCV1ZSQmJGWlVUVkpaZDBaQldVUUtWbEZSUzBSQk1VUmhXRTVxWW5sQ1ZHVllUakJhVnpGNlRWSlZkMFYzV1VSV1VWRkVSRUY0Vm1NeVZubEpSekZvWW0xU2JGcFlRWGRJYUdOT1RWUmpkd3BPVkVVeVRXcEZlVTlVVFhkWGFHTk9UV3BqZDA1VVJUQk5ha1Y1VDFSTmQxZHFRVGhOVVhOM1ExRlpSRlpSVVVkRmQwcFdWWHBGVjAxQ1VVZEJNVlZGQ2tObmQwNVJNbXg2V1RJNFoxVXpiSHBrUjFaMFkzcEZWazFDVFVkQk1WVkZRWGQzVFZaWVRteGphVUowV1ZjMWExcFhWbmROU1VkbVRVRXdSME5UY1VjS1UwbGlNMFJSUlVKQlVWVkJRVFJIVGtGRVEwSnBVVXRDWjFGRVlTOW5VRzlFYVcxM1JsWmhlV0pIT1M5dFZtMHpTakZXTmxBMFNHSnpVMFUxVERWMFVBcGFTRzlvVVhBdmJFdG1NR2h1WVhJclowbG1ielZUV0hobE4zSXZhRmxCYVdKUmMxRXZUelp0VFU1TGRWRXpRbXhUZVVoSWVHVkhWa2N2VVdaTGVWWnBDbWRUVDNORFdEaGlWRWg0WW14RVYwNTFTRWxOUlV0VFlYRjZSa3RuUVRndmVrWjJjMHN5V0c5aVJYQjRZazF1YzBZd1pDOVFTR3RsZUVOdmR6RnViMGdLVTJOcU0wWjNTVVJCVVVGQ1RVRXdSME5UY1VkVFNXSXpSRkZGUWtKUlZVRkJORWRDUVVoWUsydE1WR1UyVEVOQlFtVjNiVU5VZGsxemFuVnpTR1J3V2dwcmFUQXhLMjVSTjB0b2JrVlNZa0p0TDNSYU5YTmpXa1UwWTNSSmNXTm9NMjU1TVVWSlZFaE9kRmxYUzBKT05FTmtWVXRqYW5aRVZ6Sm9NblpyU0dWbkNuSjBXV0pXSzBGaFJYTnhNRzAwZGtkR09VVnRkblF4WTNBNVdUUXhTWGxOUWxwWmNYYzRZeTlXTVVGMGJWSlJZMUpVV1ZGQk9FZ3pUMFpFWTJoNVFqSUtNRXBJVTBSdVFtOVROMlptVTJKQ2VBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KLS0tCmFwaVZlcnNpb246IHYxCmtpbmQ6IFNlcnZpY2VBY2NvdW50Cm1ldGFkYXRhOgogIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKLS0tCmFwaVZlcnNpb246IHYxCmtpbmQ6IFNlcnZpY2VBY2NvdW50Cm1ldGFkYXRhOgogIG5hbWU6IGFjaS1jb250YWluZXJzLWhvc3QtYWdlbnQKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKLS0tCmFwaVZlcnNpb246IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8vdjEKa2luZDogQ2x1c3RlclJvbGUKbWV0YWRhdGE6CiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogIG5hbWU6IGFjaS1jb250YWluZXJzOmNvbnRyb2xsZXIKcnVsZXM6Ci0gYXBpR3JvdXBzOgogIC0gIiIKICByZXNvdXJjZXM6CiAgLSBub2RlcwogIC0gbmFtZXNwYWNlcwogIC0gcG9kcwogIC0gZW5kcG9pbnRzCiAgLSBzZXJ2aWNlcwogIC0gZXZlbnRzCiAgLSByZXBsaWNhdGlvbmNvbnRyb2xsZXJzCiAgLSBzZXJ2aWNlYWNjb3VudHMKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIHBhdGNoCiAgLSBjcmVhdGUKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICIiCiAgcmVzb3VyY2VzOgogIC0gY29uZmlnbWFwcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICJyYmFjLmF1dGhvcml6YXRpb24uazhzLmlvIgogIHJlc291cmNlczoKICAtIGNsdXN0ZXJyb2xlcwogIC0gY2x1c3RlcnJvbGViaW5kaW5ncwogIHZlcmJzOgogIC0gJyonCi0gYXBpR3JvdXBzOgogIC0gImFwaWV4dGVuc2lvbnMuazhzLmlvIgogIHJlc291cmNlczoKICAtIGN1c3RvbXJlc291cmNlZGVmaW5pdGlvbnMKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtICJpbnN0YWxsLmlzdGlvLmlvIgogIHJlc291cmNlczoKICAtIGlzdGlvY29udHJvbHBsYW5lcwogIC0gaXN0aW9vcGVyYXRvcnMKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtICJhY2kuaXN0aW8iCiAgcmVzb3VyY2VzOgogIC0gYWNpaXN0aW9vcGVyYXRvcnMKICAtIGFjaWlzdGlvb3BlcmF0b3IKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtICJuZXR3b3JraW5nLms4cy5pbyIKICByZXNvdXJjZXM6CiAgLSBuZXR3b3JrcG9saWNpZXMKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAiYXBwcyIKICByZXNvdXJjZXM6CiAgLSBkZXBsb3ltZW50cwogIC0gcmVwbGljYXNldHMKICAtIGRhZW1vbnNldHMKICAtIHN0YXRlZnVsc2V0cwogIHZlcmJzOgogIC0gJyonCi0gYXBpR3JvdXBzOgogIC0gIiIKICByZXNvdXJjZXM6CiAgLSBub2RlcwogIC0gc2VydmljZXMvc3RhdHVzCiAgdmVyYnM6CiAgLSB1cGRhdGUKLSBhcGlHcm91cHM6CiAgLSAibW9uaXRvcmluZy5jb3Jlb3MuY29tIgogIHJlc291cmNlczoKICAtIHNlcnZpY2Vtb25pdG9ycwogIHZlcmJzOgogIC0gZ2V0CiAgLSBjcmVhdGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnNuYXQiCiAgcmVzb3VyY2VzOgogIC0gc25hdHBvbGljaWVzL2ZpbmFsaXplcnMKICAtIHNuYXRwb2xpY2llcy9zdGF0dXMKICAtIG5vZGVpbmZvcwogIHZlcmJzOgogIC0gdXBkYXRlCiAgLSBjcmVhdGUKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICJhY2kuc25hdCIKICByZXNvdXJjZXM6CiAgLSBzbmF0Z2xvYmFsaW5mb3MKICAtIHNuYXRwb2xpY2llcwogIC0gbm9kZWluZm9zCiAgLSByZGNvbmZpZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGNyZWF0ZQogIC0gdXBkYXRlCiAgLSBkZWxldGUKLSBhcGlHcm91cHM6CiAgLSBhcHBzLm9wZW5zaGlmdC5pbwogIHJlc291cmNlczoKICAtIGRlcGxveW1lbnRjb25maWdzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0Ci0tLQphcGlWZXJzaW9uOiByYmFjLmF1dGhvcml6YXRpb24uazhzLmlvL3YxCmtpbmQ6IENsdXN0ZXJSb2xlCm1ldGFkYXRhOgogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCiAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKICBuYW1lOiBhY2ktY29udGFpbmVyczpob3N0LWFnZW50CnJ1bGVzOgotIGFwaUdyb3VwczoKICAtICIiCiAgcmVzb3VyY2VzOgogIC0gbm9kZXMKICAtIG5hbWVzcGFjZXMKICAtIHBvZHMKICAtIGVuZHBvaW50cwogIC0gc2VydmljZXMKICAtIHJlcGxpY2F0aW9uY29udHJvbGxlcnMKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIHVwZGF0ZQotIGFwaUdyb3VwczoKICAtICIiCiAgcmVzb3VyY2VzOgogIC0gZXZlbnRzCiAgdmVyYnM6CiAgLSBjcmVhdGUKICAtIHBhdGNoCi0gYXBpR3JvdXBzOgogIC0gIm5ldHdvcmtpbmcuazhzLmlvIgogIHJlc291cmNlczoKICAtIG5ldHdvcmtwb2xpY2llcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAotIGFwaUdyb3VwczoKICAtICJhcHBzIgogIHJlc291cmNlczoKICAtIGRlcGxveW1lbnRzCiAgLSByZXBsaWNhc2V0cwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAotIGFwaUdyb3VwczoKICAtICJhY2kuc25hdCIKICByZXNvdXJjZXM6CiAgLSBzbmF0cG9saWNpZXMKICAtIHNuYXRnbG9iYWxpbmZvcwogIC0gcmRjb25maWdzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0Ci0gYXBpR3JvdXBzOgogIC0gImFjaS5zbmF0IgogIHJlc291cmNlczoKICAtIG5vZGVpbmZvcwogIC0gc25hdGxvY2FsaW5mb3MKICB2ZXJiczoKICAtIGNyZWF0ZQogIC0gdXBkYXRlCiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0Ci0tLQphcGlWZXJzaW9uOiByYmFjLmF1dGhvcml6YXRpb24uazhzLmlvL3YxCmtpbmQ6IENsdXN0ZXJSb2xlQmluZGluZwptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVyczpjb250cm9sbGVyCiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKcm9sZVJlZjoKICBhcGlHcm91cDogcmJhYy5hdXRob3JpemF0aW9uLms4cy5pbwogIGtpbmQ6IENsdXN0ZXJSb2xlCiAgbmFtZTogYWNpLWNvbnRhaW5lcnM6Y29udHJvbGxlcgpzdWJqZWN0czoKLSBraW5kOiBTZXJ2aWNlQWNjb3VudAogIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCi0tLQphcGlWZXJzaW9uOiByYmFjLmF1dGhvcml6YXRpb24uazhzLmlvL3YxCmtpbmQ6IENsdXN0ZXJSb2xlQmluZGluZwptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVyczpob3N0LWFnZW50CiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKcm9sZVJlZjoKICBhcGlHcm91cDogcmJhYy5hdXRob3JpemF0aW9uLms4cy5pbwogIGtpbmQ6IENsdXN0ZXJSb2xlCiAgbmFtZTogYWNpLWNvbnRhaW5lcnM6aG9zdC1hZ2VudApzdWJqZWN0czoKLSBraW5kOiBTZXJ2aWNlQWNjb3VudAogIG5hbWU6IGFjaS1jb250YWluZXJzLWhvc3QtYWdlbnQKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCi0tLQphcGlWZXJzaW9uOiBhcHBzL3YxCmtpbmQ6IERhZW1vblNldAptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1ob3N0CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCiAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKc3BlYzoKICB1cGRhdGVTdHJhdGVneToKICAgIHR5cGU6IE9uRGVsZXRlCiAgc2VsZWN0b3I6CiAgICBtYXRjaExhYmVsczoKICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtaG9zdAogICAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKICB0ZW1wbGF0ZToKICAgIG1ldGFkYXRhOgogICAgICBsYWJlbHM6CiAgICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtaG9zdAogICAgICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogICAgICBhbm5vdGF0aW9uczoKICAgICAgICBzY2hlZHVsZXIuYWxwaGEua3ViZXJuZXRlcy5pby9jcml0aWNhbC1wb2Q6ICcnCiAgICBzcGVjOgogICAgICBob3N0TmV0d29yazogdHJ1ZQogICAgICBob3N0UElEOiB0cnVlCiAgICAgIGhvc3RJUEM6IHRydWUKICAgICAgc2VydmljZUFjY291bnROYW1lOiBhY2ktY29udGFpbmVycy1ob3N0LWFnZW50CiAgICAgIHRvbGVyYXRpb25zOgogICAgICAgIC0gb3BlcmF0b3I6IEV4aXN0cwogICAgICBwcmlvcml0eUNsYXNzTmFtZTogc3lzdGVtLWNsdXN0ZXItY3JpdGljYWwKICAgICAgY29udGFpbmVyczoKICAgICAgICAtIG5hbWU6IGFjaS1jb250YWluZXJzLWhvc3QKICAgICAgICAgIGltYWdlOiBub2lyby9hY2ktY29udGFpbmVycy1ob3N0OjUuMC4yLjIuMDViZjFiOAogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIHNlY3VyaXR5Q29udGV4dDoKICAgICAgICAgICAgY2FwYWJpbGl0aWVzOgogICAgICAgICAgICAgIGFkZDoKICAgICAgICAgICAgICAgIC0gU1lTX0FETUlOCiAgICAgICAgICAgICAgICAtIE5FVF9BRE1JTgogICAgICAgICAgICAgICAgLSBTWVNfUFRSQUNFCiAgICAgICAgICBlbnY6CiAgICAgICAgICAgIC0gbmFtZTogS1VCRVJORVRFU19OT0RFX05BTUUKICAgICAgICAgICAgICB2YWx1ZUZyb206CiAgICAgICAgICAgICAgICBmaWVsZFJlZjoKICAgICAgICAgICAgICAgICAgZmllbGRQYXRoOiBzcGVjLm5vZGVOYW1lCiAgICAgICAgICAgIC0gbmFtZTogVEVOQU5UCiAgICAgICAgICAgICAgdmFsdWU6ICJrdWJlIgogICAgICAgICAgICAtIG5hbWU6IE5PREVfRVBHCiAgICAgICAgICAgICAgdmFsdWU6ICJrdWJlcm5ldGVzfGt1YmUtbm9kZXMiCiAgICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgICAgIC0gbmFtZTogY25pLWJpbgogICAgICAgICAgICAgIG1vdW50UGF0aDogL21udC9jbmktYmluCiAgICAgICAgICAgIC0gbmFtZTogY25pLWNvbmYKICAgICAgICAgICAgICBtb3VudFBhdGg6IC9tbnQvY25pLWNvbmYKICAgICAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3ZhcgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3J1bgogICAgICAgICAgICAtIG5hbWU6IG9wZmxleC1ob3N0Y29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvb3BmbGV4LWFnZW50LW92cy9iYXNlLWNvbmYuZAogICAgICAgICAgICAtIG5hbWU6IGhvc3QtY29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvYWNpLWNvbnRhaW5lcnMvCiAgICAgICAgICBsaXZlbmVzc1Byb2JlOgogICAgICAgICAgICBodHRwR2V0OgogICAgICAgICAgICAgIHBhdGg6IC9zdGF0dXMKICAgICAgICAgICAgICBwb3J0OiA4MDkwCiAgICAgICAgLSBuYW1lOiBvcGZsZXgtYWdlbnQKICAgICAgICAgIGVudjoKICAgICAgICAgICAgLSBuYW1lOiBSRUJPT1RfV0lUSF9PVlMKICAgICAgICAgICAgICB2YWx1ZTogInRydWUiCiAgICAgICAgICBpbWFnZTogbm9pcm8vb3BmbGV4OjUuMC4yLjIuMDViZjFiOAogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIHNlY3VyaXR5Q29udGV4dDoKICAgICAgICAgICAgY2FwYWJpbGl0aWVzOgogICAgICAgICAgICAgIGFkZDoKICAgICAgICAgICAgICAgIC0gTkVUX0FETUlOCiAgICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgICAgIC0gbmFtZTogaG9zdHZhcgogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC92YXIKICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvcnVuCiAgICAgICAgICAgIC0gbmFtZTogaG9zdHJ1bgogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBvcGZsZXgtaG9zdGNvbmZpZy12b2x1bWUKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvZXRjL29wZmxleC1hZ2VudC1vdnMvYmFzZS1jb25mLmQKICAgICAgICAgICAgLSBuYW1lOiBvcGZsZXgtY29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvb3BmbGV4LWFnZW50LW92cy9jb25mLmQKICAgICAgICAtIG5hbWU6IG1jYXN0LWRhZW1vbgogICAgICAgICAgaW1hZ2U6IG5vaXJvL29wZmxleDo1LjAuMi4yLjA1YmYxYjgKICAgICAgICAgIGNvbW1hbmQ6IFsiL2Jpbi9zaCJdCiAgICAgICAgICBhcmdzOiBbIi91c3IvbG9jYWwvYmluL2xhdW5jaC1tY2FzdGRhZW1vbi5zaCJdCiAgICAgICAgICBpbWFnZVB1bGxQb2xpY3k6IEFsd2F5cwogICAgICAgICAgdm9sdW1lTW91bnRzOgogICAgICAgICAgICAtIG5hbWU6IGhvc3R2YXIKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvdmFyCiAgICAgICAgICAgIC0gbmFtZTogaG9zdHJ1bgogICAgICAgICAgICAgIG1vdW50UGF0aDogL3J1bgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvcnVuCiAgICAgIHJlc3RhcnRQb2xpY3k6IEFsd2F5cwogICAgICB2b2x1bWVzOgogICAgICAgIC0gbmFtZTogY25pLWJpbgogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC9vcHQKICAgICAgICAtIG5hbWU6IGNuaS1jb25mCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL2V0YwogICAgICAgIC0gbmFtZTogaG9zdHZhcgogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC92YXIKICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvcnVuCiAgICAgICAgLSBuYW1lOiBob3N0LWNvbmZpZy12b2x1bWUKICAgICAgICAgIGNvbmZpZ01hcDoKICAgICAgICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29uZmlnCiAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgIC0ga2V5OiBob3N0LWFnZW50LWNvbmZpZwogICAgICAgICAgICAgICAgcGF0aDogaG9zdC1hZ2VudC5jb25mCiAgICAgICAgLSBuYW1lOiBvcGZsZXgtaG9zdGNvbmZpZy12b2x1bWUKICAgICAgICAgIGVtcHR5RGlyOgogICAgICAgICAgICBtZWRpdW06IE1lbW9yeQogICAgICAgIC0gbmFtZTogb3BmbGV4LWNvbmZpZy12b2x1bWUKICAgICAgICAgIGNvbmZpZ01hcDoKICAgICAgICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29uZmlnCiAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgIC0ga2V5OiBvcGZsZXgtYWdlbnQtY29uZmlnCiAgICAgICAgICAgICAgICBwYXRoOiBsb2NhbC5jb25mCi0tLQphcGlWZXJzaW9uOiBhcHBzL3YxCmtpbmQ6IERhZW1vblNldAptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1vcGVudnN3aXRjaAogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCnNwZWM6CiAgdXBkYXRlU3RyYXRlZ3k6CiAgICB0eXBlOiBPbkRlbGV0ZQogIHNlbGVjdG9yOgogICAgbWF0Y2hMYWJlbHM6CiAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLW9wZW52c3dpdGNoCiAgICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogIHRlbXBsYXRlOgogICAgbWV0YWRhdGE6CiAgICAgIGxhYmVsczoKICAgICAgICBuYW1lOiBhY2ktY29udGFpbmVycy1vcGVudnN3aXRjaAogICAgICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogICAgICBhbm5vdGF0aW9uczoKICAgICAgICBzY2hlZHVsZXIuYWxwaGEua3ViZXJuZXRlcy5pby9jcml0aWNhbC1wb2Q6ICcnCiAgICBzcGVjOgogICAgICBob3N0TmV0d29yazogdHJ1ZQogICAgICBob3N0UElEOiB0cnVlCiAgICAgIGhvc3RJUEM6IHRydWUKICAgICAgc2VydmljZUFjY291bnROYW1lOiBhY2ktY29udGFpbmVycy1ob3N0LWFnZW50CiAgICAgIHRvbGVyYXRpb25zOgogICAgICAgIC0gb3BlcmF0b3I6IEV4aXN0cwogICAgICBwcmlvcml0eUNsYXNzTmFtZTogc3lzdGVtLWNsdXN0ZXItY3JpdGljYWwKICAgICAgY29udGFpbmVyczoKICAgICAgICAtIG5hbWU6IGFjaS1jb250YWluZXJzLW9wZW52c3dpdGNoCiAgICAgICAgICBpbWFnZTogbm9pcm8vb3BlbnZzd2l0Y2g6NS4wLjIuMi4wNWJmMWI4CiAgICAgICAgICBpbWFnZVB1bGxQb2xpY3k6IEFsd2F5cwogICAgICAgICAgcmVzb3VyY2VzOgogICAgICAgICAgICBsaW1pdHM6CiAgICAgICAgICAgICAgbWVtb3J5OiAiMUdpIgogICAgICAgICAgc2VjdXJpdHlDb250ZXh0OgogICAgICAgICAgICBjYXBhYmlsaXRpZXM6CiAgICAgICAgICAgICAgYWRkOgogICAgICAgICAgICAgICAgLSBORVRfQURNSU4KICAgICAgICAgICAgICAgIC0gU1lTX01PRFVMRQogICAgICAgICAgICAgICAgLSBTWVNfTklDRQogICAgICAgICAgICAgICAgLSBJUENfTE9DSwogICAgICAgICAgZW52OgogICAgICAgICAgICAtIG5hbWU6IE9WU19SVU5ESVIKICAgICAgICAgICAgICB2YWx1ZTogL3Vzci9sb2NhbC92YXIvcnVuL29wZW52c3dpdGNoCiAgICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgICAgIC0gbmFtZTogaG9zdHZhcgogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC92YXIKICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvcnVuCiAgICAgICAgICAgIC0gbmFtZTogaG9zdHJ1bgogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBob3N0ZXRjCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL2V0YwogICAgICAgICAgICAtIG5hbWU6IGhvc3Rtb2R1bGVzCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvbGliL21vZHVsZXMKICAgICAgICAgIGxpdmVuZXNzUHJvYmU6CiAgICAgICAgICAgIGV4ZWM6CiAgICAgICAgICAgICAgY29tbWFuZDoKICAgICAgICAgICAgICAgIC0gL3Vzci9sb2NhbC9iaW4vbGl2ZW5lc3Mtb3ZzLnNoCiAgICAgIHJlc3RhcnRQb2xpY3k6IEFsd2F5cwogICAgICB2b2x1bWVzOgogICAgICAgIC0gbmFtZTogaG9zdGV0YwogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC9ldGMKICAgICAgICAtIG5hbWU6IGhvc3R2YXIKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvdmFyCiAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL3J1bgogICAgICAgIC0gbmFtZTogaG9zdG1vZHVsZXMKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvbGliL21vZHVsZXMKLS0tCmFwaVZlcnNpb246IGFwcHMvdjEKa2luZDogRGVwbG95bWVudAptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1jb250cm9sbGVyCiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCiAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKICAgIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKc3BlYzoKICByZXBsaWNhczogMQogIHN0cmF0ZWd5OgogICAgdHlwZTogUmVjcmVhdGUKICBzZWxlY3RvcjoKICAgIG1hdGNoTGFiZWxzOgogICAgICBuYW1lOiBhY2ktY29udGFpbmVycy1jb250cm9sbGVyCiAgICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogIHRlbXBsYXRlOgogICAgbWV0YWRhdGE6CiAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICAgICAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogICAgICBsYWJlbHM6CiAgICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgogICAgICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogICAgICBhbm5vdGF0aW9uczoKICAgICAgICBzY2hlZHVsZXIuYWxwaGEua3ViZXJuZXRlcy5pby9jcml0aWNhbC1wb2Q6ICcnCiAgICBzcGVjOgogICAgICBob3N0TmV0d29yazogdHJ1ZQogICAgICBzZXJ2aWNlQWNjb3VudE5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICAgICAgdG9sZXJhdGlvbnM6CiAgICAgICAgLSBvcGVyYXRvcjogRXhpc3RzCiAgICAgICAgICBlZmZlY3Q6IE5vU2NoZWR1bGUKICAgICAgcHJpb3JpdHlDbGFzc05hbWU6IHN5c3RlbS1ub2RlLWNyaXRpY2FsCiAgICAgIGNvbnRhaW5lcnM6CiAgICAgICAgLSBuYW1lOiBhY2ktY29udGFpbmVycy1jb250cm9sbGVyCiAgICAgICAgICBpbWFnZTogbm9pcm8vYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcjo1LjAuMi4yLjA1YmYxYjgKICAgICAgICAgIGltYWdlUHVsbFBvbGljeTogQWx3YXlzCiAgICAgICAgICBlbnY6CiAgICAgICAgICAgIC0gbmFtZTogV0FUQ0hfTkFNRVNQQUNFCiAgICAgICAgICAgICAgdmFsdWU6ICIiCiAgICAgICAgICAgIC0gbmFtZTogQUNJX1NOQVRfTkFNRVNQQUNFCiAgICAgICAgICAgICAgdmFsdWU6ICJhY2ktY29udGFpbmVycy1zeXN0ZW0iCiAgICAgICAgICAgIC0gbmFtZTogQUNJX1NOQUdMT0JBTElORk9fTkFNRQogICAgICAgICAgICAgIHZhbHVlOiAic25hdGdsb2JhbGluZm8iCiAgICAgICAgICAgIC0gbmFtZTogQUNJX1JEQ09ORklHX05BTUUKICAgICAgICAgICAgICB2YWx1ZTogInJvdXRpbmdkb21haW4tY29uZmlnIgogICAgICAgICAgICAtIG5hbWU6IFNZU1RFTV9OQU1FU1BBQ0UKICAgICAgICAgICAgICB2YWx1ZTogImt1YmUtc3lzdGVtIgogICAgICAgICAgdm9sdW1lTW91bnRzOgogICAgICAgICAgICAtIG5hbWU6IGNvbnRyb2xsZXItY29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvYWNpLWNvbnRhaW5lcnMvCiAgICAgICAgICAgIC0gbmFtZTogYWNpLXVzZXItY2VydC12b2x1bWUKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvZXRjL2FjaS1jZXJ0LwogICAgICAgICAgbGl2ZW5lc3NQcm9iZToKICAgICAgICAgICAgaHR0cEdldDoKICAgICAgICAgICAgICBwYXRoOiAvc3RhdHVzCiAgICAgICAgICAgICAgcG9ydDogODA5MQogICAgICB2b2x1bWVzOgogICAgICAgIC0gbmFtZTogYWNpLXVzZXItY2VydC12b2x1bWUKICAgICAgICAgIHNlY3JldDoKICAgICAgICAgICAgc2VjcmV0TmFtZTogYWNpLXVzZXItY2VydAogICAgICAgIC0gbmFtZTogY29udHJvbGxlci1jb25maWctdm9sdW1lCiAgICAgICAgICBjb25maWdNYXA6CiAgICAgICAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbmZpZwogICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAtIGtleTogY29udHJvbGxlci1jb25maWcKICAgICAgICAgICAgICAgIHBhdGg6IGNvbnRyb2xsZXIuY29uZgo="
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aci-containers-config
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  controller-config: |-
+    {
+        "log-level": "info",
+        "apic-hosts": [
+            "10.30.120.100"
+        ],
+        "apic-username": "kube",
+        "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "apic-use-inst-tag": true,
+        "aci-prefix": "kube",
+        "aci-vmm-type": "Kubernetes",
+        "aci-vmm-domain": "kube",
+        "aci-vmm-controller": "kube",
+        "aci-policy-tenant": "kube",
+        "require-netpol-annot": false,
+        "install-istio": true,
+        "istio-profile": "demo",
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
+        "aci-service-phys-dom": "kube-pdom",
+        "aci-service-encap": "vlan-4003",
+        "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
+        "aci-vrf-tenant": "common",
+        "aci-vrf-dn": "uni/tn-common/ctx-kube",
+        "aci-l3out": "l3out",
+        "aci-ext-networks": [
+            "default"
+        ],
+        "aci-vrf": "kube",
+        "default-endpoint-group": {
+            "policy-space": "kube",
+            "name": "kubernetes|kube-default"
+        },
+        "max-nodes-svc-graph": 32,
+        "namespace-default-endpoint-group": {
+            "istio-operator": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "istio-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "kube-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            }        },
+        "service-ip-pool": [
+            {
+                "end": "10.3.0.254",
+                "start": "10.3.0.2"
+            }
+        ],
+        "snat-contract-scope": "global",
+        "static-service-ip-pool": [
+            {
+                "end": "10.4.0.254",
+                "start": "10.4.0.2"
+            }
+        ],
+        "pod-ip-pool": [
+            {
+                "end": "10.2.255.254",
+                "start": "10.2.0.2"
+            }
+        ],
+        "pod-subnet-chunk-size": 32,
+        "node-service-ip-pool": [
+            {
+                "end": "10.5.0.254",
+                "start": "10.5.0.2"
+            }
+        ],
+        "node-service-subnets": [
+            "10.5.0.1/24"
+        ]
+    }
+  host-agent-config: |-
+    {
+        "app-profile": "kubernetes",
+        "ep-registry": null,
+        "opflex-mode": null,
+        "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
+        "aci-vmm-type": "Kubernetes",
+        "aci-vmm-domain": "kube",
+        "aci-vmm-controller": "kube",
+        "aci-prefix": "kube",
+        "aci-vrf": "kube",
+        "aci-vrf-tenant": "common",
+        "service-vlan": 4003,
+        "kubeapi-vlan": 4001,
+        "pod-subnet": "10.2.0.1/16",
+        "node-subnet": "10.1.0.1/16",
+        "encap-type": "vxlan",
+        "aci-infra-vlan": 4093,
+        "cni-netconfig": [
+            {
+                "gateway": "10.2.0.1",
+                "routes": [
+                    {
+                        "dst": "0.0.0.0/0",
+                        "gw": "10.2.0.1"
+                    }
+                ],
+                "subnet": "10.2.0.0/16"
+            }
+        ],
+        "default-endpoint-group": {
+            "policy-space": "kube",
+            "name": "kubernetes|kube-default"
+        },
+        "namespace-default-endpoint-group": {
+            "istio-operator": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "istio-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "kube-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            }        },
+        "enable-drop-log": true
+    }
+  opflex-agent-config: |-
+    {
+        "log": {
+            "level": "info"
+        },
+        "opflex": {
+        }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snat-operator-config
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+    "start": "5000"
+    "end": "65000"
+    "ports-per-node": "3000"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aci-user-cert
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+data:
+  user.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUNkZ0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQW1Bd2dnSmNBZ0VBQW9HQkFOcitBK2dPS2JBVlZySnMKYjMrWldiY25WWG8vZ2R1eElUa3ZtMDlrZWlGQ24rVXAvU0dkcXY2QWgramxKZkY3dXYrRmdDSnRDeEQ4N3FZdwowcTVEY0dWTEljZkY0WlViOUI4ckpXS0JJNndKZnh0TWZGdVVOWTI0Y2d3UXBKcXJNVXFBRHovTVcrd3JaZWhzClNuRnN5ZXdYUjM4OGVSN0VLakRXZWdkSnlQY1hBZ01CQUFFQ2dZQjlBWGIxWmZCQ0JVeEIrVWdFVEdNNys0WDkKakhieUUwQmx4bGtmanJsd2R2bVM5TTc3KzJaNmRLQWdQMzNUUk0vUHdFTU9ZN1JuZEJvK1g2eERzVmRjVEpJeQo1Vnc4eFVabHIrYXVFT2xzMlpuWngxMWU1emg3c1UzTmo1SzM1QldSOUdUWEo2UE1kcFQ0OWxCOWJsbE1qRHJMCjcrNWJDc2R1NjNPOEthTjlZUUpCQVBHTWJwSHBGc3RDMWNXR3BSUXgzaXdGK1pMWUFyQVViQ0tiV1FmYmlaVHAKQ1M4RGdPbXlVN3VLVFJLaUMrMlJZVFMzcHJMVjU3R3ZmZkZ4SmpUd0d5a0NRUURvR0J3ZjVpT3N5dU1RTno3SwpSaXJiRDBKN1I2WWVRa0paK3BDZUt3eStOeUlxeGgwTEJEbUJ5bVNLdlgwV0VLQ2l0T2dwaTMyRldCb3FIamYzCk1RZy9Ba0JMQkxScWVKdnRzT28zbUtPNGEreDJlN3lSVUtrMUNvS3pGTkJIMG5VZVhHblB3aVROYitiMWZmU0YKN3ZJSmJIZG1LZ3VKeTBsVU5BN0haNzdYL2lKUkFrQWpuYmVMS1p6bDRraVA3M3BpUGZ4TG0zN2ZQakoreURvNApacHdVdVpSK0NDWGxISHZPZWZwOU1WcldjNWVqY0MvR2FDNk1XWXlNanVXTSt4QXBqY3V2QWtFQXpZK3AxNDBDCnh3cHI5NWxpbm52V2NDN043MDhBSkZpbTMvRlUxMEdEbzc3eUlPSTVoKzUzN0piWWRtNTU1aE9lSC9LalNla2gKRUY0TW14UlBtaXQ5OXc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==
+  user.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUI2RENDQVZFQ0FnUG9NQTBHQ1NxR1NJYjNEUUVCQlFVQU1Ed3hDekFKQmdOVkJBWVRBbFZUTVJZd0ZBWUQKVlFRS0RBMURhWE5qYnlCVGVYTjBaVzF6TVJVd0V3WURWUVFEREF4VmMyVnlJRzFoYm1SbFpYQXdIaGNOTVRjdwpOVEUyTWpFeU9UTXdXaGNOTWpjd05URTBNakV5T1RNd1dqQThNUXN3Q1FZRFZRUUdFd0pWVXpFV01CUUdBMVVFCkNnd05RMmx6WTI4Z1UzbHpkR1Z0Y3pFVk1CTUdBMVVFQXd3TVZYTmxjaUJ0WVc1a1pXVndNSUdmTUEwR0NTcUcKU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FEYS9nUG9EaW13RlZheWJHOS9tVm0zSjFWNlA0SGJzU0U1TDV0UApaSG9oUXAvbEtmMGhuYXIrZ0lmbzVTWHhlN3IvaFlBaWJRc1EvTzZtTU5LdVEzQmxTeUhIeGVHVkcvUWZLeVZpCmdTT3NDWDhiVEh4YmxEV051SElNRUtTYXF6RktnQTgvekZ2c0syWG9iRXB4Yk1uc0YwZC9QSGtleENvdzFub0gKU2NqM0Z3SURBUUFCTUEwR0NTcUdTSWIzRFFFQkJRVUFBNEdCQUhYK2tMVGU2TENBQmV3bUNUdk1zanVzSGRwWgpraTAxK25RN0tobkVSYkJtL3RaNXNjWkU0Y3RJcWNoM255MUVJVEhOdFlXS0JONENkVUtjanZEVzJoMnZrSGVnCnJ0WWJWK0FhRXNxMG00dkdGOUVtdnQxY3A5WTQxSXlNQlpZcXc4Yy9WMUF0bVJRY1JUWVFBOEgzT0ZEY2h5QjIKMEpIU0RuQm9TN2ZmU2JCeAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-controller
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-host-agent
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers:controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - endpoints
+  - services
+  - events
+  - replicationcontrollers
+  - serviceaccounts
+  verbs:
+  - list
+  - watch
+  - get
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - "install.istio.io"
+  resources:
+  - istiocontrolplanes
+  - istiooperators
+  verbs:
+  - '*'
+- apiGroups:
+  - "aci.istio"
+  resources:
+  - aciistiooperators
+  - aciistiooperator
+  verbs:
+  - '*'
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - services/status
+  verbs:
+  - update
+- apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatpolicies/finalizers
+  - snatpolicies/status
+  - nodeinfos
+  verbs:
+  - update
+  - create
+  - list
+  - watch
+  - get
+  - delete
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatglobalinfos
+  - snatpolicies
+  - nodeinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers:host-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - endpoints
+  - services
+  - replicationcontrollers
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatpolicies
+  - snatglobalinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - nodeinfos
+  - snatlocalinfos
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers:controller
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers:controller
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers:host-agent
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers:host-agent
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-host-agent
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aci-containers-host
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+spec:
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      name: aci-containers-host
+      network-plugin: aci-containers
+  template:
+    metadata:
+      labels:
+        name: aci-containers-host
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      serviceAccountName: aci-containers-host-agent
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: aci-containers-host
+          image: noiro/aci-containers-host:5.0.2.2.05bf1b8
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - NET_ADMIN
+                - SYS_PTRACE
+          env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
+          volumeMounts:
+            - name: cni-bin
+              mountPath: /mnt/cni-bin
+            - name: cni-conf
+              mountPath: /mnt/cni-conf
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: opflex-hostconfig-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+            - name: host-config-volume
+              mountPath: /usr/local/etc/aci-containers/
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8090
+        - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
+          image: noiro/opflex:5.0.2.2.05bf1b8
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: opflex-hostconfig-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+            - name: opflex-config-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
+        - name: mcast-daemon
+          image: noiro/opflex:5.0.2.2.05bf1b8
+          command: ["/bin/sh"]
+          args: ["/usr/local/bin/launch-mcastdaemon.sh"]
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+      restartPolicy: Always
+      volumes:
+        - name: cni-bin
+          hostPath:
+            path: /opt
+        - name: cni-conf
+          hostPath:
+            path: /etc
+        - name: hostvar
+          hostPath:
+            path: /var
+        - name: hostrun
+          hostPath:
+            path: /run
+        - name: host-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: host-agent-config
+                path: host-agent.conf
+        - name: opflex-hostconfig-volume
+          emptyDir:
+            medium: Memory
+        - name: opflex-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: opflex-agent-config
+                path: local.conf
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aci-containers-openvswitch
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+spec:
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      name: aci-containers-openvswitch
+      network-plugin: aci-containers
+  template:
+    metadata:
+      labels:
+        name: aci-containers-openvswitch
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      serviceAccountName: aci-containers-host-agent
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: aci-containers-openvswitch
+          image: noiro/openvswitch:5.0.2.2.05bf1b8
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "1Gi"
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - SYS_MODULE
+                - SYS_NICE
+                - IPC_LOCK
+          env:
+            - name: OVS_RUNDIR
+              value: /usr/local/var/run/openvswitch
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: hostetc
+              mountPath: /usr/local/etc
+            - name: hostmodules
+              mountPath: /lib/modules
+          livenessProbe:
+            exec:
+              command:
+                - /usr/local/bin/liveness-ovs.sh
+      restartPolicy: Always
+      volumes:
+        - name: hostetc
+          hostPath:
+            path: /etc
+        - name: hostvar
+          hostPath:
+            path: /var
+        - name: hostrun
+          hostPath:
+            path: /run
+        - name: hostmodules
+          hostPath:
+            path: /lib/modules
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aci-containers-controller
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+    name: aci-containers-controller
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: aci-containers-controller
+      network-plugin: aci-containers
+  template:
+    metadata:
+      name: aci-containers-controller
+      namespace: kube-system
+      labels:
+        name: aci-containers-controller
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      serviceAccountName: aci-containers-controller
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+      priorityClassName: system-node-critical
+      containers:
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:5.0.2.2.05bf1b8
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: ACI_SNAT_NAMESPACE
+              value: "aci-containers-system"
+            - name: ACI_SNAGLOBALINFO_NAME
+              value: "snatglobalinfo"
+            - name: ACI_RDCONFIG_NAME
+              value: "routingdomain-config"
+            - name: SYSTEM_NAMESPACE
+              value: "kube-system"
+          volumeMounts:
+            - name: controller-config-volume
+              mountPath: /usr/local/etc/aci-containers/
+            - name: aci-user-cert-volume
+              mountPath: /usr/local/etc/aci-cert/
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8091
+      volumes:
+        - name: aci-user-cert-volume
+          secret:
+            secretName: aci-user-cert
+        - name: controller-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: controller-config
+                path: controller.conf
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-operator
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers-operator
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  - namespaces
+  - configmaps
+  - secrets
+  - pods
+  - services
+  - serviceaccounts
+  - serviceaccounts/token
+  - endpoints
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.ctrl
+  resources:
+  - acicontainersoperators
+  - acicontainersoperators/status
+  - acicontainersoperators/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.snat
+  resources:
+  - snatpolicies
+  - snatglobalinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - aci.snat
+  resources:
+  - nodeinfos
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+- apiGroups:
+  - config.openshift.io
+  - operator.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers-operator
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers-operator
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-operator
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aci-containers-operator
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    name: aci-containers-operator
+    network-plugin: aci-containers
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: aci-containers-operator
+      network-plugin: aci-containers
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: aci-containers-operator
+      namespace: kube-system
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: aci-containers-operator
+        network-plugin: aci-containers
+    spec:
+      containers:
+      - image: noiro/aci-containers-operator:5.0.2.2.05bf1b8
+        imagePullPolicy: Always
+        name: aci-containers-operator
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - name: aci-operator-config
+          mountPath: /usr/local/etc/aci-containers/
+        env:
+        - name: SYSTEM_NAMESPACE
+          value: "kube-system"
+        - name: ACC_PROVISION_FLAVOR
+          value: "kubernetes-1.15"
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: aci-containers-operator
+      serviceAccountName: aci-containers-operator
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - name: aci-operator-config
+        configMap:
+          name: aci-operator-config
+          items:
+            - key: spec
+              path: aci-operator.conf

--- a/provision/testdata/help.stdout.txt
+++ b/provision/testdata/help.stdout.txt
@@ -2,6 +2,7 @@ usage: acc_provision.py [-h] [-v] [--release] [--debug] [--sample] [-c file]
                         [-o file] [-z file] [-r file] [-a] [-d] [-u name]
                         [-p pass] [-w timeout] [--list-flavors] [-f flavor]
                         [-t token] [--test-data-out file] [--skip-kafka-certs]
+                        [--upgrade]
 
 Provision an ACI/Kubernetes installation
 
@@ -32,3 +33,5 @@ optional arguments:
   --test-data-out file  capture apic responses for test replay. E.g.
                         ../testdata/apic_xx.json
   --skip-kafka-certs    skip kafka certificate generation
+  --upgrade             generate kubernetes deployment file for cluster
+                        upgrade


### PR DESCRIPTION
To generate a kubernetes yaml file with changes required in step 1 here: https://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/4-x/installation-upgrade-downgrade/Cisco-ACI-CNI-Plug-in-Upgrade.html#id_99051

Instead of manually changing the update strategy and the operator configmap, this new flag will generate a new yaml with the desired changes.

Sample run:
acc-provision -c acc_provision_input.yaml -f kubernetes-1.18 -u username -p password -o aci_deployment.yaml --upgrade

This step would generate a new yaml ready to upgrade the cluster, however no tar.gz is generated as our upgrades don't use the tar files.

(cherry picked from commit 3454b4fcf52114196ab9a7f4b92abad727439489)