### PR TITLE
Correct boto3 package name for python3 RPM spec

### DIFF
--- a/provision/rpm/acc-provision.spec.in
+++ b/provision/rpm/acc-provision.spec.in
@@ -12,7 +12,7 @@ Requires:	python3-pyOpenSSL >= 0.13
 Requires:	python3-pyyaml >= 3.10
 Requires:	python3-requests >= 2.2
 Requires:	python3-jinja2 >= 2.7
-Requires:       python-boto3
+Requires:       python3-boto3
 
 %description
 Tools to provision and support ACI fabric DC workloads


### PR DESCRIPTION
(cherry picked from commit 34754c49363cbeb9466377f5993d8af1b922b2d6)