### PR TITLE
Improvements to overlay support with kind

### DIFF
--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -1022,7 +1022,15 @@ flavors:
     overlay: True
     config:
       aci_config:
+        system_id: kube
         use_legacy_kube_naming_convention: True
+        vrf:
+          name: defaultVrf
+          tenant: kube
+        overlay_vrf: defaultVrf
+        apic_hosts: ["127.0.0.1"]
+        vmm_domain:
+          domain: kubernetes
       kube_config:
         use_aci_anywhere_crd: True
         pod_exec_resources_controller: True
@@ -1041,12 +1049,14 @@ flavors:
         use_host_netns_volume: True
         use_openshift_run_level: False
         ep_registry: k8s
+        snat_operator:
+          snat_namespace: kube-system
+      net_config:
+        opflex_server_port: 8009
       istio_config:
         install_istio: False
       drop_log_config:
         enable: true
-      snat_operator:
-        snat_namespace: kube-system
     status: Experimental
     hidden: False
     order: 21

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -1,4 +1,5 @@
 
+{% if config.flavor != "k8s-overlay" %}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -14,6 +15,7 @@ metadata:
   annotations:
     openshift.io/node-selector: ''
 ---
+{% endif %}
 {% if config.kube_config.use_acicni_priority_class %}
 apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
@@ -394,9 +396,7 @@ data:
     {
         "flavor": {{config.flavor|json}},
         "log-level": {{config.logging.controller_log_level|json}},
-        {% if config.flavor != "k8s-overlay" %}
         "apic-hosts": {{config.aci_config.apic_hosts|json|indent(width=8)}},
-        {% endif %}
         {% if config.aci_config.capic %}
         "max-csr-tunnels": {{config.net_config.max_csr_tunnels|json|indent(width=8)}},
         {% endif %}
@@ -412,7 +412,7 @@ data:
         "aci-vmm-controller": {{config.aci_config.vmm_domain.controller|json}},
         "aci-policy-tenant": {{config.kube_config.default_endpoint_group.tenant|json}},
         {% endif %}
-        {% if config.aci_config.capic %}
+        {% if config.aci_config.capic or config.flavor == "k8s-overlay" %}
         "lb-type": "None",
         {% endif %}
         {% if config.istio_config.install_istio %}
@@ -485,9 +485,11 @@ data:
         "opflex-mode": {{ config.kube_config.opflex_mode|json }},
         "log-level": {{config.logging.hostagent_log_level|json}},
         "aci-snat-namespace": "{{ config.kube_config.snat_operator.snat_namespace }}",
+        {% if config.flavor != "k8s-overlay" %}
         "aci-vmm-type": {{config.aci_config.vmm_domain.type|json}},
         "aci-vmm-domain": {{config.aci_config.vmm_domain.domain|json}},
         "aci-vmm-controller": {{config.aci_config.vmm_domain.controller|json}},
+        {% endif %}
         {% if config.aci_config.vmm_domain.nested_inside.duplicate_file_router_default_svc %}
         "installer-provisioned-lb-ip": {{config.aci_config.vmm_domain.nested_inside.installer_provisioned_lb_ip|json}},
         {% endif %}
@@ -501,9 +503,9 @@ data:
         {% if config.flavor != "k8s-overlay" %}
         "service-vlan": {{ config.net_config.service_vlan|json }},
         "kubeapi-vlan": {{ config.net_config.kubeapi_vlan|json }},
+        {% endif %}
         "pod-subnet": {{ config.net_config.pod_subnet|json }},
         "node-subnet": {{ config.net_config.node_subnet|json }},
-        {% endif %}
         "encap-type": {{ config.node_config.encap_type|json }},
         "aci-infra-vlan": {{ config.net_config.infra_vlan|json }},
         {% if config.net_config.interface_mtu %}
@@ -591,7 +593,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: snat-operator-config
+  {% if config.flavor != "k8s-overlay" %}
   namespace: aci-containers-system
+  {% else %}
+  namespace: {{ config.kube_config.system_namespace }}
+  {% endif %}
   labels:
     aci-containers-config-version: "{{ config.registry.configuration_version }}"
     network-plugin: aci-containers
@@ -1446,8 +1452,10 @@ spec:
           image: {{ config.registry.image_prefix }}/aci-containers-controller:{{ config.registry.aci_containers_controller_version }}
           imagePullPolicy: {{ config.kube_config.image_pull_policy }}
           env:
+            {% if config.flavor != "k8s-overlay" %}
             - name: WATCH_NAMESPACE
               value: "{{ config.kube_config.snat_operator.watch_namespace }}"
+            {% endif %}
             - name: ACI_SNAT_NAMESPACE
               value: "{{ config.kube_config.snat_operator.snat_namespace }}"
             - name: ACI_SNAGLOBALINFO_NAME

--- a/provision/testdata/flavor_localhost.inp.yaml
+++ b/provision/testdata/flavor_localhost.inp.yaml
@@ -1,12 +1,7 @@
 #
 # Configuration for ACI overlay
 #
-aci_config:
-  system_id: kube                       # Every opflex cluster on the same fabric must have a distict ID
-  vrf:                                  # VRF used to create all subnets used by this Kubernetes cluster
-    name: defaultVrf          # This should exist, the provisioning tool does not create it
-    tenant: kube        # This can be tenant for this cluster (system-id) or common
-  overlay_vrf: defaultVrf
+
 #
 # Networks used by Kubernetes
 #
@@ -16,10 +11,7 @@ net_config:
   extern_dynamic: 10.3.56.1/21       # Subnet to use for dynamically allocated external services
   extern_static: 10.4.56.1/21        # Subnet to use for statically allocated external services
   node_svc_subnet: 10.5.56.1/21          # Subnet to use for service graph
-  kubeapi_vlan: 202                    # The VLAN used by the internal physdom for nodes
-  service_vlan: 1022                    # The VLAN used for external LoadBalancer services
-  infra_vlan: 4093
-  opflex_server_port: 8009
+  interface_mtu: 1400
 
 #
 #

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -1,13 +1,4 @@
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: aci-containers-system
-  labels:
-    aci-containers-config-version: "dummy"
-  annotations:
-    openshift.io/node-selector: ''
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -360,6 +351,10 @@ data:
     {
         "flavor": "k8s-overlay",
         "log-level": "debug",
+        "apic-hosts": [
+            "127.0.0.1"
+        ],
+        "lb-type": "None",
         "aci-vrf-tenant": "kube",
         "aci-vrf": "defaultVrf",
         "default-endpoint-group": {
@@ -408,15 +403,15 @@ data:
         "ep-registry": "k8s",
         "opflex-mode": "overlay",
         "log-level": "debug",
-        "aci-snat-namespace": "aci-containers-system",
-        "aci-vmm-type": "Kubernetes",
-        "aci-vmm-domain": "kube",
-        "aci-vmm-controller": "kube",
+        "aci-snat-namespace": "kube-system",
         "aci-prefix": "kube",
         "aci-vrf": "defaultVrf",
         "aci-vrf-tenant": "kube",
+        "pod-subnet": "10.2.56.1/21",
+        "node-subnet": "1.100.202.1/24",
         "encap-type": "vxlan",
         "aci-infra-vlan": null,
+        "interface-mtu": 1400,
         "cni-netconfig": [
             {
                 "gateway": "10.2.56.1",
@@ -454,7 +449,7 @@ data:
    {
         "aci-policy-tenant": "kube",
         "aci-vrf": "defaultVrf",
-        "aci-vmm-domain": "kube",
+        "aci-vmm-domain": "kubernetes",
         "pod-subnet": "10.2.56.1/21"
    }
 ---
@@ -462,7 +457,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: snat-operator-config
-  namespace: aci-containers-system
+  namespace: kube-system
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
@@ -1089,10 +1084,8 @@ spec:
           image: noirolabs/aci-containers-controller:latest
           imagePullPolicy: Always
           env:
-            - name: WATCH_NAMESPACE
-              value: ""
             - name: ACI_SNAT_NAMESPACE
-              value: "aci-containers-system"
+              value: "kube-system"
             - name: ACI_SNAGLOBALINFO_NAME
               value: "snatglobalinfo"
             - name: ACI_RDCONFIG_NAME


### PR DESCRIPTION
Default params wherever possible for k8s-overlay flavor

Fix SNAT ns for overlay flavor.
Default opflex-server port to 8009 if not specified

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>