### PR TITLE
acc-provision UTs fails with Ubuntu 20.04 due to deprecated TLS PROTOCOL V1 version

### DIFF
--- a/provision/acc_provision/fake_apic.py
+++ b/provision/acc_provision/fake_apic.py
@@ -61,7 +61,7 @@ def start_fake_apic(port, gets, deletes):
     httpd.socket = ssl.wrap_socket(httpd.socket,
                                    server_side=True,
                                    certfile='localhost.pem',
-                                   ssl_version=ssl.PROTOCOL_TLSv1)
+                                   ssl_version=ssl.PROTOCOL_TLS)
     thread = threading.Thread(target=httpd.serve_forever)
     thread.daemon = True
     thread.start()


### PR DESCRIPTION
In fake_apic.py, TLS PROTOCOL version mentioned was: **ssl.PROTOCOL_TLSv1**  which is deprecated according to https://docs.python.org/3/library/ssl.html. 

Replaced the TLS version with **ssl.PROTOCOL_TLS** which selects the highest protocol version that both the client and server support. This option can select both “SSL” and “TLS” protocols



