### PR TITLE
Fixing configuration of vSphere eLag

### DIFF
--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -1965,7 +1965,7 @@ class ApicKubeConfig(object):
                 collections.OrderedDict(
                     [
                         (
-                            "vmmRsUsrAggrLagPolAtt",
+                            "vmmRsUsrCustomAggrLagPolAtt",
                             collections.OrderedDict(
                                 [
                                     (

--- a/provision/testdata/nested-elag.apic.txt
+++ b/provision/testdata/nested-elag.apic.txt
@@ -182,7 +182,7 @@
                 }
             },
             {
-                "vmmRsUsrAggrLagPolAtt": {
+                "vmmRsUsrCustomAggrLagPolAtt": {
                     "attributes": {
                         "status": "",
                         "tDn": "uni/vmmp-VMware/dom-myvmware/vswitchpolcont/enlacplagp-my-elag",


### PR DESCRIPTION
For associating Lag Policy to Custom Trunk Port Groups, the
following needs to be used:

POST http://\<apic-ip\>//api/node/mo/uni/vmmp-VMware/dom-\<dom-name\>/ usrcustomaggr -\<trunkpg-name\>.xml
\<vmmRsUsrCustomAggrLagPolAtt tDn="uni/vmmp-VMware/dom-\<domain-name\> /vswitchpolcont/enlacplagp-\<lagpolicy-name\>" status=""/>

However, instead of using vmmRsUsrCustomAggrLagPolAtt, we were using
vmmRsUsrAggrLagPolAtt