### PR TITLE
Stop using 'fake' APIC in pure overlay case.

### DIFF
--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -1173,7 +1173,7 @@ flavors:
           name: defaultVrf
           tenant: kube
         overlay_vrf: defaultVrf
-        apic_hosts: ["127.0.0.1"]
+        apic_hosts: []
         vmm_domain:
           domain: kubernetes
       kube_config:

--- a/provision/testdata/flavor_localhost.kube.yaml
+++ b/provision/testdata/flavor_localhost.kube.yaml
@@ -656,9 +656,7 @@ data:
     {
         "flavor": "k8s-overlay",
         "log-level": "debug",
-        "apic-hosts": [
-            "127.0.0.1"
-        ],
+        "apic-hosts": [],
         "lb-type": "None",
         "aci-vrf-tenant": "kube",
         "aci-vrf": "defaultVrf",


### PR DESCRIPTION
Intent should come from k8s directly

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>