### PR TITLE
sriov daemonset and config map as a part of acc_provision

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -234,6 +234,9 @@ def config_default():
         },
         "multus": {
             "disable": True,
+        },
+        "sriov_config": {
+            "enable": False,
         }
     }
     return default_config
@@ -538,6 +541,21 @@ def config_adjust(args, config, prov_apic, no_random):
         adj_config["aci_config"]["vmm_domain"]["injected_cluster_type"] = ""
     if not config["aci_config"]["vmm_domain"].get("injected_cluster_provider"):
         adj_config["aci_config"]["vmm_domain"]["injected_cluster_provider"] = ""
+
+    if config["sriov_config"].get("enable"):
+        adj_config["vendors"] = "15b3"
+        adj_config["drivers"] = "mlx5_core"
+        adj_config["resourcePrefix"] = "mellanox.com"
+        adj_config["resourceName"] = "cx5_sriov_switchdev"
+        adj_config["devices"] = ""
+        adj_config["isRdma"] = "false"
+
+        if 'device_info' in config["sriov_config"]:
+            if 'devices' in config["sriov_config"]["device_info"]:
+                adj_config["devices"] = str(config["sriov_config"]["device_info"].get("devices"))
+            if config["sriov_config"]["device_info"].get("isRdma"):
+                adj_config["isRdma"] = "true"
+
     return adj_config
 
 

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -2464,3 +2464,231 @@ status:
   epg: aci-containers-inet-out
   ipaddr: 0.0.0.0/0
 {% endif %}
+{% if config.sriov_config.enable %}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sriov-device-plugin
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-device-plugin-amd64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriovdp
+spec:
+  selector:
+    matchLabels:
+      name: sriov-device-plugin
+  template:
+    metadata:
+      labels:
+        name: sriov-device-plugin
+        tier: node
+        app: sriovdp
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: sriov-device-plugin
+      containers:
+      - name: kube-sriovdp
+        image: docker.io/nfvpe/sriov-device-plugin:v3.3
+        imagePullPolicy: IfNotPresent
+        args:
+        - --log-dir=sriovdp
+        - --log-level=10
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: devicesock
+          mountPath: /var/lib/kubelet/
+          readOnly: false
+        - name: log
+          mountPath: /var/log
+        - name: config-volume
+          mountPath: /etc/pcidp
+        - name: device-info
+          mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
+      volumes:
+        - name: devicesock
+          hostPath:
+            path: /var/lib/kubelet/
+        - name: log
+          hostPath:
+            path: /var/log
+        - name: device-info
+          hostPath:
+            path: /var/run/k8s.cni.cncf.io/devinfo/dp
+            type: DirectoryOrCreate
+        - name: config-volume
+          configMap:
+            name: sriovdp-config
+            items:
+            - key: config.json
+              path: config.json
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-device-plugin-ppc64le
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriovdp
+spec:
+  selector:
+    matchLabels:
+      name: sriov-device-plugin
+  template:
+    metadata:
+      labels:
+        name: sriov-device-plugin
+        tier: node
+        app: sriovdp
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: ppc64le
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: sriov-device-plugin
+      containers:
+      - name: kube-sriovdp
+        image: docker.io/nfvpe/sriov-device-plugin:ppc64le
+        imagePullPolicy: IfNotPresent
+        args:
+        - --log-dir=sriovdp
+        - --log-level=10
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: devicesock
+          mountPath: /var/lib/kubelet/
+          readOnly: false
+        - name: log
+          mountPath: /var/log
+        - name: config-volume
+          mountPath: /etc/pcidp
+        - name: device-info
+          mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
+      volumes:
+        - name: devicesock
+          hostPath:
+            path: /var/lib/kubelet/
+        - name: log
+          hostPath:
+            path: /var/log
+        - name: device-info
+          hostPath:
+            path: /var/run/k8s.cni.cncf.io/devinfo/dp
+            type: DirectoryOrCreate
+        - name: config-volume
+          configMap:
+            name: sriovdp-config
+            items:
+            - key: config.json
+              path: config.json
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-device-plugin-arm64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriovdp
+spec:
+  selector:
+    matchLabels:
+      name: sriov-device-plugin
+  template:
+    metadata:
+      labels:
+        name: sriov-device-plugin
+        tier: node
+        app: sriovdp
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: arm64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: sriov-device-plugin
+      containers:
+      - name: kube-sriovdp
+# this is a temporary image repository for arm64 architecture, util CI/CD of the
+# sriov-device-plugin will not allow to recreate multiple images
+        image: alexeyperevalov/arm64-sriov-device-plugin
+        imagePullPolicy: IfNotPresent
+        args:
+        - --log-dir=sriovdp
+        - --log-level=10
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: devicesock
+          mountPath: /var/lib/kubelet/
+          readOnly: false
+        - name: log
+          mountPath: /var/log
+        - name: config-volume
+          mountPath: /etc/pcidp
+        - name: device-info
+          mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
+      volumes:
+        - name: devicesock
+          hostPath:
+            path: /var/lib/kubelet/
+        - name: log
+          hostPath:
+            path: /var/log
+        - name: device-info
+          hostPath:
+            path: /var/run/k8s.cni.cncf.io/devinfo/dp
+            type: DirectoryOrCreate
+        - name: config-volume
+          configMap:
+            name: sriovdp-config
+            items:
+            - key: config.json
+              path: config.json
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sriovdp-config
+  namespace: kube-system
+data:
+  config.json: |
+    {
+        "resourceList": [
+                 {
+                   "resourcePrefix": {{config.resourcePrefix|json}},
+                   "resourceName": {{config.resourceName|json}},
+                   "selectors": {
+                      "vendors": [{{config.vendors|json}}],
+                      {% if config.devices == "" %}
+                      "devices": ["1014","101e"],
+                      {% else %}
+                      "devices": [{{config.devices|json}}],
+                      {% endif %}
+                      "drivers": [{{config.drivers|json}}],
+                      "isRdma":  {{config.isRdma}}
+                   }
+                 }
+        ]
+    }
+{% endif %}

--- a/provision/acc_provision/templates/overlay-provision-config.yaml
+++ b/provision/acc_provision/templates/overlay-provision-config.yaml
@@ -64,3 +64,9 @@ istio_config:
 
 #drop_log_config:
   #enable: False        #default is True
+
+#sriov_config:
+  # enable: True         # default is False
+  # device_info:
+        # isRdma: True   # default is false
+        # devices: ""    # default is "1014","101e"

--- a/provision/acc_provision/templates/provision-config.yaml
+++ b/provision/acc_provision/templates/provision-config.yaml
@@ -88,3 +88,9 @@ registry:
 
 #multus:
   # disable: False       # default is True
+
+#sriov_config:
+  # enable: True     # default is False
+  # device_info:
+    # isRdma: True   # default is false
+    # devices: ""    # default is "1014","101e" 

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -601,6 +601,39 @@ def test_with_no_drop_log():
 
 
 @in_testdir
+def test_sriov_config():
+    run_provision(
+        "with_sriov_config_input.yaml",
+        "with_sriov_config_kube.yaml",
+        None,
+        None,
+        "base_case.apic.txt"
+    )
+
+
+@in_testdir
+def test_no_sriov_config():
+    run_provision(
+        "with_no_sriov_config_input.yaml",
+        "with_no_sriov_config_kube.yaml",
+        None,
+        None,
+        "base_case.apic.txt"
+    )
+
+
+@in_testdir
+def test_sriov_with_no_deviceinfo():
+    run_provision(
+        "with_sriov_config_no_deviceinfo_input.yaml",
+        "with_sriov_config_no_deviceinfo_kube.yaml",
+        None,
+        None,
+        "base_case.apic.txt"
+    )
+
+
+@in_testdir
 def test_flavor_RKE_1_2_3_base():
     run_provision(
         "flavor_RKE_1_2_3.inp.yaml",

--- a/provision/testdata/with_no_sriov_config_input.yaml
+++ b/provision/testdata/with_no_sriov_config_input.yaml
@@ -1,0 +1,53 @@
+aci_config:
+  system_id: kube
+  use_legacy_kube_naming_convention: True
+  apic_hosts:
+    - 10.30.120.100
+  apic_login:
+    username: admin
+    password: noir0123
+  aep: kube-aep
+  vrf:
+    name: kube
+    tenant: common
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  custom_epgs:
+    - group1
+    - group2
+
+net_config:
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+
+kube_config:
+  controller: 1.1.1.1
+  use_cluster_role: true
+  use_ds_rolling_update: true
+
+registry:
+  image_prefix: noiro
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info
+
+sriov_config:
+  enable: False

--- a/provision/testdata/with_no_sriov_config_kube.yaml
+++ b/provision/testdata/with_no_sriov_config_kube.yaml
@@ -1,0 +1,2183 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: acicontainersoperators.aci.ctrl
+spec:
+  group: aci.ctrl
+  names:
+    kind: AciContainersOperator
+    listKind: AciContainersOperatorList
+    plural: acicontainersoperators
+    singular: acicontainersoperator
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: acicontainersoperator owns the lifecycle of ACI objects in the cluster
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AciContainersOperatorSpec defines the desired spec for ACI Objects
+            properties:
+              flavor:
+                type: string
+              config:
+                type: string
+            type: object
+          status:
+            description: AciContainersOperatorStatus defines the successful completion of AciContainersOperator
+            properties:
+              status:
+                type: boolean
+            type: object
+        required:
+        - spec
+        type: object
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+  annotations:
+    openshift.io/node-selector: ''
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: podifs.aci.aw
+spec:
+  group: aci.aw
+  names:
+    kind: PodIF
+    listKind: PodIFList
+    plural: podifs
+    singular: podif
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: PodIF describes a pod network interface
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          status:
+            description: PodIFStatus is the status of a PodIF
+            properties:
+              containerID:
+                type: string
+              epg:
+                type: string
+              ifname:
+                type: string
+              ipaddr:
+                type: string
+              macaddr:
+                type: string
+              podname:
+                type: string
+              podns:
+                type: string
+              vtep:
+                type: string
+            type: object
+        required:
+        - status
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatglobalinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatGlobalInfo
+    listKind: SnatGlobalInfoList
+    plural: snatglobalinfos
+    singular: snatglobalinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: SnatGlobalInfo is the Schema for the snatglobalinfos API
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              globalInfos:
+                additionalProperties:
+                  items:
+                    properties:
+                      macAddress:
+                        type: string
+                      portRanges:
+                        items:
+                          properties:
+                            end:
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            start:
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          type: object
+                        type: array
+                      snatIp:
+                        type: string
+                      snatIpUid:
+                        type: string
+                      snatPolicyName:
+                        type: string
+                    required:
+                    - macAddress
+                    - portRanges
+                    - snatIp
+                    - snatIpUid
+                    - snatPolicyName
+                    type: object
+                  type: array
+                type: object
+            required:
+            - globalInfos
+            type: object
+          status:
+            description: SnatGlobalInfoStatus defines the observed state of SnatGlobalInfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatlocalinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatLocalInfo
+    listKind: SnatLocalInfoList
+    plural: snatlocalinfos
+    singular: snatlocalinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SnatLocalInfoSpec defines the desired state of SnatLocalInfo
+            properties:
+              localInfos:
+                items:
+                  properties:
+                    podName:
+                      type: string
+                    podNamespace:
+                      type: string
+                    podUid:
+                      type: string
+                    snatPolicies:
+                      items:
+                        properties:
+                          destIp:
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            type: string
+                          snatIp:
+                            type: string
+                        required:
+                        - destIp
+                        - name
+                        - snatIp
+                        type: object
+                      type: array
+                  required:
+                  - podName
+                  - podNamespace
+                  - podUid
+                  - snatPolicies
+                  type: object
+                type: array
+            required:
+            - localInfos
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatpolicies.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatPolicy
+    listKind: SnatPolicyList
+    plural: snatpolicies
+    singular: snatpolicy
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            properties:
+              selector:
+                type: object
+                properties:
+                  labels:
+                    type: object
+                    description: 'Selection of Pods'
+                    properties:
+                    additionalProperties:
+                      type: string
+                  namespace:
+                    type: string
+                type: object
+              snatIp:
+                type: array
+                items:
+                  type: string
+              destIp:
+                type: array
+                items:
+                  type: string
+            type: object
+          status:
+            type: object
+            properties:
+            additionalProperties:
+              type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nodeinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: NodeInfo
+    listKind: NodeInfoList
+    plural: nodeinfos
+    singular: nodeinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              macaddress:
+                type: string
+              snatpolicynames:
+                additionalProperties:
+                  type: boolean
+                type: object
+            type: object
+          status:
+            description: NodeinfoStatus defines the observed state of Nodeinfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rdconfigs.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: RdConfig
+    listKind: RdConfigList
+    plural: rdconfigs
+    singular: rdconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              discoveredsubnets:
+                items:
+                  type: string
+                type: array
+              usersubnets:
+                items:
+                  type: string
+                type: array
+            required:
+            - usersubnets
+            type: object
+          status:
+            description: NodeinfoStatus defines the observed state of Nodeinfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.aci.netpol
+spec:
+  group: aci.netpol
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Network Policy describes traffic flow at IP address or port level
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              appliedTo:
+                properties:
+                  namespaceSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  podSelector:
+                    description: allow ingress from the same namespace
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+              egress:
+                description: Set of egress rules evaluated based on the order in which they are set.
+                items:
+                  properties:
+                    action:
+                      description: Action specifies the action to be applied on the rule.
+                      type: string
+                    enableLogging:
+                      description: EnableLogging is used to indicate if agent should generate logs default to false.
+                      type: boolean
+                    ports:
+                      description: Set of port and protocol allowed/denied by the rule. If this field is unset or empty, this rule matches all ports.
+                      items:
+                        description: NetworkPolicyPort describes the port and protocol to match in a rule.
+                        properties:
+                          endPort:
+                            description: EndPort defines the end of the port range, being the end included within the range. It can only be specified when a numerical `port` is specified.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can be either a numerical or named port on a Pod. If this field is not provided, this matches all port names and numbers.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            default: TCP
+                            description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      description: Rule is matched if traffic is intended for workloads selected by this field. If this field is empty or missing, this rule matches all destinations.
+                      items:
+                        properties:
+                          ipBlock:
+                            description: IPBlock describes the IPAddresses/IPBlocks that is matched in to/from. IPBlock cannot be set as part of the AppliedTo field. Cannot be set with any other selector.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            description: Select all Pods from Namespaces matched by this selector, as workloads in To/From fields. If set with PodSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except PodSelector or ExternalEntitySelector.
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          podSelector:
+                            description: Select Pods from NetworkPolicy's Namespace as workloads in AppliedTo/To/From fields. If set with NamespaceSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    toFqDn:
+                      properties:
+                        matchNames:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - matchNames
+                      type: object
+                  required:
+                  - enableLogging
+                  - toFqDn
+                  type: object
+                type: array
+              ingress:
+                description: Set of ingress rules evaluated based on the order in which they are set.
+                items:
+                  properties:
+                    action:
+                      description: Action specifies the action to be applied on the rule.
+                      type: string
+                    enableLogging:
+                      description: EnableLogging is used to indicate if agent should generate logs when rules are matched. Should be default to false.
+                      type: boolean
+                    from:
+                      description: Rule is matched if traffic originates from workloads selected by this field. If this field is empty, this rule matches all sources.
+                      items:
+                        properties:
+                          ipBlock:
+                            description: IPBlock describes the IPAddresses/IPBlocks that is matched in to/from. IPBlock cannot be set as part of the AppliedTo field. Cannot be set with any other selector.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          podSelector:
+                            description: Select Pods from NetworkPolicy's Namespace as workloads in AppliedTo/To/From fields. If set with NamespaceSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    ports:
+                      description: Set of port and protocol allowed/denied by the rule. If this field is unset or empty, this rule matches all ports.
+                      items:
+                        description: NetworkPolicyPort describes the port and protocol to match in a rule.
+                        properties:
+                          endPort:
+                            description: EndPort defines the end of the port range, being the end included within the range. It can only be specified when a numerical `port` is specified.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can be either a numerical or named port on a Pod. If this field is not provided, this matches all port names and numbers.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            default: TCP
+                            description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              policyTypes:
+                items:
+                  description: Policy Type string describes the NetworkPolicy type This type is beta-level in 1.8
+                  type: string
+                type: array
+              priority:
+                description: Priority specfies the order of the NetworkPolicy relative to other NetworkPolicies.
+                type: integer
+              type:
+                description: type of the policy.
+                type: string
+            required:
+            - type
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dnsnetworkpolicies.aci.dnsnetpol
+spec:
+  group: aci.dnsnetpol
+  names:
+    kind: DnsNetworkPolicy
+    listKind: DnsNetworkPolicyList
+    plural: dnsnetworkpolicies
+    singular: dnsnetworkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1beta
+    schema:
+      openAPIV3Schema:
+        description: dns network Policy
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              appliedTo:
+                properties:
+                  namespaceSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  podSelector:
+                    description: allow ingress from the same namespace
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+              egress:
+                description: Set of egress rules evaluated based on the order in which they are set.
+                properties:
+                  toFqdn:
+                    properties:
+                      matchNames:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - matchNames
+                    type: object
+                required:
+                - toFqdn
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: qospolicies.aci.qos
+spec:
+  group: aci.qos
+  names:
+    kind: QosPolicy
+    listKind: QosPolicyList
+    plural: qospolicies
+    singular: qospolicy
+  scope: Namespaced
+  preserveUnknownFields: false
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              podSelector:
+                description: 'Selection of Pods'
+                type: object
+                properties:
+                  matchLabels:
+                    type: object
+                    description:
+              ingress:
+                type: object
+                properties:
+                  policing_rate:
+                    type: integer
+                    minimum: 0
+                  policing_burst:
+                    type: integer
+                    minimum: 0
+              egress:
+                type: object
+                properties:
+                  policing_rate:
+                    type: integer
+                    minimum: 0
+                  policing_burst:
+                    type: integer
+                    minimum: 0
+              dscpmark:
+                type: integer
+                default: 0
+                minimum: 0
+                maximum: 63
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: netflowpolicies.aci.netflow
+spec:
+  group: aci.netflow
+  names:
+    kind: NetflowPolicy
+    listKind: NetflowPolicyList
+    plural: netflowpolicies
+    singular: netflowpolicy
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+  - name: v1alpha
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              flowSamplingPolicy:
+                type: object
+                properties:
+                  destIp:
+                    type: string
+                  destPort:
+                    type: integer
+                    minimum: 0
+                    maximum: 65535
+                    default: 2055
+                  flowType:
+                    type: string
+                    enum:
+                      - netflow
+                      - ipfix
+                    default: netflow
+                  activeFlowTimeOut:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                    default: 60
+                  idleFlowTimeOut:
+                    type: integer
+                    minimum: 0
+                    maximum: 600
+                    default: 15
+                  samplingRate:
+                    type: integer
+                    minimum: 0
+                    maximum: 1000
+                    default: 0
+                required:
+                - destIp
+                type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: erspanpolicies.aci.erspan
+spec:
+  group: aci.erspan
+  names:
+    kind: ErspanPolicy
+    listKind: ErspanPolicyList
+    plural: erspanpolicies
+    singular: erspanpolicy
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+  - name: v1alpha
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              selector:
+                type: object
+                description: 'Selection of Pods'
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+                  namespace:
+                    type: string
+              source:
+                type: object
+                properties:
+                  adminState:
+                    description: Administrative state.
+                    default: start
+                    type: string
+                    enum:
+                      - start
+                      - stop
+                  direction:
+                    description: Direction of the packets to monitor.
+                    default: both
+                    type: string
+                    enum:
+                      - in
+                      - out
+                      - both
+              destination:
+                type: object
+                properties:
+                  destIP:
+                    description: Destination IP of the ERSPAN packet.
+                    type: string
+                  flowID:
+                    description: Unique flow ID of the ERSPAN packet.
+                    default: 1
+                    type: integer
+                    minimum: 1
+                    maximum: 1023
+                required:
+                - destIP
+                type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: enabledroplogs.aci.droplog
+spec:
+  group: aci.droplog
+  names:
+    kind: EnableDropLog
+    listKind: EnableDropLogList
+    plural: enabledroplogs
+    singular: enabledroplog
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            description: Defines the desired state of EnableDropLog
+            type: object
+            properties:
+              disableDefaultDropLog:
+                description: Disables the default droplog enabled by acc-provision.
+                default: false
+                type: boolean
+              nodeSelector:
+                type: object
+                description: Drop logging is enabled on nodes selected based on labels
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: prunedroplogs.aci.droplog
+spec:
+  group: aci.droplog
+  names:
+    kind: PruneDropLog
+    listKind: PruneDropLogList
+    plural: prunedroplogs
+    singular: prunedroplog
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            description: Defines the desired state of PruneDropLog
+            type: object
+            properties:
+              nodeSelector:
+                type: object
+                description: Drop logging filters are applied to nodes selected based on labels
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+              dropLogFilters:
+                type: object
+                properties:
+                  srcIP:
+                    type: string
+                  destIP:
+                    type: string
+                  srcMAC:
+                    type: string
+                  destMAC:
+                    type: string
+                  srcPort:
+                    type: integer
+                  destPort:
+                    type: integer
+                  ipProto:
+                    type: integer
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: aciistiooperators.aci.istio
+spec:
+  group: aci.istio
+  names:
+    kind: AciIstioOperator
+    listKind: AciIstioOperatorList
+    plural: aciistiooperators
+    singular: aciistiooperator
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AciIstioOperatorSpec defines the desired state of AciIstioOperator
+            properties:
+              config:
+                type: string
+              profile:
+                type: string
+            required:
+            - config
+            - profile
+            type: object
+          status:
+            description: AciIstioOperatorStatus defines the observed state of AciIstioOperator
+            properties:
+              Successful or Not:
+                type: boolean
+            required:
+            - Successful or Not
+            type: object
+        type: object
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aci-operator-config
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  spec: |-
+    {
+        "flavor": "kubernetes-1.22",
+        "config": "CmFwaVZlcnNpb246IHYxCmtpbmQ6IE5hbWVzcGFjZQptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogIGFubm90YXRpb25zOgogICAgb3BlbnNoaWZ0LmlvL25vZGUtc2VsZWN0b3I6ICcnCi0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogcG9kaWZzLmFjaS5hdwpzcGVjOgogIGdyb3VwOiBhY2kuYXcKICBuYW1lczoKICAgIGtpbmQ6IFBvZElGCiAgICBsaXN0S2luZDogUG9kSUZMaXN0CiAgICBwbHVyYWw6IHBvZGlmcwogICAgc2luZ3VsYXI6IHBvZGlmCiAgc2NvcGU6IE5hbWVzcGFjZWQKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIGRlc2NyaXB0aW9uOiBQb2RJRiBkZXNjcmliZXMgYSBwb2QgbmV0d29yayBpbnRlcmZhY2UKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHN0YXR1czoKICAgICAgICAgICAgZGVzY3JpcHRpb246IFBvZElGU3RhdHVzIGlzIHRoZSBzdGF0dXMgb2YgYSBQb2RJRgogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIGNvbnRhaW5lcklEOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgZXBnOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgaWZuYW1lOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgaXBhZGRyOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgbWFjYWRkcjoKICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgIHBvZG5hbWU6CiAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICBwb2RuczoKICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgIHZ0ZXA6CiAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgLSBzdGF0dXMKICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBzbmF0Z2xvYmFsaW5mb3MuYWNpLnNuYXQKc3BlYzoKICBncm91cDogYWNpLnNuYXQKICBuYW1lczoKICAgIGtpbmQ6IFNuYXRHbG9iYWxJbmZvCiAgICBsaXN0S2luZDogU25hdEdsb2JhbEluZm9MaXN0CiAgICBwbHVyYWw6IHNuYXRnbG9iYWxpbmZvcwogICAgc2luZ3VsYXI6IHNuYXRnbG9iYWxpbmZvCiAgc2NvcGU6IE5hbWVzcGFjZWQKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIGRlc2NyaXB0aW9uOiBTbmF0R2xvYmFsSW5mbyBpcyB0aGUgU2NoZW1hIGZvciB0aGUgc25hdGdsb2JhbGluZm9zIEFQSQogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgbWV0YWRhdGE6CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBnbG9iYWxJbmZvczoKICAgICAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgbWFjQWRkcmVzczoKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICBwb3J0UmFuZ2VzOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZW5kOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXhpbXVtOiA2NTUzNQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAxCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHN0YXJ0OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXhpbXVtOiA2NTUzNQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAxCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgIHNuYXRJcDoKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICBzbmF0SXBVaWQ6CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgc25hdFBvbGljeU5hbWU6CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgIC0gbWFjQWRkcmVzcwogICAgICAgICAgICAgICAgICAgIC0gcG9ydFJhbmdlcwogICAgICAgICAgICAgICAgICAgIC0gc25hdElwCiAgICAgICAgICAgICAgICAgICAgLSBzbmF0SXBVaWQKICAgICAgICAgICAgICAgICAgICAtIHNuYXRQb2xpY3lOYW1lCiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgIC0gZ2xvYmFsSW5mb3MKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzdGF0dXM6CiAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTbmF0R2xvYmFsSW5mb1N0YXR1cyBkZWZpbmVzIHRoZSBvYnNlcnZlZCBzdGF0ZSBvZiBTbmF0R2xvYmFsSW5mbwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBzbmF0bG9jYWxpbmZvcy5hY2kuc25hdApzcGVjOgogIGdyb3VwOiBhY2kuc25hdAogIG5hbWVzOgogICAga2luZDogU25hdExvY2FsSW5mbwogICAgbGlzdEtpbmQ6IFNuYXRMb2NhbEluZm9MaXN0CiAgICBwbHVyYWw6IHNuYXRsb2NhbGluZm9zCiAgICBzaW5ndWxhcjogc25hdGxvY2FsaW5mbwogIHNjb3BlOiBOYW1lc3BhY2VkCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTbmF0TG9jYWxJbmZvU3BlYyBkZWZpbmVzIHRoZSBkZXNpcmVkIHN0YXRlIG9mIFNuYXRMb2NhbEluZm8KICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBsb2NhbEluZm9zOgogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgcG9kTmFtZToKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIHBvZE5hbWVzcGFjZToKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIHBvZFVpZDoKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIHNuYXRQb2xpY2llczoKICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGRlc3RJcDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgbmFtZToKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgIHNuYXRJcDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgLSBkZXN0SXAKICAgICAgICAgICAgICAgICAgICAgICAgLSBuYW1lCiAgICAgICAgICAgICAgICAgICAgICAgIC0gc25hdElwCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgIC0gcG9kTmFtZQogICAgICAgICAgICAgICAgICAtIHBvZE5hbWVzcGFjZQogICAgICAgICAgICAgICAgICAtIHBvZFVpZAogICAgICAgICAgICAgICAgICAtIHNuYXRQb2xpY2llcwogICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAtIGxvY2FsSW5mb3MKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgdHlwZTogb2JqZWN0Ci0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogc25hdHBvbGljaWVzLmFjaS5zbmF0CnNwZWM6CiAgZ3JvdXA6IGFjaS5zbmF0CiAgbmFtZXM6CiAgICBraW5kOiBTbmF0UG9saWN5CiAgICBsaXN0S2luZDogU25hdFBvbGljeUxpc3QKICAgIHBsdXJhbDogc25hdHBvbGljaWVzCiAgICBzaW5ndWxhcjogc25hdHBvbGljeQogIHNjb3BlOiBDbHVzdGVyCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzdWJyZXNvdXJjZXM6CiAgICAgIHN0YXR1czoge30KICAgIHNjaGVtYToKICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgbWV0YWRhdGE6CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgc2VsZWN0b3I6CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIGxhYmVsczoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogJ1NlbGVjdGlvbiBvZiBQb2RzJwogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgbmFtZXNwYWNlOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgc25hdElwOgogICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICBkZXN0SXA6CiAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHN0YXR1czoKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgIHR5cGU6IHN0cmluZwotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IG5vZGVpbmZvcy5hY2kuc25hdApzcGVjOgogIGdyb3VwOiBhY2kuc25hdAogIG5hbWVzOgogICAga2luZDogTm9kZUluZm8KICAgIGxpc3RLaW5kOiBOb2RlSW5mb0xpc3QKICAgIHBsdXJhbDogbm9kZWluZm9zCiAgICBzaW5ndWxhcjogbm9kZWluZm8KICBzY29wZTogTmFtZXNwYWNlZAogIHZlcnNpb25zOgogIC0gbmFtZTogdjEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIG1hY2FkZHJlc3M6CiAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICBzbmF0cG9saWN5bmFtZXM6CiAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgdHlwZTogYm9vbGVhbgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3RhdHVzOgogICAgICAgICAgICBkZXNjcmlwdGlvbjogTm9kZWluZm9TdGF0dXMgZGVmaW5lcyB0aGUgb2JzZXJ2ZWQgc3RhdGUgb2YgTm9kZWluZm8KICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgdHlwZTogb2JqZWN0Ci0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogcmRjb25maWdzLmFjaS5zbmF0CnNwZWM6CiAgZ3JvdXA6IGFjaS5zbmF0CiAgbmFtZXM6CiAgICBraW5kOiBSZENvbmZpZwogICAgbGlzdEtpbmQ6IFJkQ29uZmlnTGlzdAogICAgcGx1cmFsOiByZGNvbmZpZ3MKICAgIHNpbmd1bGFyOiByZGNvbmZpZwogIHNjb3BlOiBOYW1lc3BhY2VkCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgZGlzY292ZXJlZHN1Ym5ldHM6CiAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgIHVzZXJzdWJuZXRzOgogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgIC0gdXNlcnN1Ym5ldHMKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzdGF0dXM6CiAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBOb2RlaW5mb1N0YXR1cyBkZWZpbmVzIHRoZSBvYnNlcnZlZCBzdGF0ZSBvZiBOb2RlaW5mbwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBuZXR3b3JrcG9saWNpZXMuYWNpLm5ldHBvbApzcGVjOgogIGdyb3VwOiBhY2kubmV0cG9sCiAgbmFtZXM6CiAgICBraW5kOiBOZXR3b3JrUG9saWN5CiAgICBsaXN0S2luZDogTmV0d29ya1BvbGljeUxpc3QKICAgIHBsdXJhbDogbmV0d29ya3BvbGljaWVzCiAgICBzaW5ndWxhcjogbmV0d29ya3BvbGljeQogIHNjb3BlOiBOYW1lc3BhY2VkCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgZGVzY3JpcHRpb246IE5ldHdvcmsgUG9saWN5IGRlc2NyaWJlcyB0cmFmZmljIGZsb3cgYXQgSVAgYWRkcmVzcyBvciBwb3J0IGxldmVsCiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIGFwcGxpZWRUbzoKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIG5hbWVzcGFjZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICBwb2RTZWxlY3RvcjoKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogYWxsb3cgaW5ncmVzcyBmcm9tIHRoZSBzYW1lIG5hbWVzcGFjZQogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgZWdyZXNzOgogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNldCBvZiBlZ3Jlc3MgcnVsZXMgZXZhbHVhdGVkIGJhc2VkIG9uIHRoZSBvcmRlciBpbiB3aGljaCB0aGV5IGFyZSBzZXQuCiAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICBhY3Rpb246CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogQWN0aW9uIHNwZWNpZmllcyB0aGUgYWN0aW9uIHRvIGJlIGFwcGxpZWQgb24gdGhlIHJ1bGUuCiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICBlbmFibGVMb2dnaW5nOgogICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEVuYWJsZUxvZ2dpbmcgaXMgdXNlZCB0byBpbmRpY2F0ZSBpZiBhZ2VudCBzaG91bGQgZ2VuZXJhdGUgbG9ncyBkZWZhdWx0IHRvIGZhbHNlLgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYm9vbGVhbgogICAgICAgICAgICAgICAgICAgIHBvcnRzOgogICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNldCBvZiBwb3J0IGFuZCBwcm90b2NvbCBhbGxvd2VkL2RlbmllZCBieSB0aGUgcnVsZS4gSWYgdGhpcyBmaWVsZCBpcyB1bnNldCBvciBlbXB0eSwgdGhpcyBydWxlIG1hdGNoZXMgYWxsIHBvcnRzLgogICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBOZXR3b3JrUG9saWN5UG9ydCBkZXNjcmliZXMgdGhlIHBvcnQgYW5kIHByb3RvY29sIHRvIG1hdGNoIGluIGEgcnVsZS4KICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICBlbmRQb3J0OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEVuZFBvcnQgZGVmaW5lcyB0aGUgZW5kIG9mIHRoZSBwb3J0IHJhbmdlLCBiZWluZyB0aGUgZW5kIGluY2x1ZGVkIHdpdGhpbiB0aGUgcmFuZ2UuIEl0IGNhbiBvbmx5IGJlIHNwZWNpZmllZCB3aGVuIGEgbnVtZXJpY2FsIGBwb3J0YCBpcyBzcGVjaWZpZWQuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBmb3JtYXQ6IGludDMyCiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgICAgICAgcG9ydDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGFueU9mOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgLSB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFRoZSBwb3J0IG9uIHRoZSBnaXZlbiBwcm90b2NvbC4gVGhpcyBjYW4gYmUgZWl0aGVyIGEgbnVtZXJpY2FsIG9yIG5hbWVkIHBvcnQgb24gYSBQb2QuIElmIHRoaXMgZmllbGQgaXMgbm90IHByb3ZpZGVkLCB0aGlzIG1hdGNoZXMgYWxsIHBvcnQgbmFtZXMgYW5kIG51bWJlcnMuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICB4LWt1YmVybmV0ZXMtaW50LW9yLXN0cmluZzogdHJ1ZQogICAgICAgICAgICAgICAgICAgICAgICAgIHByb3RvY29sOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVmYXVsdDogVENQCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogVGhlIHByb3RvY29sIChUQ1AsIFVEUCwgb3IgU0NUUCkgd2hpY2ggdHJhZmZpYyBtdXN0IG1hdGNoLiBJZiBub3Qgc3BlY2lmaWVkLCB0aGlzIGZpZWxkIGRlZmF1bHRzIHRvIFRDUC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgdG86CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogUnVsZSBpcyBtYXRjaGVkIGlmIHRyYWZmaWMgaXMgaW50ZW5kZWQgZm9yIHdvcmtsb2FkcyBzZWxlY3RlZCBieSB0aGlzIGZpZWxkLiBJZiB0aGlzIGZpZWxkIGlzIGVtcHR5IG9yIG1pc3NpbmcsIHRoaXMgcnVsZSBtYXRjaGVzIGFsbCBkZXN0aW5hdGlvbnMuCiAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICBpcEJsb2NrOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IElQQmxvY2sgZGVzY3JpYmVzIHRoZSBJUEFkZHJlc3Nlcy9JUEJsb2NrcyB0aGF0IGlzIG1hdGNoZWQgaW4gdG8vZnJvbS4gSVBCbG9jayBjYW5ub3QgYmUgc2V0IGFzIHBhcnQgb2YgdGhlIEFwcGxpZWRUbyBmaWVsZC4gQ2Fubm90IGJlIHNldCB3aXRoIGFueSBvdGhlciBzZWxlY3Rvci4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNpZHI6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IENJRFIgaXMgYSBzdHJpbmcgcmVwcmVzZW50aW5nIHRoZSBJUCBCbG9jayBWYWxpZCBleGFtcGxlcyBhcmUgIjE5Mi4xNjguMS4xLzI0IiBvciAiMjAwMTpkYjk6Oi82NCIKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZXhjZXB0OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBFeGNlcHQgaXMgYSBzbGljZSBvZiBDSURScyB0aGF0IHNob3VsZCBub3QgYmUgaW5jbHVkZWQgd2l0aGluIGFuIElQIEJsb2NrIFZhbGlkIGV4YW1wbGVzIGFyZSAiMTkyLjE2OC4xLjEvMjQiIG9yICIyMDAxOmRiOTo6LzY0IiBFeGNlcHQgdmFsdWVzIHdpbGwgYmUgcmVqZWN0ZWQgaWYgdGhleSBhcmUgb3V0c2lkZSB0aGUgQ0lEUiByYW5nZQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgLSBjaWRyCiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICBuYW1lc3BhY2VTZWxlY3RvcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTZWxlY3QgYWxsIFBvZHMgZnJvbSBOYW1lc3BhY2VzIG1hdGNoZWQgYnkgdGhpcyBzZWxlY3RvciwgYXMgd29ya2xvYWRzIGluIFRvL0Zyb20gZmllbGRzLiBJZiBzZXQgd2l0aCBQb2RTZWxlY3RvciwgUG9kcyBhcmUgbWF0Y2hlZCBmcm9tIE5hbWVzcGFjZXMgbWF0Y2hlZCBieSB0aGUgTmFtZXNwYWNlU2VsZWN0b3IuIENhbm5vdCBiZSBzZXQgd2l0aCBhbnkgb3RoZXIgc2VsZWN0b3IgZXhjZXB0IFBvZFNlbGVjdG9yIG9yIEV4dGVybmFsRW50aXR5U2VsZWN0b3IuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBvcGVyYXRvcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogb3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuIFZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFsdWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiB2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0ga2V5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgICAgcG9kU2VsZWN0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogU2VsZWN0IFBvZHMgZnJvbSBOZXR3b3JrUG9saWN5J3MgTmFtZXNwYWNlIGFzIHdvcmtsb2FkcyBpbiBBcHBsaWVkVG8vVG8vRnJvbSBmaWVsZHMuIElmIHNldCB3aXRoIE5hbWVzcGFjZVNlbGVjdG9yLCBQb2RzIGFyZSBtYXRjaGVkIGZyb20gTmFtZXNwYWNlcyBtYXRjaGVkIGJ5IHRoZSBOYW1lc3BhY2VTZWxlY3Rvci4gQ2Fubm90IGJlIHNldCB3aXRoIGFueSBvdGhlciBzZWxlY3RvciBleGNlcHQgTmFtZXNwYWNlU2VsZWN0b3IuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBvcGVyYXRvcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogb3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuIFZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFsdWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiB2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0ga2V5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICB0b0ZxRG46CiAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICBtYXRjaE5hbWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgICAgLSBtYXRjaE5hbWVzCiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgIC0gZW5hYmxlTG9nZ2luZwogICAgICAgICAgICAgICAgICAtIHRvRnFEbgogICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgaW5ncmVzczoKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTZXQgb2YgaW5ncmVzcyBydWxlcyBldmFsdWF0ZWQgYmFzZWQgb24gdGhlIG9yZGVyIGluIHdoaWNoIHRoZXkgYXJlIHNldC4KICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgIGFjdGlvbjoKICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBBY3Rpb24gc3BlY2lmaWVzIHRoZSBhY3Rpb24gdG8gYmUgYXBwbGllZCBvbiB0aGUgcnVsZS4KICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIGVuYWJsZUxvZ2dpbmc6CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRW5hYmxlTG9nZ2luZyBpcyB1c2VkIHRvIGluZGljYXRlIGlmIGFnZW50IHNob3VsZCBnZW5lcmF0ZSBsb2dzIHdoZW4gcnVsZXMgYXJlIG1hdGNoZWQuIFNob3VsZCBiZSBkZWZhdWx0IHRvIGZhbHNlLgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYm9vbGVhbgogICAgICAgICAgICAgICAgICAgIGZyb206CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogUnVsZSBpcyBtYXRjaGVkIGlmIHRyYWZmaWMgb3JpZ2luYXRlcyBmcm9tIHdvcmtsb2FkcyBzZWxlY3RlZCBieSB0aGlzIGZpZWxkLiBJZiB0aGlzIGZpZWxkIGlzIGVtcHR5LCB0aGlzIHJ1bGUgbWF0Y2hlcyBhbGwgc291cmNlcy4KICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGlwQmxvY2s6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogSVBCbG9jayBkZXNjcmliZXMgdGhlIElQQWRkcmVzc2VzL0lQQmxvY2tzIHRoYXQgaXMgbWF0Y2hlZCBpbiB0by9mcm9tLiBJUEJsb2NrIGNhbm5vdCBiZSBzZXQgYXMgcGFydCBvZiB0aGUgQXBwbGllZFRvIGZpZWxkLiBDYW5ub3QgYmUgc2V0IHdpdGggYW55IG90aGVyIHNlbGVjdG9yLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgY2lkcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogQ0lEUiBpcyBhIHN0cmluZyByZXByZXNlbnRpbmcgdGhlIElQIEJsb2NrIFZhbGlkIGV4YW1wbGVzIGFyZSAiMTkyLjE2OC4xLjEvMjQiIG9yICIyMDAxOmRiOTo6LzY0IgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBleGNlcHQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEV4Y2VwdCBpcyBhIHNsaWNlIG9mIENJRFJzIHRoYXQgc2hvdWxkIG5vdCBiZSBpbmNsdWRlZCB3aXRoaW4gYW4gSVAgQmxvY2sgVmFsaWQgZXhhbXBsZXMgYXJlICIxOTIuMTY4LjEuMS8yNCIgb3IgIjIwMDE6ZGI5OjovNjQiIEV4Y2VwdCB2YWx1ZXMgd2lsbCBiZSByZWplY3RlZCBpZiB0aGV5IGFyZSBvdXRzaWRlIHRoZSBDSURSIHJhbmdlCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIGNpZHIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgIG5hbWVzcGFjZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbWF0Y2hFeHByZXNzaW9uczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGtleToKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgb3BlcmF0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IG9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLiBWYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogdmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbiwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsIHRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIGtleQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgLSBvcGVyYXRvcgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbWF0Y2hMYWJlbHM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgIHBvZFNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNlbGVjdCBQb2RzIGZyb20gTmV0d29ya1BvbGljeSdzIE5hbWVzcGFjZSBhcyB3b3JrbG9hZHMgaW4gQXBwbGllZFRvL1RvL0Zyb20gZmllbGRzLiBJZiBzZXQgd2l0aCBOYW1lc3BhY2VTZWxlY3RvciwgUG9kcyBhcmUgbWF0Y2hlZCBmcm9tIE5hbWVzcGFjZXMgbWF0Y2hlZCBieSB0aGUgTmFtZXNwYWNlU2VsZWN0b3IuIENhbm5vdCBiZSBzZXQgd2l0aCBhbnkgb3RoZXIgc2VsZWN0b3IgZXhjZXB0IE5hbWVzcGFjZVNlbGVjdG9yLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbWF0Y2hFeHByZXNzaW9uczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogbWF0Y2hFeHByZXNzaW9ucyBpcyBhIGxpc3Qgb2YgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnRzLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGtleToKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgb3BlcmF0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IG9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLiBWYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogdmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbiwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsIHRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIGtleQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgLSBvcGVyYXRvcgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbWF0Y2hMYWJlbHM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgcG9ydHM6CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogU2V0IG9mIHBvcnQgYW5kIHByb3RvY29sIGFsbG93ZWQvZGVuaWVkIGJ5IHRoZSBydWxlLiBJZiB0aGlzIGZpZWxkIGlzIHVuc2V0IG9yIGVtcHR5LCB0aGlzIHJ1bGUgbWF0Y2hlcyBhbGwgcG9ydHMuCiAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IE5ldHdvcmtQb2xpY3lQb3J0IGRlc2NyaWJlcyB0aGUgcG9ydCBhbmQgcHJvdG9jb2wgdG8gbWF0Y2ggaW4gYSBydWxlLgogICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGVuZFBvcnQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRW5kUG9ydCBkZWZpbmVzIHRoZSBlbmQgb2YgdGhlIHBvcnQgcmFuZ2UsIGJlaW5nIHRoZSBlbmQgaW5jbHVkZWQgd2l0aGluIHRoZSByYW5nZS4gSXQgY2FuIG9ubHkgYmUgc3BlY2lmaWVkIHdoZW4gYSBudW1lcmljYWwgYHBvcnRgIGlzIHNwZWNpZmllZC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIGZvcm1hdDogaW50MzIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICBwb3J0OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgYW55T2Y6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0gdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogVGhlIHBvcnQgb24gdGhlIGdpdmVuIHByb3RvY29sLiBUaGlzIGNhbiBiZSBlaXRoZXIgYSBudW1lcmljYWwgb3IgbmFtZWQgcG9ydCBvbiBhIFBvZC4gSWYgdGhpcyBmaWVsZCBpcyBub3QgcHJvdmlkZWQsIHRoaXMgbWF0Y2hlcyBhbGwgcG9ydCBuYW1lcyBhbmQgbnVtYmVycy4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIHgta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nOiB0cnVlCiAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvdG9jb2w6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZWZhdWx0OiBUQ1AKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBUaGUgcHJvdG9jb2wgKFRDUCwgVURQLCBvciBTQ1RQKSB3aGljaCB0cmFmZmljIG11c3QgbWF0Y2guIElmIG5vdCBzcGVjaWZpZWQsIHRoaXMgZmllbGQgZGVmYXVsdHMgdG8gVENQLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgIHBvbGljeVR5cGVzOgogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBQb2xpY3kgVHlwZSBzdHJpbmcgZGVzY3JpYmVzIHRoZSBOZXR3b3JrUG9saWN5IHR5cGUgVGhpcyB0eXBlIGlzIGJldGEtbGV2ZWwgaW4gMS44CiAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICBwcmlvcml0eToKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBQcmlvcml0eSBzcGVjZmllcyB0aGUgb3JkZXIgb2YgdGhlIE5ldHdvcmtQb2xpY3kgcmVsYXRpdmUgdG8gb3RoZXIgTmV0d29ya1BvbGljaWVzLgogICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgIHR5cGU6CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogdHlwZSBvZiB0aGUgcG9saWN5LgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAtIHR5cGUKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgLSBzcGVjCiAgICAgICAgdHlwZTogb2JqZWN0CiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKc3RhdHVzOgogIGFjY2VwdGVkTmFtZXM6CiAgICBraW5kOiAiIgogICAgcGx1cmFsOiAiIgogIGNvbmRpdGlvbnM6IFtdCiAgc3RvcmVkVmVyc2lvbnM6IFtdCi0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogZG5zbmV0d29ya3BvbGljaWVzLmFjaS5kbnNuZXRwb2wKc3BlYzoKICBncm91cDogYWNpLmRuc25ldHBvbAogIG5hbWVzOgogICAga2luZDogRG5zTmV0d29ya1BvbGljeQogICAgbGlzdEtpbmQ6IERuc05ldHdvcmtQb2xpY3lMaXN0CiAgICBwbHVyYWw6IGRuc25ldHdvcmtwb2xpY2llcwogICAgc2luZ3VsYXI6IGRuc25ldHdvcmtwb2xpY3kKICBzY29wZTogTmFtZXNwYWNlZAogIHZlcnNpb25zOgogIC0gbmFtZTogdjFiZXRhCiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICBkZXNjcmlwdGlvbjogZG5zIG5ldHdvcmsgUG9saWN5CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIGFwcGxpZWRUbzoKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIG5hbWVzcGFjZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICBwb2RTZWxlY3RvcjoKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogYWxsb3cgaW5ncmVzcyBmcm9tIHRoZSBzYW1lIG5hbWVzcGFjZQogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogb3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuIFZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YWx1ZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiB2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgZWdyZXNzOgogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNldCBvZiBlZ3Jlc3MgcnVsZXMgZXZhbHVhdGVkIGJhc2VkIG9uIHRoZSBvcmRlciBpbiB3aGljaCB0aGV5IGFyZSBzZXQuCiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICB0b0ZxZG46CiAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgIG1hdGNoTmFtZXM6CiAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgIC0gbWF0Y2hOYW1lcwogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAtIHRvRnFkbgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHJlcXVpcmVkOgogICAgICAgIC0gc3BlYwogICAgICAgIHR5cGU6IG9iamVjdAogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCnN0YXR1czoKICBhY2NlcHRlZE5hbWVzOgogICAga2luZDogIiIKICAgIHBsdXJhbDogIiIKICBjb25kaXRpb25zOiBbXQogIHN0b3JlZFZlcnNpb25zOiBbXQotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IHFvc3BvbGljaWVzLmFjaS5xb3MKc3BlYzoKICBncm91cDogYWNpLnFvcwogIG5hbWVzOgogICAga2luZDogUW9zUG9saWN5CiAgICBsaXN0S2luZDogUW9zUG9saWN5TGlzdAogICAgcGx1cmFsOiBxb3Nwb2xpY2llcwogICAgc2luZ3VsYXI6IHFvc3BvbGljeQogIHNjb3BlOiBOYW1lc3BhY2VkCiAgcHJlc2VydmVVbmtub3duRmllbGRzOiBmYWxzZQogIHZlcnNpb25zOgogIC0gbmFtZTogdjEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc3VicmVzb3VyY2VzOgogICAgICBzdGF0dXM6IHt9CiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIHBvZFNlbGVjdG9yOgogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246ICdTZWxlY3Rpb24gb2YgUG9kcycKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgbWF0Y2hMYWJlbHM6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246CiAgICAgICAgICAgICAgaW5ncmVzczoKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgcG9saWNpbmdfcmF0ZToKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgICBwb2xpY2luZ19idXJzdDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgIGVncmVzczoKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgcG9saWNpbmdfcmF0ZToKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgICBwb2xpY2luZ19idXJzdDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgIGRzY3BtYXJrOgogICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgICAgZGVmYXVsdDogMAogICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgbWF4aW11bTogNjMKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBuZXRmbG93cG9saWNpZXMuYWNpLm5ldGZsb3cKc3BlYzoKICBncm91cDogYWNpLm5ldGZsb3cKICBuYW1lczoKICAgIGtpbmQ6IE5ldGZsb3dQb2xpY3kKICAgIGxpc3RLaW5kOiBOZXRmbG93UG9saWN5TGlzdAogICAgcGx1cmFsOiBuZXRmbG93cG9saWNpZXMKICAgIHNpbmd1bGFyOiBuZXRmbG93cG9saWN5CiAgc2NvcGU6IENsdXN0ZXIKICBwcmVzZXJ2ZVVua25vd25GaWVsZHM6IGZhbHNlCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MWFscGhhCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgIyBvcGVuQVBJVjNTY2hlbWEgaXMgdGhlIHNjaGVtYSBmb3IgdmFsaWRhdGluZyBjdXN0b20gb2JqZWN0cy4KICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgZmxvd1NhbXBsaW5nUG9saWN5OgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBkZXN0SXA6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIGRlc3RQb3J0OgogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAwCiAgICAgICAgICAgICAgICAgICAgbWF4aW11bTogNjU1MzUKICAgICAgICAgICAgICAgICAgICBkZWZhdWx0OiAyMDU1CiAgICAgICAgICAgICAgICAgIGZsb3dUeXBlOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIGVudW06CiAgICAgICAgICAgICAgICAgICAgICAtIG5ldGZsb3cKICAgICAgICAgICAgICAgICAgICAgIC0gaXBmaXgKICAgICAgICAgICAgICAgICAgICBkZWZhdWx0OiBuZXRmbG93CiAgICAgICAgICAgICAgICAgIGFjdGl2ZUZsb3dUaW1lT3V0OgogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAwCiAgICAgICAgICAgICAgICAgICAgbWF4aW11bTogMzYwMAogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IDYwCiAgICAgICAgICAgICAgICAgIGlkbGVGbG93VGltZU91dDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgICAgIG1heGltdW06IDYwMAogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IDE1CiAgICAgICAgICAgICAgICAgIHNhbXBsaW5nUmF0ZToKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgICAgIG1heGltdW06IDEwMDAKICAgICAgICAgICAgICAgICAgICBkZWZhdWx0OiAwCiAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgIC0gZGVzdElwCiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBlcnNwYW5wb2xpY2llcy5hY2kuZXJzcGFuCnNwZWM6CiAgZ3JvdXA6IGFjaS5lcnNwYW4KICBuYW1lczoKICAgIGtpbmQ6IEVyc3BhblBvbGljeQogICAgbGlzdEtpbmQ6IEVyc3BhblBvbGljeUxpc3QKICAgIHBsdXJhbDogZXJzcGFucG9saWNpZXMKICAgIHNpbmd1bGFyOiBlcnNwYW5wb2xpY3kKICBzY29wZTogQ2x1c3RlcgogIHByZXNlcnZlVW5rbm93bkZpZWxkczogZmFsc2UKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxYWxwaGEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBzcGVjOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBzZWxlY3RvcjoKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246ICdTZWxlY3Rpb24gb2YgUG9kcycKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIGxhYmVsczoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIG5hbWVzcGFjZToKICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICBzb3VyY2U6CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIGFkbWluU3RhdGU6CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEFkbWluaXN0cmF0aXZlIHN0YXRlLgogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IHN0YXJ0CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgZW51bToKICAgICAgICAgICAgICAgICAgICAgIC0gc3RhcnQKICAgICAgICAgICAgICAgICAgICAgIC0gc3RvcAogICAgICAgICAgICAgICAgICBkaXJlY3Rpb246CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IERpcmVjdGlvbiBvZiB0aGUgcGFja2V0cyB0byBtb25pdG9yLgogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IGJvdGgKICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICBlbnVtOgogICAgICAgICAgICAgICAgICAgICAgLSBpbgogICAgICAgICAgICAgICAgICAgICAgLSBvdXQKICAgICAgICAgICAgICAgICAgICAgIC0gYm90aAogICAgICAgICAgICAgIGRlc3RpbmF0aW9uOgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBkZXN0SVA6CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IERlc3RpbmF0aW9uIElQIG9mIHRoZSBFUlNQQU4gcGFja2V0LgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICBmbG93SUQ6CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFVuaXF1ZSBmbG93IElEIG9mIHRoZSBFUlNQQU4gcGFja2V0LgogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IDEKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMQogICAgICAgICAgICAgICAgICAgIG1heGltdW06IDEwMjMKICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgLSBkZXN0SVAKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IGVuYWJsZWRyb3Bsb2dzLmFjaS5kcm9wbG9nCnNwZWM6CiAgZ3JvdXA6IGFjaS5kcm9wbG9nCiAgbmFtZXM6CiAgICBraW5kOiBFbmFibGVEcm9wTG9nCiAgICBsaXN0S2luZDogRW5hYmxlRHJvcExvZ0xpc3QKICAgIHBsdXJhbDogZW5hYmxlZHJvcGxvZ3MKICAgIHNpbmd1bGFyOiBlbmFibGVkcm9wbG9nCiAgc2NvcGU6IENsdXN0ZXIKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxYWxwaGExCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgIyBvcGVuQVBJVjNTY2hlbWEgaXMgdGhlIHNjaGVtYSBmb3IgdmFsaWRhdGluZyBjdXN0b20gb2JqZWN0cy4KICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgZGVzY3JpcHRpb246IERlZmluZXMgdGhlIGRlc2lyZWQgc3RhdGUgb2YgRW5hYmxlRHJvcExvZwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBkaXNhYmxlRGVmYXVsdERyb3BMb2c6CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRGlzYWJsZXMgdGhlIGRlZmF1bHQgZHJvcGxvZyBlbmFibGVkIGJ5IGFjYy1wcm92aXNpb24uCiAgICAgICAgICAgICAgICBkZWZhdWx0OiBmYWxzZQogICAgICAgICAgICAgICAgdHlwZTogYm9vbGVhbgogICAgICAgICAgICAgIG5vZGVTZWxlY3RvcjoKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IERyb3AgbG9nZ2luZyBpcyBlbmFibGVkIG9uIG5vZGVzIHNlbGVjdGVkIGJhc2VkIG9uIGxhYmVscwogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgbGFiZWxzOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBwcnVuZWRyb3Bsb2dzLmFjaS5kcm9wbG9nCnNwZWM6CiAgZ3JvdXA6IGFjaS5kcm9wbG9nCiAgbmFtZXM6CiAgICBraW5kOiBQcnVuZURyb3BMb2cKICAgIGxpc3RLaW5kOiBQcnVuZURyb3BMb2dMaXN0CiAgICBwbHVyYWw6IHBydW5lZHJvcGxvZ3MKICAgIHNpbmd1bGFyOiBwcnVuZWRyb3Bsb2cKICBzY29wZTogQ2x1c3RlcgogIHZlcnNpb25zOgogIC0gbmFtZTogdjFhbHBoYTEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAjIG9wZW5BUElWM1NjaGVtYSBpcyB0aGUgc2NoZW1hIGZvciB2YWxpZGF0aW5nIGN1c3RvbSBvYmplY3RzLgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBkZXNjcmlwdGlvbjogRGVmaW5lcyB0aGUgZGVzaXJlZCBzdGF0ZSBvZiBQcnVuZURyb3BMb2cKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgbm9kZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRHJvcCBsb2dnaW5nIGZpbHRlcnMgYXJlIGFwcGxpZWQgdG8gbm9kZXMgc2VsZWN0ZWQgYmFzZWQgb24gbGFiZWxzCiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBsYWJlbHM6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgIGRyb3BMb2dGaWx0ZXJzOgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBzcmNJUDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgZGVzdElQOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICBzcmNNQUM6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIGRlc3RNQUM6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIHNyY1BvcnQ6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgICAgICBkZXN0UG9ydDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgIGlwUHJvdG86CiAgICAgICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IGFjaWlzdGlvb3BlcmF0b3JzLmFjaS5pc3RpbwpzcGVjOgogIGdyb3VwOiBhY2kuaXN0aW8KICBuYW1lczoKICAgIGtpbmQ6IEFjaUlzdGlvT3BlcmF0b3IKICAgIGxpc3RLaW5kOiBBY2lJc3Rpb09wZXJhdG9yTGlzdAogICAgcGx1cmFsOiBhY2lpc3Rpb29wZXJhdG9ycwogICAgc2luZ3VsYXI6IGFjaWlzdGlvb3BlcmF0b3IKICBzY29wZTogTmFtZXNwYWNlZAogIHZlcnNpb25zOgogIC0gbmFtZTogdjEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBkZXNjcmlwdGlvbjogQWNpSXN0aW9PcGVyYXRvclNwZWMgZGVmaW5lcyB0aGUgZGVzaXJlZCBzdGF0ZSBvZiBBY2lJc3Rpb09wZXJhdG9yCiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgY29uZmlnOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgcHJvZmlsZToKICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgLSBjb25maWcKICAgICAgICAgICAgLSBwcm9maWxlCiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3RhdHVzOgogICAgICAgICAgICBkZXNjcmlwdGlvbjogQWNpSXN0aW9PcGVyYXRvclN0YXR1cyBkZWZpbmVzIHRoZSBvYnNlcnZlZCBzdGF0ZSBvZiBBY2lJc3Rpb09wZXJhdG9yCiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgU3VjY2Vzc2Z1bCBvciBOb3Q6CiAgICAgICAgICAgICAgICB0eXBlOiBib29sZWFuCiAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAtIFN1Y2Nlc3NmdWwgb3IgTm90CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHR5cGU6IG9iamVjdAotLS0KYXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnTWFwCm1ldGFkYXRhOgogIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbmZpZwogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCmRhdGE6CiAgY29udHJvbGxlci1jb25maWc6IHwtCiAgICB7CiAgICAgICAgImZsYXZvciI6ICJrdWJlcm5ldGVzLTEuMjIiLAogICAgICAgICJsb2ctbGV2ZWwiOiAiaW5mbyIsCiAgICAgICAgImFwaWMtaG9zdHMiOiBbCiAgICAgICAgICAgICIxMC4zMC4xMjAuMTAwIgogICAgICAgIF0sCiAgICAgICAgImFwaWMtdXNlcm5hbWUiOiAia3ViZSIsCiAgICAgICAgImFwaWMtcHJpdmF0ZS1rZXktcGF0aCI6ICIvdXNyL2xvY2FsL2V0Yy9hY2ktY2VydC91c2VyLmtleSIsCiAgICAgICAgImFjaS1wcmVmaXgiOiAia3ViZSIsCiAgICAgICAgImFjaS12bW0tdHlwZSI6ICJLdWJlcm5ldGVzIiwKICAgICAgICAiYWNpLXZtbS1kb21haW4iOiAia3ViZSIsCiAgICAgICAgImFjaS12bW0tY29udHJvbGxlciI6ICJrdWJlIiwKICAgICAgICAiYWNpLXBvbGljeS10ZW5hbnQiOiAia3ViZSIsCiAgICAgICAgImluc3RhbGwtaXN0aW8iOiB0cnVlLAogICAgICAgICJpc3Rpby1wcm9maWxlIjogImRlbW8iLAogICAgICAgICJhY2ktcG9kYmQtZG4iOiAidW5pL3RuLWt1YmUvQkQta3ViZS1wb2QtYmQiLAogICAgICAgICJhY2ktbm9kZWJkLWRuIjogInVuaS90bi1rdWJlL0JELWt1YmUtbm9kZS1iZCIsCiAgICAgICAgImFjaS1zZXJ2aWNlLXBoeXMtZG9tIjogImt1YmUtcGRvbSIsCiAgICAgICAgImFjaS1zZXJ2aWNlLWVuY2FwIjogInZsYW4tNDAwMyIsCiAgICAgICAgImFjaS1zZXJ2aWNlLW1vbml0b3ItaW50ZXJ2YWwiOiA1LAogICAgICAgICJhY2ktcGJyLXRyYWNraW5nLW5vbi1zbmF0IjogZmFsc2UsCiAgICAgICAgImFjaS12cmYtdGVuYW50IjogImNvbW1vbiIsCiAgICAgICAgImFjaS12cmYtZG4iOiAidW5pL3RuLWNvbW1vbi9jdHgta3ViZSIsCiAgICAgICAgImFjaS1sM291dCI6ICJsM291dCIsCiAgICAgICAgImFjaS1leHQtbmV0d29ya3MiOiBbCiAgICAgICAgICAgICJkZWZhdWx0IgogICAgICAgIF0sCiAgICAgICAgImFjaS12cmYiOiAia3ViZSIsCiAgICAgICAgImRlZmF1bHQtZW5kcG9pbnQtZ3JvdXAiOiB7CiAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAia3ViZSIsCiAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1kZWZhdWx0IgogICAgICAgIH0sCiAgICAgICAgIm1heC1ub2Rlcy1zdmMtZ3JhcGgiOiAzMiwKICAgICAgICAibmFtZXNwYWNlLWRlZmF1bHQtZW5kcG9pbnQtZ3JvdXAiOiB7CiAgICAgICAgICAgICJpc3Rpby1vcGVyYXRvciI6IHsKICAgICAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAia3ViZSIsCiAgICAgICAgICAgICAgICAibmFtZSI6ICJrdWJlcm5ldGVzfGt1YmUtaXN0aW8iCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgICJpc3Rpby1zeXN0ZW0iOiB7CiAgICAgICAgICAgICAgICAicG9saWN5LXNwYWNlIjogImt1YmUiLAogICAgICAgICAgICAgICAgIm5hbWUiOiAia3ViZXJuZXRlc3xrdWJlLWlzdGlvIgogICAgICAgICAgICB9LAogICAgICAgICAgICAia3ViZS1zeXN0ZW0iOiB7CiAgICAgICAgICAgICAgICAicG9saWN5LXNwYWNlIjogImt1YmUiLAogICAgICAgICAgICAgICAgIm5hbWUiOiAia3ViZXJuZXRlc3xrdWJlLXN5c3RlbSIKICAgICAgICAgICAgfSAgICAgICAgfSwKICAgICAgICAic2VydmljZS1pcC1wb29sIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAiZW5kIjogIjEwLjMuMC4yNTQiLAogICAgICAgICAgICAgICAgInN0YXJ0IjogIjEwLjMuMC4yIgogICAgICAgICAgICB9CiAgICAgICAgXSwKICAgICAgICAic25hdC1jb250cmFjdC1zY29wZSI6ICJnbG9iYWwiLAogICAgICAgICJzdGF0aWMtc2VydmljZS1pcC1wb29sIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAiZW5kIjogIjEwLjQuMC4yNTQiLAogICAgICAgICAgICAgICAgInN0YXJ0IjogIjEwLjQuMC4yIgogICAgICAgICAgICB9CiAgICAgICAgXSwKICAgICAgICAicG9kLWlwLXBvb2wiOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJlbmQiOiAiMTAuMi4yNTUuMjU0IiwKICAgICAgICAgICAgICAgICJzdGFydCI6ICIxMC4yLjAuMiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgInBvZC1zdWJuZXQtY2h1bmstc2l6ZSI6IDMyLAogICAgICAgICJub2RlLXNlcnZpY2UtaXAtcG9vbCI6IFsKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgImVuZCI6ICIxMC41LjAuMjU0IiwKICAgICAgICAgICAgICAgICJzdGFydCI6ICIxMC41LjAuMiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgIm5vZGUtc2VydmljZS1zdWJuZXRzIjogWwogICAgICAgICAgICAiMTAuNS4wLjEvMjQiCiAgICAgICAgXQogICAgfQogIGhvc3QtYWdlbnQtY29uZmlnOiB8LQogICAgewogICAgICAgICJmbGF2b3IiOiAia3ViZXJuZXRlcy0xLjIyIiwKICAgICAgICAiYXBwLXByb2ZpbGUiOiAia3ViZXJuZXRlcyIsCiAgICAgICAgImVwLXJlZ2lzdHJ5IjogbnVsbCwKICAgICAgICAib3BmbGV4LW1vZGUiOiBudWxsLAogICAgICAgICJsb2ctbGV2ZWwiOiAiaW5mbyIsCiAgICAgICAgImFjaS1zbmF0LW5hbWVzcGFjZSI6ICJhY2ktY29udGFpbmVycy1zeXN0ZW0iLAogICAgICAgICJhY2ktdm1tLXR5cGUiOiAiS3ViZXJuZXRlcyIsCiAgICAgICAgImFjaS12bW0tZG9tYWluIjogImt1YmUiLAogICAgICAgICJhY2ktdm1tLWNvbnRyb2xsZXIiOiAia3ViZSIsCiAgICAgICAgImFjaS1wcmVmaXgiOiAia3ViZSIsCiAgICAgICAgImFjaS12cmYiOiAia3ViZSIsCiAgICAgICAgImFjaS12cmYtdGVuYW50IjogImNvbW1vbiIsCiAgICAgICAgInNlcnZpY2UtdmxhbiI6IDQwMDMsCiAgICAgICAgImt1YmVhcGktdmxhbiI6IDQwMDEsCiAgICAgICAgInBvZC1zdWJuZXQiOiAiMTAuMi4wLjEvMTYiLAogICAgICAgICJub2RlLXN1Ym5ldCI6ICIxMC4xLjAuMS8xNiIsCiAgICAgICAgImVuY2FwLXR5cGUiOiAidnhsYW4iLAogICAgICAgICJhY2ktaW5mcmEtdmxhbiI6IDQwOTMsCiAgICAgICAgImNuaS1uZXRjb25maWciOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJnYXRld2F5IjogIjEwLjIuMC4xIiwKICAgICAgICAgICAgICAgICJyb3V0ZXMiOiBbCiAgICAgICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgICAgICAiZHN0IjogIjAuMC4wLjAvMCIsCiAgICAgICAgICAgICAgICAgICAgICAgICJndyI6ICIxMC4yLjAuMSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBdLAogICAgICAgICAgICAgICAgInN1Ym5ldCI6ICIxMC4yLjAuMC8xNiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgImRlZmF1bHQtZW5kcG9pbnQtZ3JvdXAiOiB7CiAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAia3ViZSIsCiAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1kZWZhdWx0IgogICAgICAgIH0sCiAgICAgICAgIm5hbWVzcGFjZS1kZWZhdWx0LWVuZHBvaW50LWdyb3VwIjogewogICAgICAgICAgICAiaXN0aW8tb3BlcmF0b3IiOiB7CiAgICAgICAgICAgICAgICAicG9saWN5LXNwYWNlIjogImt1YmUiLAogICAgICAgICAgICAgICAgIm5hbWUiOiAia3ViZXJuZXRlc3xrdWJlLWlzdGlvIgogICAgICAgICAgICB9LAogICAgICAgICAgICAiaXN0aW8tc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJrdWJlIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1pc3RpbyIKICAgICAgICAgICAgfSwKICAgICAgICAgICAgImt1YmUtc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJrdWJlIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1zeXN0ZW0iCiAgICAgICAgICAgIH0gICAgICAgIH0sCiAgICAgICAgImVuYWJsZS1kcm9wLWxvZyI6IHRydWUKICAgIH0KICBvcGZsZXgtYWdlbnQtY29uZmlnOiB8LQogICAgewogICAgICAgICJsb2ciOiB7CiAgICAgICAgICAgICJsZXZlbCI6ICJpbmZvIgogICAgICAgIH0sCiAgICAgICAgIm9wZmxleCI6IHsKICAgICAgICAgICAgIm5vdGlmIiA6IHsgImVuYWJsZWQiIDogImZhbHNlIiB9CiAgICAgICAgfQogICAgfQotLS0KYXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnTWFwCm1ldGFkYXRhOgogIG5hbWU6IHNuYXQtb3BlcmF0b3ItY29uZmlnCiAgbmFtZXNwYWNlOiBhY2ktY29udGFpbmVycy1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCmRhdGE6CiAgICAic3RhcnQiOiAiNTAwMCIKICAgICJlbmQiOiAiNjUwMDAiCiAgICAicG9ydHMtcGVyLW5vZGUiOiAiMzAwMCIKLS0tCmFwaVZlcnNpb246IHYxCmtpbmQ6IFNlY3JldAptZXRhZGF0YToKICBuYW1lOiBhY2ktdXNlci1jZXJ0CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCmRhdGE6CiAgdXNlci5rZXk6IExTMHRMUzFDUlVkSlRpQlFVa2xXUVZSRklFdEZXUzB0TFMwdENrMUpTVU5rWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUlJVWkJRVk5EUVcxQmQyZG5TbU5CWjBWQlFXOUhRa0ZPY2l0QksyZFBTMkpCVmxaeVNuTUtZak1yV2xkaVkyNVdXRzh2WjJSMWVFbFVhM1p0TURsclpXbEdRMjRyVlhBdlUwZGtjWFkyUVdncmFteEtaa1kzZFhZclJtZERTblJEZUVRNE4zRlpkd293Y1RWRVkwZFdURWxqWmtZMFdsVmlPVUk0Y2twWFMwSkpObmRLWm5oMFRXWkdkVlZPV1RJMFkyZDNVWEJLY1hKTlZYRkJSSG92VFZjcmQzSmFaV2h6Q2xOdVJuTjVaWGRZVWpNNE9HVlNOMFZMYWtSWFpXZGtTbmxRWTFoQlowMUNRVUZGUTJkWlFqbEJXR0l4V21aQ1EwSlZlRUlyVldkRlZFZE5OeXMwV0RrS2FraGllVVV3UW14NGJHdG1hbkpzZDJSMmJWTTVUVGMzS3pKYU5tUkxRV2RRTXpOVVVrMHZVSGRGVFU5Wk4xSnVaRUp2SzFnMmVFUnpWbVJqVkVwSmVRbzFWbmM0ZUZWYWJISXJZWFZGVDJ4ek1scHVXbmd4TVdVMWVtZzNjMVV6VG1vMVN6TTFRbGRTT1VkVVdFbzJVRTFrY0ZRME9XeENPV0pzYkUxcVJISk1DamNyTldKRGMyUjFOak5QT0V0aFRqbFpVVXBDUVZCSFRXSndTSEJHYzNSRE1XTlhSM0JTVVhnemFYZEdLMXBNV1VGeVFWVmlRMHRpVjFGbVltbGFWSEFLUTFNNFJHZFBiWGxWTjNWTFZGSkxhVU1yTWxKWlZGTXpjSEpNVmpVM1IzWm1aa1o0U21wVWQwZDVhME5SVVVSdlIwSjNaalZwVDNONWRVMVJUbm8zU3dwU2FYSmlSREJLTjFJMldXVlJhMHBhSzNCRFpVdDNlU3RPZVVseGVHZ3dURUpFYlVKNWJWTkxkbGd3VjBWTFEybDBUMmR3YVRNeVJsZENiM0ZJYW1ZekNrMVJaeTlCYTBKTVFreFNjV1ZLZG5SelQyOHpiVXRQTkdFcmVESmxOM2xTVlV0ck1VTnZTM3BHVGtKSU1HNVZaVmhIYmxCM2FWUk9ZaXRpTVdabVUwWUtOM1pKU21KSVpHMUxaM1ZLZVRCc1ZVNUJOMGhhTnpkWUwybEtVa0ZyUVdwdVltVk1TMXA2YkRScmFWQTNNM0JwVUdaNFRHMHpOMlpRYWtvcmVVUnZOQXBhY0hkVmRWcFNLME5EV0d4SVNIWlBaV1p3T1UxV2NsZGpOV1ZxWTBNdlIyRkROazFYV1hsTmFuVlhUU3Q0UVhCcVkzVjJRV3RGUVhwWkszQXhOREJEQ25oM2NISTVOV3hwYm01MlYyTkROMDQzTURoQlNrWnBiVE12UmxVeE1FZEViemMzZVVsUFNUVm9LelV6TjBwaVdXUnROVFUxYUU5bFNDOUxhbE5sYTJnS1JVWTBUVzE0VWxCdGFYUTVPWGM5UFFvdExTMHRMVVZPUkNCUVVrbFdRVlJGSUV0RldTMHRMUzB0Q2c9PQogIHVzZXIuY3J0OiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VJMlJFTkRRVlpGUTBGblVHOU5RVEJIUTFOeFIxTkpZak5FVVVWQ1FsRlZRVTFFZDNoRGVrRktRbWRPVmtKQldWUkJiRlpVVFZKWmQwWkJXVVFLVmxGUlMwUkJNVVJoV0U1cVlubENWR1ZZVGpCYVZ6RjZUVkpWZDBWM1dVUldVVkZFUkVGNFZtTXlWbmxKUnpGb1ltMVNiRnBZUVhkSWFHTk9UVlJqZHdwT1ZFVXlUV3BGZVU5VVRYZFhhR05PVFdwamQwNVVSVEJOYWtWNVQxUk5kMWRxUVRoTlVYTjNRMUZaUkZaUlVVZEZkMHBXVlhwRlYwMUNVVWRCTVZWRkNrTm5kMDVSTW14NldUSTRaMVV6Ykhwa1IxWjBZM3BGVmsxQ1RVZEJNVlZGUVhkM1RWWllUbXhqYVVKMFdWYzFhMXBYVm5kTlNVZG1UVUV3UjBOVGNVY0tVMGxpTTBSUlJVSkJVVlZCUVRSSFRrRkVRMEpwVVV0Q1oxRkVZUzluVUc5RWFXMTNSbFpoZVdKSE9TOXRWbTB6U2pGV05sQTBTR0p6VTBVMVREVjBVQXBhU0c5b1VYQXZiRXRtTUdodVlYSXJaMGxtYnpWVFdIaGxOM0l2YUZsQmFXSlJjMUV2VHpadFRVNUxkVkV6UW14VGVVaEllR1ZIVmtjdlVXWkxlVlpwQ21kVFQzTkRXRGhpVkVoNFlteEVWMDUxU0VsTlJVdFRZWEY2Umt0blFUZ3Zla1oyYzBzeVdHOWlSWEI0WWsxdWMwWXdaQzlRU0d0bGVFTnZkekZ1YjBnS1UyTnFNMFozU1VSQlVVRkNUVUV3UjBOVGNVZFRTV0l6UkZGRlFrSlJWVUZCTkVkQ1FVaFlLMnRNVkdVMlRFTkJRbVYzYlVOVWRrMXphblZ6U0dSd1dncHJhVEF4SzI1Uk4wdG9ia1ZTWWtKdEwzUmFOWE5qV2tVMFkzUkpjV05vTTI1NU1VVkpWRWhPZEZsWFMwSk9ORU5rVlV0amFuWkVWekpvTW5aclNHVm5DbkowV1dKV0swRmhSWE54TUcwMGRrZEdPVVZ0ZG5ReFkzQTVXVFF4U1hsTlFscFpjWGM0WXk5V01VRjBiVkpSWTFKVVdWRkJPRWd6VDBaRVkyaDVRaklLTUVwSVUwUnVRbTlUTjJabVUySkNlQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09Ci0tLQphcGlWZXJzaW9uOiB2MQpraW5kOiBTZXJ2aWNlQWNjb3VudAptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1jb250cm9sbGVyCiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCi0tLQphcGlWZXJzaW9uOiB2MQpraW5kOiBTZXJ2aWNlQWNjb3VudAptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1ob3N0LWFnZW50CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCi0tLQphcGlWZXJzaW9uOiByYmFjLmF1dGhvcml6YXRpb24uazhzLmlvL3YxCmtpbmQ6IENsdXN0ZXJSb2xlCm1ldGFkYXRhOgogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCiAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKICBuYW1lOiBhY2ktY29udGFpbmVyczpjb250cm9sbGVyCnJ1bGVzOgotIGFwaUdyb3VwczoKICAtICIiCiAgcmVzb3VyY2VzOgogIC0gbm9kZXMKICAtIG5hbWVzcGFjZXMKICAtIHBvZHMKICAtIGVuZHBvaW50cwogIC0gc2VydmljZXMKICAtIGV2ZW50cwogIC0gcmVwbGljYXRpb25jb250cm9sbGVycwogIC0gc2VydmljZWFjY291bnRzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0CiAgLSBwYXRjaAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICIiCiAgcmVzb3VyY2VzOgogIC0gY29uZmlnbWFwcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICJhcGlleHRlbnNpb25zLms4cy5pbyIKICByZXNvdXJjZXM6CiAgLSBjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zCiAgdmVyYnM6CiAgLSAnKicKLSBhcGlHcm91cHM6CiAgLSAicmJhYy5hdXRob3JpemF0aW9uLms4cy5pbyIKICByZXNvdXJjZXM6CiAgLSBjbHVzdGVycm9sZXMKICAtIGNsdXN0ZXJyb2xlYmluZGluZ3MKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtICJpbnN0YWxsLmlzdGlvLmlvIgogIHJlc291cmNlczoKICAtIGlzdGlvY29udHJvbHBsYW5lcwogIC0gaXN0aW9vcGVyYXRvcnMKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtICJhY2kuaXN0aW8iCiAgcmVzb3VyY2VzOgogIC0gYWNpaXN0aW9vcGVyYXRvcnMKICAtIGFjaWlzdGlvb3BlcmF0b3IKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtICJuZXR3b3JraW5nLms4cy5pbyIKICByZXNvdXJjZXM6CiAgLSBuZXR3b3JrcG9saWNpZXMKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAiYXBwcyIKICByZXNvdXJjZXM6CiAgLSBkZXBsb3ltZW50cwogIC0gcmVwbGljYXNldHMKICAtIGRhZW1vbnNldHMKICAtIHN0YXRlZnVsc2V0cwogIHZlcmJzOgogIC0gJyonCi0gYXBpR3JvdXBzOgogIC0gIiIKICByZXNvdXJjZXM6CiAgLSBub2RlcwogIC0gc2VydmljZXMvc3RhdHVzCiAgdmVyYnM6CiAgLSB1cGRhdGUKLSBhcGlHcm91cHM6CiAgLSAibW9uaXRvcmluZy5jb3Jlb3MuY29tIgogIHJlc291cmNlczoKICAtIHNlcnZpY2Vtb25pdG9ycwogIHZlcmJzOgogIC0gZ2V0CiAgLSBjcmVhdGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnNuYXQiCiAgcmVzb3VyY2VzOgogIC0gc25hdHBvbGljaWVzL2ZpbmFsaXplcnMKICAtIHNuYXRwb2xpY2llcy9zdGF0dXMKICAtIG5vZGVpbmZvcwogIHZlcmJzOgogIC0gdXBkYXRlCiAgLSBjcmVhdGUKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICJhY2kuc25hdCIKICByZXNvdXJjZXM6CiAgLSBzbmF0Z2xvYmFsaW5mb3MKICAtIHNuYXRwb2xpY2llcwogIC0gbm9kZWluZm9zCiAgLSByZGNvbmZpZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGNyZWF0ZQogIC0gdXBkYXRlCiAgLSBkZWxldGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnFvcyIKICByZXNvdXJjZXM6CiAgLSBxb3Nwb2xpY2llcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQogIC0gcGF0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYWNpLm5ldGZsb3ciCiAgcmVzb3VyY2VzOgogIC0gbmV0Zmxvd3BvbGljaWVzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0CiAgLSB1cGRhdGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLmVyc3BhbiIKICByZXNvdXJjZXM6CiAgLSBlcnNwYW5wb2xpY2llcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gdXBkYXRlCi0gYXBpR3JvdXBzOgogIC0gImFjaS5hdyIKICByZXNvdXJjZXM6CiAgLSBwb2RpZnMKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtIGFwcHMub3BlbnNoaWZ0LmlvCiAgcmVzb3VyY2VzOgogIC0gZGVwbG95bWVudGNvbmZpZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSBkaXNjb3ZlcnkuazhzLmlvCiAgcmVzb3VyY2VzOgogIC0gZW5kcG9pbnRzbGljZXMKICB2ZXJiczoKICAtIGdldAogIC0gbGlzdAogIC0gd2F0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYWNpLm5ldHBvbCIKICByZXNvdXJjZXM6CiAgLSBuZXR3b3JrcG9saWNpZXMKICB2ZXJiczoKICAtIGdldAogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGNyZWF0ZQogIC0gdXBkYXRlCiAgLSBkZWxldGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLmRuc25ldHBvbCIKICByZXNvdXJjZXM6CiAgLSBkbnNuZXR3b3JrcG9saWNpZXMKICB2ZXJiczoKICAtIGdldAogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGNyZWF0ZQogIC0gdXBkYXRlCiAgLSBkZWxldGUKLS0tCmFwaVZlcnNpb246IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8vdjEKa2luZDogQ2x1c3RlclJvbGUKbWV0YWRhdGE6CiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogIG5hbWU6IGFjaS1jb250YWluZXJzOmhvc3QtYWdlbnQKcnVsZXM6Ci0gYXBpR3JvdXBzOgogIC0gIiIKICByZXNvdXJjZXM6CiAgLSBub2RlcwogIC0gbmFtZXNwYWNlcwogIC0gcG9kcwogIC0gZW5kcG9pbnRzCiAgLSBzZXJ2aWNlcwogIC0gcmVwbGljYXRpb25jb250cm9sbGVycwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gdXBkYXRlCi0gYXBpR3JvdXBzOgogIC0gIiIKICByZXNvdXJjZXM6CiAgLSBldmVudHMKICB2ZXJiczoKICAtIGNyZWF0ZQogIC0gcGF0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYXBpZXh0ZW5zaW9ucy5rOHMuaW8iCiAgcmVzb3VyY2VzOgogIC0gY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAotIGFwaUdyb3VwczoKICAtICJhY2kuYXciCiAgcmVzb3VyY2VzOgogIC0gcG9kaWZzCiAgLSBwb2RpZnMvc3RhdHVzCiAgdmVyYnM6CiAgLSAiKiIKLSBhcGlHcm91cHM6CiAgLSAibmV0d29ya2luZy5rOHMuaW8iCiAgcmVzb3VyY2VzOgogIC0gbmV0d29ya3BvbGljaWVzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0Ci0gYXBpR3JvdXBzOgogIC0gImFwcHMiCiAgcmVzb3VyY2VzOgogIC0gZGVwbG95bWVudHMKICAtIHJlcGxpY2FzZXRzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0Ci0gYXBpR3JvdXBzOgogIC0gImFjaS5zbmF0IgogIHJlc291cmNlczoKICAtIHNuYXRwb2xpY2llcwogIC0gc25hdGdsb2JhbGluZm9zCiAgLSByZGNvbmZpZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnFvcyIKICByZXNvdXJjZXM6CiAgLSBxb3Nwb2xpY2llcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQogIC0gcGF0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYWNpLmRyb3Bsb2ciCiAgcmVzb3VyY2VzOgogIC0gZW5hYmxlZHJvcGxvZ3MKICAtIHBydW5lZHJvcGxvZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnNuYXQiCiAgcmVzb3VyY2VzOgogIC0gbm9kZWluZm9zCiAgLSBzbmF0bG9jYWxpbmZvcwogIHZlcmJzOgogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtIGRpc2NvdmVyeS5rOHMuaW8KICByZXNvdXJjZXM6CiAgLSBlbmRwb2ludHNsaWNlcwogIHZlcmJzOgogIC0gZ2V0CiAgLSBsaXN0CiAgLSB3YXRjaAotIGFwaUdyb3VwczoKICAtICJhY2kubmV0cG9sIgogIHJlc291cmNlczoKICAtIG5ldHdvcmtwb2xpY2llcwogIHZlcmJzOgogIC0gZ2V0CiAgLSBsaXN0CiAgLSB3YXRjaAotLS0KYXBpVmVyc2lvbjogcmJhYy5hdXRob3JpemF0aW9uLms4cy5pby92MQpraW5kOiBDbHVzdGVyUm9sZUJpbmRpbmcKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnM6Y29udHJvbGxlcgogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCnJvbGVSZWY6CiAgYXBpR3JvdXA6IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8KICBraW5kOiBDbHVzdGVyUm9sZQogIG5hbWU6IGFjaS1jb250YWluZXJzOmNvbnRyb2xsZXIKc3ViamVjdHM6Ci0ga2luZDogU2VydmljZUFjY291bnQKICBuYW1lOiBhY2ktY29udGFpbmVycy1jb250cm9sbGVyCiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQotLS0KYXBpVmVyc2lvbjogcmJhYy5hdXRob3JpemF0aW9uLms4cy5pby92MQpraW5kOiBDbHVzdGVyUm9sZUJpbmRpbmcKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnM6aG9zdC1hZ2VudAogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCnJvbGVSZWY6CiAgYXBpR3JvdXA6IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8KICBraW5kOiBDbHVzdGVyUm9sZQogIG5hbWU6IGFjaS1jb250YWluZXJzOmhvc3QtYWdlbnQKc3ViamVjdHM6Ci0ga2luZDogU2VydmljZUFjY291bnQKICBuYW1lOiBhY2ktY29udGFpbmVycy1ob3N0LWFnZW50CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQotLS0KYXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEYWVtb25TZXQKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnMtaG9zdAogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCnNwZWM6CiAgdXBkYXRlU3RyYXRlZ3k6CiAgICB0eXBlOiBSb2xsaW5nVXBkYXRlCiAgc2VsZWN0b3I6CiAgICBtYXRjaExhYmVsczoKICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtaG9zdAogICAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKICB0ZW1wbGF0ZToKICAgIG1ldGFkYXRhOgogICAgICBsYWJlbHM6CiAgICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtaG9zdAogICAgICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogICAgICBhbm5vdGF0aW9uczoKICAgICAgICBzY2hlZHVsZXIuYWxwaGEua3ViZXJuZXRlcy5pby9jcml0aWNhbC1wb2Q6ICcnCiAgICAgICAgcHJvbWV0aGV1cy5pby9zY3JhcGU6ICJ0cnVlIgogICAgICAgIHByb21ldGhldXMuaW8vcG9ydDogIjk2MTIiCiAgICBzcGVjOgogICAgICBob3N0TmV0d29yazogdHJ1ZQogICAgICBob3N0UElEOiB0cnVlCiAgICAgIGhvc3RJUEM6IHRydWUKICAgICAgc2VydmljZUFjY291bnROYW1lOiBhY2ktY29udGFpbmVycy1ob3N0LWFnZW50CiAgICAgIHRvbGVyYXRpb25zOgogICAgICAgIC0gb3BlcmF0b3I6IEV4aXN0cwogICAgICBwcmlvcml0eUNsYXNzTmFtZTogc3lzdGVtLWNsdXN0ZXItY3JpdGljYWwKICAgICAgY29udGFpbmVyczoKICAgICAgICAtIG5hbWU6IGFjaS1jb250YWluZXJzLWhvc3QKICAgICAgICAgIGltYWdlOiBub2lyby9hY2ktY29udGFpbmVycy1ob3N0OjUuMi4yLjAuMGVmNDcxOAogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIHNlY3VyaXR5Q29udGV4dDoKICAgICAgICAgICAgY2FwYWJpbGl0aWVzOgogICAgICAgICAgICAgIGFkZDoKICAgICAgICAgICAgICAgIC0gU1lTX0FETUlOCiAgICAgICAgICAgICAgICAtIE5FVF9BRE1JTgogICAgICAgICAgICAgICAgLSBTWVNfUFRSQUNFCiAgICAgICAgICAgICAgICAtIE5FVF9SQVcKICAgICAgICAgIGVudjoKICAgICAgICAgICAgLSBuYW1lOiBLVUJFUk5FVEVTX05PREVfTkFNRQogICAgICAgICAgICAgIHZhbHVlRnJvbToKICAgICAgICAgICAgICAgIGZpZWxkUmVmOgogICAgICAgICAgICAgICAgICBmaWVsZFBhdGg6IHNwZWMubm9kZU5hbWUKICAgICAgICAgICAgLSBuYW1lOiBURU5BTlQKICAgICAgICAgICAgICB2YWx1ZTogImt1YmUiCiAgICAgICAgICAgIC0gbmFtZTogTk9ERV9FUEcKICAgICAgICAgICAgICB2YWx1ZTogImt1YmVybmV0ZXN8a3ViZS1ub2RlcyIKICAgICAgICAgICAgLSBuYW1lOiBEVVJBVElPTl9XQUlUX0ZPUl9ORVRXT1JLCiAgICAgICAgICAgICAgdmFsdWU6ICIyMTAiCiAgICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgICAgIC0gbmFtZTogY25pLWJpbgogICAgICAgICAgICAgIG1vdW50UGF0aDogL21udC9jbmktYmluCiAgICAgICAgICAgIC0gbmFtZTogY25pLWNvbmYKICAgICAgICAgICAgICBtb3VudFBhdGg6IC9tbnQvY25pLWNvbmYKICAgICAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3ZhcgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3J1bgogICAgICAgICAgICAtIG5hbWU6IG9wZmxleC1ob3N0Y29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvb3BmbGV4LWFnZW50LW92cy9iYXNlLWNvbmYuZAogICAgICAgICAgICAtIG5hbWU6IGhvc3QtY29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvYWNpLWNvbnRhaW5lcnMvCiAgICAgICAgICAgIC0gbW91bnRQYXRoOiAvcnVuL25ldG5zCiAgICAgICAgICAgICAgbmFtZTogaG9zdC1ydW4tbmV0bnMKICAgICAgICAgICAgICByZWFkT25seTogdHJ1ZQogICAgICAgICAgICAgIG1vdW50UHJvcGFnYXRpb246IEhvc3RUb0NvbnRhaW5lcgogICAgICAgICAgbGl2ZW5lc3NQcm9iZToKICAgICAgICAgICAgaHR0cEdldDoKICAgICAgICAgICAgICBwYXRoOiAvc3RhdHVzCiAgICAgICAgICAgICAgcG9ydDogODA5MAogICAgICAgIC0gbmFtZTogb3BmbGV4LWFnZW50CiAgICAgICAgICBlbnY6CiAgICAgICAgICAgIC0gbmFtZTogUkVCT09UX1dJVEhfT1ZTCiAgICAgICAgICAgICAgdmFsdWU6ICJ0cnVlIgogICAgICAgICAgaW1hZ2U6IG5vaXJvL29wZmxleDo1LjIuMi4wLmQyNzM5ZGEKICAgICAgICAgIGltYWdlUHVsbFBvbGljeTogQWx3YXlzCiAgICAgICAgICBzZWN1cml0eUNvbnRleHQ6CiAgICAgICAgICAgIGNhcGFiaWxpdGllczoKICAgICAgICAgICAgICBhZGQ6CiAgICAgICAgICAgICAgICAtIE5FVF9BRE1JTgogICAgICAgICAgdm9sdW1lTW91bnRzOgogICAgICAgICAgICAtIG5hbWU6IGhvc3R2YXIKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvdmFyCiAgICAgICAgICAgIC0gbmFtZTogaG9zdHJ1bgogICAgICAgICAgICAgIG1vdW50UGF0aDogL3J1bgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvcnVuCiAgICAgICAgICAgIC0gbmFtZTogb3BmbGV4LWhvc3Rjb25maWctdm9sdW1lCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL2V0Yy9vcGZsZXgtYWdlbnQtb3ZzL2Jhc2UtY29uZi5kCiAgICAgICAgICAgIC0gbmFtZTogb3BmbGV4LWNvbmZpZy12b2x1bWUKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvZXRjL29wZmxleC1hZ2VudC1vdnMvY29uZi5kCiAgICAgICAgLSBuYW1lOiBtY2FzdC1kYWVtb24KICAgICAgICAgIGltYWdlOiBub2lyby9vcGZsZXg6NS4yLjIuMC5kMjczOWRhCiAgICAgICAgICBjb21tYW5kOiBbIi9iaW4vc2giXQogICAgICAgICAgYXJnczogWyIvdXNyL2xvY2FsL2Jpbi9sYXVuY2gtbWNhc3RkYWVtb24uc2giXQogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIHZvbHVtZU1vdW50czoKICAgICAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3ZhcgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3J1bgogICAgICByZXN0YXJ0UG9saWN5OiBBbHdheXMKICAgICAgdm9sdW1lczoKICAgICAgICAtIG5hbWU6IGNuaS1iaW4KICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvb3B0CiAgICAgICAgLSBuYW1lOiBjbmktY29uZgogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC9ldGMKICAgICAgICAtIG5hbWU6IGhvc3R2YXIKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvdmFyCiAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL3J1bgogICAgICAgIC0gbmFtZTogaG9zdC1jb25maWctdm9sdW1lCiAgICAgICAgICBjb25maWdNYXA6CiAgICAgICAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbmZpZwogICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAtIGtleTogaG9zdC1hZ2VudC1jb25maWcKICAgICAgICAgICAgICAgIHBhdGg6IGhvc3QtYWdlbnQuY29uZgogICAgICAgIC0gbmFtZTogb3BmbGV4LWhvc3Rjb25maWctdm9sdW1lCiAgICAgICAgICBlbXB0eURpcjoKICAgICAgICAgICAgbWVkaXVtOiBNZW1vcnkKICAgICAgICAtIG5hbWU6IG9wZmxleC1jb25maWctdm9sdW1lCiAgICAgICAgICBjb25maWdNYXA6CiAgICAgICAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbmZpZwogICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAtIGtleTogb3BmbGV4LWFnZW50LWNvbmZpZwogICAgICAgICAgICAgICAgcGF0aDogbG9jYWwuY29uZgogICAgICAgIC0gbmFtZTogaG9zdC1ydW4tbmV0bnMKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvcnVuL25ldG5zCi0tLQphcGlWZXJzaW9uOiBhcHBzL3YxCmtpbmQ6IERhZW1vblNldAptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1vcGVudnN3aXRjaAogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCnNwZWM6CiAgdXBkYXRlU3RyYXRlZ3k6CiAgICB0eXBlOiBSb2xsaW5nVXBkYXRlCiAgc2VsZWN0b3I6CiAgICBtYXRjaExhYmVsczoKICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtb3BlbnZzd2l0Y2gKICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgdGVtcGxhdGU6CiAgICBtZXRhZGF0YToKICAgICAgbGFiZWxzOgogICAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLW9wZW52c3dpdGNoCiAgICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgICAgIGFubm90YXRpb25zOgogICAgICAgIHNjaGVkdWxlci5hbHBoYS5rdWJlcm5ldGVzLmlvL2NyaXRpY2FsLXBvZDogJycKICAgIHNwZWM6CiAgICAgIGhvc3ROZXR3b3JrOiB0cnVlCiAgICAgIGhvc3RQSUQ6IHRydWUKICAgICAgaG9zdElQQzogdHJ1ZQogICAgICBzZXJ2aWNlQWNjb3VudE5hbWU6IGFjaS1jb250YWluZXJzLWhvc3QtYWdlbnQKICAgICAgdG9sZXJhdGlvbnM6CiAgICAgICAgLSBvcGVyYXRvcjogRXhpc3RzCiAgICAgIHByaW9yaXR5Q2xhc3NOYW1lOiBzeXN0ZW0tY2x1c3Rlci1jcml0aWNhbAogICAgICBjb250YWluZXJzOgogICAgICAgIC0gbmFtZTogYWNpLWNvbnRhaW5lcnMtb3BlbnZzd2l0Y2gKICAgICAgICAgIGltYWdlOiBub2lyby9vcGVudnN3aXRjaDo1LjIuMi4wLjU2ODFhOWIKICAgICAgICAgIGltYWdlUHVsbFBvbGljeTogQWx3YXlzCiAgICAgICAgICByZXNvdXJjZXM6CiAgICAgICAgICAgIGxpbWl0czoKICAgICAgICAgICAgICBtZW1vcnk6ICIxR2kiCiAgICAgICAgICBzZWN1cml0eUNvbnRleHQ6CiAgICAgICAgICAgIGNhcGFiaWxpdGllczoKICAgICAgICAgICAgICBhZGQ6CiAgICAgICAgICAgICAgICAtIE5FVF9BRE1JTgogICAgICAgICAgICAgICAgLSBTWVNfTU9EVUxFCiAgICAgICAgICAgICAgICAtIFNZU19OSUNFCiAgICAgICAgICAgICAgICAtIElQQ19MT0NLCiAgICAgICAgICBlbnY6CiAgICAgICAgICAgIC0gbmFtZTogT1ZTX1JVTkRJUgogICAgICAgICAgICAgIHZhbHVlOiAvdXNyL2xvY2FsL3Zhci9ydW4vb3BlbnZzd2l0Y2gKICAgICAgICAgIHZvbHVtZU1vdW50czoKICAgICAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3ZhcgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3J1bgogICAgICAgICAgICAtIG5hbWU6IGhvc3RldGMKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvZXRjCiAgICAgICAgICAgIC0gbmFtZTogaG9zdG1vZHVsZXMKICAgICAgICAgICAgICBtb3VudFBhdGg6IC9saWIvbW9kdWxlcwogICAgICAgICAgbGl2ZW5lc3NQcm9iZToKICAgICAgICAgICAgZXhlYzoKICAgICAgICAgICAgICBjb21tYW5kOgogICAgICAgICAgICAgICAgLSAvdXNyL2xvY2FsL2Jpbi9saXZlbmVzcy1vdnMuc2gKICAgICAgcmVzdGFydFBvbGljeTogQWx3YXlzCiAgICAgIHZvbHVtZXM6CiAgICAgICAgLSBuYW1lOiBob3N0ZXRjCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL2V0YwogICAgICAgIC0gbmFtZTogaG9zdHZhcgogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC92YXIKICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvcnVuCiAgICAgICAgLSBuYW1lOiBob3N0bW9kdWxlcwogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC9saWIvbW9kdWxlcwotLS0KYXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEZXBsb3ltZW50Cm1ldGFkYXRhOgogIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgpzcGVjOgogIHJlcGxpY2FzOiAxCiAgc3RyYXRlZ3k6CiAgICB0eXBlOiBSZWNyZWF0ZQogIHNlbGVjdG9yOgogICAgbWF0Y2hMYWJlbHM6CiAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgdGVtcGxhdGU6CiAgICBtZXRhZGF0YToKICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgogICAgICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCiAgICAgIGxhYmVsczoKICAgICAgICBuYW1lOiBhY2ktY29udGFpbmVycy1jb250cm9sbGVyCiAgICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgICAgIGFubm90YXRpb25zOgogICAgICAgIHNjaGVkdWxlci5hbHBoYS5rdWJlcm5ldGVzLmlvL2NyaXRpY2FsLXBvZDogJycKICAgIHNwZWM6CiAgICAgIGhvc3ROZXR3b3JrOiB0cnVlCiAgICAgIHNlcnZpY2VBY2NvdW50TmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgogICAgICB0b2xlcmF0aW9uczoKICAgICAgICAtIG9wZXJhdG9yOiBFeGlzdHMKICAgICAgICAgIGVmZmVjdDogTm9TY2hlZHVsZQogICAgICBwcmlvcml0eUNsYXNzTmFtZTogc3lzdGVtLW5vZGUtY3JpdGljYWwKICAgICAgY29udGFpbmVyczoKICAgICAgICAtIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICAgICAgICAgIGltYWdlOiBub2lyby9hY2ktY29udGFpbmVycy1jb250cm9sbGVyOjUuMi4yLjAuMGVmNDcxOAogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIGVudjoKICAgICAgICAgICAgLSBuYW1lOiBXQVRDSF9OQU1FU1BBQ0UKICAgICAgICAgICAgICB2YWx1ZTogIiIKICAgICAgICAgICAgLSBuYW1lOiBBQ0lfU05BVF9OQU1FU1BBQ0UKICAgICAgICAgICAgICB2YWx1ZTogImFjaS1jb250YWluZXJzLXN5c3RlbSIKICAgICAgICAgICAgLSBuYW1lOiBBQ0lfU05BR0xPQkFMSU5GT19OQU1FCiAgICAgICAgICAgICAgdmFsdWU6ICJzbmF0Z2xvYmFsaW5mbyIKICAgICAgICAgICAgLSBuYW1lOiBBQ0lfUkRDT05GSUdfTkFNRQogICAgICAgICAgICAgIHZhbHVlOiAicm91dGluZ2RvbWFpbi1jb25maWciCiAgICAgICAgICAgIC0gbmFtZTogU1lTVEVNX05BTUVTUEFDRQogICAgICAgICAgICAgIHZhbHVlOiAia3ViZS1zeXN0ZW0iCiAgICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgICAgIC0gbmFtZTogY29udHJvbGxlci1jb25maWctdm9sdW1lCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL2V0Yy9hY2ktY29udGFpbmVycy8KICAgICAgICAgICAgLSBuYW1lOiBhY2ktdXNlci1jZXJ0LXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvYWNpLWNlcnQvCiAgICAgICAgICBsaXZlbmVzc1Byb2JlOgogICAgICAgICAgICBodHRwR2V0OgogICAgICAgICAgICAgIHBhdGg6IC9zdGF0dXMKICAgICAgICAgICAgICBwb3J0OiA4MDkxCiAgICAgIHZvbHVtZXM6CiAgICAgICAgLSBuYW1lOiBhY2ktdXNlci1jZXJ0LXZvbHVtZQogICAgICAgICAgc2VjcmV0OgogICAgICAgICAgICBzZWNyZXROYW1lOiBhY2ktdXNlci1jZXJ0CiAgICAgICAgLSBuYW1lOiBjb250cm9sbGVyLWNvbmZpZy12b2x1bWUKICAgICAgICAgIGNvbmZpZ01hcDoKICAgICAgICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29uZmlnCiAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgIC0ga2V5OiBjb250cm9sbGVyLWNvbmZpZwogICAgICAgICAgICAgICAgcGF0aDogY29udHJvbGxlci5jb25mCg=="
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aci-containers-config
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  controller-config: |-
+    {
+        "flavor": "kubernetes-1.22",
+        "log-level": "info",
+        "apic-hosts": [
+            "10.30.120.100"
+        ],
+        "apic-username": "kube",
+        "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "aci-prefix": "kube",
+        "aci-vmm-type": "Kubernetes",
+        "aci-vmm-domain": "kube",
+        "aci-vmm-controller": "kube",
+        "aci-policy-tenant": "kube",
+        "install-istio": true,
+        "istio-profile": "demo",
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
+        "aci-service-phys-dom": "kube-pdom",
+        "aci-service-encap": "vlan-4003",
+        "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
+        "aci-vrf-tenant": "common",
+        "aci-vrf-dn": "uni/tn-common/ctx-kube",
+        "aci-l3out": "l3out",
+        "aci-ext-networks": [
+            "default"
+        ],
+        "aci-vrf": "kube",
+        "default-endpoint-group": {
+            "policy-space": "kube",
+            "name": "kubernetes|kube-default"
+        },
+        "max-nodes-svc-graph": 32,
+        "namespace-default-endpoint-group": {
+            "istio-operator": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "istio-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "kube-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            }        },
+        "service-ip-pool": [
+            {
+                "end": "10.3.0.254",
+                "start": "10.3.0.2"
+            }
+        ],
+        "snat-contract-scope": "global",
+        "static-service-ip-pool": [
+            {
+                "end": "10.4.0.254",
+                "start": "10.4.0.2"
+            }
+        ],
+        "pod-ip-pool": [
+            {
+                "end": "10.2.255.254",
+                "start": "10.2.0.2"
+            }
+        ],
+        "pod-subnet-chunk-size": 32,
+        "node-service-ip-pool": [
+            {
+                "end": "10.5.0.254",
+                "start": "10.5.0.2"
+            }
+        ],
+        "node-service-subnets": [
+            "10.5.0.1/24"
+        ]
+    }
+  host-agent-config: |-
+    {
+        "flavor": "kubernetes-1.22",
+        "app-profile": "kubernetes",
+        "ep-registry": null,
+        "opflex-mode": null,
+        "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
+        "aci-vmm-type": "Kubernetes",
+        "aci-vmm-domain": "kube",
+        "aci-vmm-controller": "kube",
+        "aci-prefix": "kube",
+        "aci-vrf": "kube",
+        "aci-vrf-tenant": "common",
+        "service-vlan": 4003,
+        "kubeapi-vlan": 4001,
+        "pod-subnet": "10.2.0.1/16",
+        "node-subnet": "10.1.0.1/16",
+        "encap-type": "vxlan",
+        "aci-infra-vlan": 4093,
+        "cni-netconfig": [
+            {
+                "gateway": "10.2.0.1",
+                "routes": [
+                    {
+                        "dst": "0.0.0.0/0",
+                        "gw": "10.2.0.1"
+                    }
+                ],
+                "subnet": "10.2.0.0/16"
+            }
+        ],
+        "default-endpoint-group": {
+            "policy-space": "kube",
+            "name": "kubernetes|kube-default"
+        },
+        "namespace-default-endpoint-group": {
+            "istio-operator": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "istio-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "kube-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            }        },
+        "enable-drop-log": true
+    }
+  opflex-agent-config: |-
+    {
+        "log": {
+            "level": "info"
+        },
+        "opflex": {
+            "notif" : { "enabled" : "false" }
+        }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snat-operator-config
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+    "start": "5000"
+    "end": "65000"
+    "ports-per-node": "3000"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aci-user-cert
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+data:
+  user.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUNkZ0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQW1Bd2dnSmNBZ0VBQW9HQkFOcitBK2dPS2JBVlZySnMKYjMrWldiY25WWG8vZ2R1eElUa3ZtMDlrZWlGQ24rVXAvU0dkcXY2QWgramxKZkY3dXYrRmdDSnRDeEQ4N3FZdwowcTVEY0dWTEljZkY0WlViOUI4ckpXS0JJNndKZnh0TWZGdVVOWTI0Y2d3UXBKcXJNVXFBRHovTVcrd3JaZWhzClNuRnN5ZXdYUjM4OGVSN0VLakRXZWdkSnlQY1hBZ01CQUFFQ2dZQjlBWGIxWmZCQ0JVeEIrVWdFVEdNNys0WDkKakhieUUwQmx4bGtmanJsd2R2bVM5TTc3KzJaNmRLQWdQMzNUUk0vUHdFTU9ZN1JuZEJvK1g2eERzVmRjVEpJeQo1Vnc4eFVabHIrYXVFT2xzMlpuWngxMWU1emg3c1UzTmo1SzM1QldSOUdUWEo2UE1kcFQ0OWxCOWJsbE1qRHJMCjcrNWJDc2R1NjNPOEthTjlZUUpCQVBHTWJwSHBGc3RDMWNXR3BSUXgzaXdGK1pMWUFyQVViQ0tiV1FmYmlaVHAKQ1M4RGdPbXlVN3VLVFJLaUMrMlJZVFMzcHJMVjU3R3ZmZkZ4SmpUd0d5a0NRUURvR0J3ZjVpT3N5dU1RTno3SwpSaXJiRDBKN1I2WWVRa0paK3BDZUt3eStOeUlxeGgwTEJEbUJ5bVNLdlgwV0VLQ2l0T2dwaTMyRldCb3FIamYzCk1RZy9Ba0JMQkxScWVKdnRzT28zbUtPNGEreDJlN3lSVUtrMUNvS3pGTkJIMG5VZVhHblB3aVROYitiMWZmU0YKN3ZJSmJIZG1LZ3VKeTBsVU5BN0haNzdYL2lKUkFrQWpuYmVMS1p6bDRraVA3M3BpUGZ4TG0zN2ZQakoreURvNApacHdVdVpSK0NDWGxISHZPZWZwOU1WcldjNWVqY0MvR2FDNk1XWXlNanVXTSt4QXBqY3V2QWtFQXpZK3AxNDBDCnh3cHI5NWxpbm52V2NDN043MDhBSkZpbTMvRlUxMEdEbzc3eUlPSTVoKzUzN0piWWRtNTU1aE9lSC9LalNla2gKRUY0TW14UlBtaXQ5OXc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==
+  user.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUI2RENDQVZFQ0FnUG9NQTBHQ1NxR1NJYjNEUUVCQlFVQU1Ed3hDekFKQmdOVkJBWVRBbFZUTVJZd0ZBWUQKVlFRS0RBMURhWE5qYnlCVGVYTjBaVzF6TVJVd0V3WURWUVFEREF4VmMyVnlJRzFoYm1SbFpYQXdIaGNOTVRjdwpOVEUyTWpFeU9UTXdXaGNOTWpjd05URTBNakV5T1RNd1dqQThNUXN3Q1FZRFZRUUdFd0pWVXpFV01CUUdBMVVFCkNnd05RMmx6WTI4Z1UzbHpkR1Z0Y3pFVk1CTUdBMVVFQXd3TVZYTmxjaUJ0WVc1a1pXVndNSUdmTUEwR0NTcUcKU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FEYS9nUG9EaW13RlZheWJHOS9tVm0zSjFWNlA0SGJzU0U1TDV0UApaSG9oUXAvbEtmMGhuYXIrZ0lmbzVTWHhlN3IvaFlBaWJRc1EvTzZtTU5LdVEzQmxTeUhIeGVHVkcvUWZLeVZpCmdTT3NDWDhiVEh4YmxEV051SElNRUtTYXF6RktnQTgvekZ2c0syWG9iRXB4Yk1uc0YwZC9QSGtleENvdzFub0gKU2NqM0Z3SURBUUFCTUEwR0NTcUdTSWIzRFFFQkJRVUFBNEdCQUhYK2tMVGU2TENBQmV3bUNUdk1zanVzSGRwWgpraTAxK25RN0tobkVSYkJtL3RaNXNjWkU0Y3RJcWNoM255MUVJVEhOdFlXS0JONENkVUtjanZEVzJoMnZrSGVnCnJ0WWJWK0FhRXNxMG00dkdGOUVtdnQxY3A5WTQxSXlNQlpZcXc4Yy9WMUF0bVJRY1JUWVFBOEgzT0ZEY2h5QjIKMEpIU0RuQm9TN2ZmU2JCeAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-controller
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-host-agent
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers:controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - endpoints
+  - services
+  - events
+  - replicationcontrollers
+  - serviceaccounts
+  verbs:
+  - list
+  - watch
+  - get
+  - patch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - "install.istio.io"
+  resources:
+  - istiocontrolplanes
+  - istiooperators
+  verbs:
+  - '*'
+- apiGroups:
+  - "aci.istio"
+  resources:
+  - aciistiooperators
+  - aciistiooperator
+  verbs:
+  - '*'
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - services/status
+  verbs:
+  - update
+- apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatpolicies/finalizers
+  - snatpolicies/status
+  - nodeinfos
+  verbs:
+  - update
+  - create
+  - list
+  - watch
+  - get
+  - delete
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatglobalinfos
+  - snatpolicies
+  - nodeinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "aci.qos"
+  resources:
+  - qospolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - "aci.netflow"
+  resources:
+  - netflowpolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - "aci.erspan"
+  resources:
+  - erspanpolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - "aci.aw"
+  resources:
+  - podifs
+  verbs:
+  - '*'
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "aci.netpol"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "aci.dnsnetpol"
+  resources:
+  - dnsnetworkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers:host-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - endpoints
+  - services
+  - replicationcontrollers
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.aw"
+  resources:
+  - podifs
+  - podifs/status
+  verbs:
+  - "*"
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatpolicies
+  - snatglobalinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.qos"
+  resources:
+  - qospolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - "aci.droplog"
+  resources:
+  - enabledroplogs
+  - prunedroplogs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - nodeinfos
+  - snatlocalinfos
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+  - delete
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "aci.netpol"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers:controller
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers:controller
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers:host-agent
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers:host-agent
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-host-agent
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aci-containers-host
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-host
+      network-plugin: aci-containers
+  template:
+    metadata:
+      labels:
+        name: aci-containers-host
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9612"
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      serviceAccountName: aci-containers-host-agent
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: aci-containers-host
+          image: noiro/aci-containers-host:5.2.2.0.0ef4718
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - NET_ADMIN
+                - SYS_PTRACE
+                - NET_RAW
+          env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
+            - name: DURATION_WAIT_FOR_NETWORK
+              value: "210"
+          volumeMounts:
+            - name: cni-bin
+              mountPath: /mnt/cni-bin
+            - name: cni-conf
+              mountPath: /mnt/cni-conf
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: opflex-hostconfig-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+            - name: host-config-volume
+              mountPath: /usr/local/etc/aci-containers/
+            - mountPath: /run/netns
+              name: host-run-netns
+              readOnly: true
+              mountPropagation: HostToContainer
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8090
+        - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
+          image: noiro/opflex:5.2.2.0.d2739da
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: opflex-hostconfig-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+            - name: opflex-config-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
+        - name: mcast-daemon
+          image: noiro/opflex:5.2.2.0.d2739da
+          command: ["/bin/sh"]
+          args: ["/usr/local/bin/launch-mcastdaemon.sh"]
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+      restartPolicy: Always
+      volumes:
+        - name: cni-bin
+          hostPath:
+            path: /opt
+        - name: cni-conf
+          hostPath:
+            path: /etc
+        - name: hostvar
+          hostPath:
+            path: /var
+        - name: hostrun
+          hostPath:
+            path: /run
+        - name: host-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: host-agent-config
+                path: host-agent.conf
+        - name: opflex-hostconfig-volume
+          emptyDir:
+            medium: Memory
+        - name: opflex-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: opflex-agent-config
+                path: local.conf
+        - name: host-run-netns
+          hostPath:
+            path: /run/netns
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aci-containers-openvswitch
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-openvswitch
+      network-plugin: aci-containers
+  template:
+    metadata:
+      labels:
+        name: aci-containers-openvswitch
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      serviceAccountName: aci-containers-host-agent
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: aci-containers-openvswitch
+          image: noiro/openvswitch:5.2.2.0.5681a9b
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "1Gi"
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - SYS_MODULE
+                - SYS_NICE
+                - IPC_LOCK
+          env:
+            - name: OVS_RUNDIR
+              value: /usr/local/var/run/openvswitch
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: hostetc
+              mountPath: /usr/local/etc
+            - name: hostmodules
+              mountPath: /lib/modules
+          livenessProbe:
+            exec:
+              command:
+                - /usr/local/bin/liveness-ovs.sh
+      restartPolicy: Always
+      volumes:
+        - name: hostetc
+          hostPath:
+            path: /etc
+        - name: hostvar
+          hostPath:
+            path: /var
+        - name: hostrun
+          hostPath:
+            path: /run
+        - name: hostmodules
+          hostPath:
+            path: /lib/modules
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aci-containers-controller
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+    name: aci-containers-controller
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: aci-containers-controller
+      network-plugin: aci-containers
+  template:
+    metadata:
+      name: aci-containers-controller
+      namespace: kube-system
+      labels:
+        name: aci-containers-controller
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      serviceAccountName: aci-containers-controller
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+      priorityClassName: system-node-critical
+      containers:
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:5.2.2.0.0ef4718
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: ACI_SNAT_NAMESPACE
+              value: "aci-containers-system"
+            - name: ACI_SNAGLOBALINFO_NAME
+              value: "snatglobalinfo"
+            - name: ACI_RDCONFIG_NAME
+              value: "routingdomain-config"
+            - name: SYSTEM_NAMESPACE
+              value: "kube-system"
+          volumeMounts:
+            - name: controller-config-volume
+              mountPath: /usr/local/etc/aci-containers/
+            - name: aci-user-cert-volume
+              mountPath: /usr/local/etc/aci-cert/
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8091
+      volumes:
+        - name: aci-user-cert-volume
+          secret:
+            secretName: aci-user-cert
+        - name: controller-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: controller-config
+                path: controller.conf
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-operator
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers-operator
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  - namespaces
+  - configmaps
+  - secrets
+  - pods
+  - services
+  - serviceaccounts
+  - serviceaccounts/token
+  - endpoints
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.ctrl
+  resources:
+  - acicontainersoperators
+  - acicontainersoperators/status
+  - acicontainersoperators/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.snat
+  resources:
+  - snatpolicies
+  - snatglobalinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - aci.snat
+  resources:
+  - nodeinfos
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+- apiGroups:
+  - config.openshift.io
+  - operator.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers-operator
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers-operator
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-operator
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aci-containers-operator
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    name: aci-containers-operator
+    network-plugin: aci-containers
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: aci-containers-operator
+      network-plugin: aci-containers
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: aci-containers-operator
+      namespace: kube-system
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: aci-containers-operator
+        network-plugin: aci-containers
+    spec:
+      containers:
+      - image: noiro/aci-containers-operator:5.2.2.0.0ef4718
+        imagePullPolicy: Always
+        name: aci-containers-operator
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - name: aci-operator-config
+          mountPath: /usr/local/etc/aci-containers/
+        env:
+        - name: SYSTEM_NAMESPACE
+          value: "kube-system"
+        - name: ACC_PROVISION_FLAVOR
+          value: "kubernetes-1.22"
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: aci-containers-operator
+      serviceAccountName: aci-containers-operator
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - name: aci-operator-config
+        configMap:
+          name: aci-operator-config
+          items:
+            - key: spec
+              path: aci-operator.conf

--- a/provision/testdata/with_sriov_config_input.yaml
+++ b/provision/testdata/with_sriov_config_input.yaml
@@ -1,0 +1,56 @@
+aci_config:
+  system_id: kube
+  use_legacy_kube_naming_convention: True
+  apic_hosts:
+    - 10.30.120.100
+  apic_login:
+    username: admin
+    password: noir0123
+  aep: kube-aep
+  vrf:
+    name: kube
+    tenant: common
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  custom_epgs:
+    - group1
+    - group2
+
+net_config:
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+
+kube_config:
+  controller: 1.1.1.1
+  use_cluster_role: true
+  use_ds_rolling_update: true
+
+registry:
+  image_prefix: noiro
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info
+
+sriov_config:
+  enable: True
+  device_info:
+      isRdma: True
+      devices: 1110 

--- a/provision/testdata/with_sriov_config_kube.yaml
+++ b/provision/testdata/with_sriov_config_kube.yaml
@@ -1,0 +1,2405 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: acicontainersoperators.aci.ctrl
+spec:
+  group: aci.ctrl
+  names:
+    kind: AciContainersOperator
+    listKind: AciContainersOperatorList
+    plural: acicontainersoperators
+    singular: acicontainersoperator
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: acicontainersoperator owns the lifecycle of ACI objects in the cluster
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AciContainersOperatorSpec defines the desired spec for ACI Objects
+            properties:
+              flavor:
+                type: string
+              config:
+                type: string
+            type: object
+          status:
+            description: AciContainersOperatorStatus defines the successful completion of AciContainersOperator
+            properties:
+              status:
+                type: boolean
+            type: object
+        required:
+        - spec
+        type: object
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+  annotations:
+    openshift.io/node-selector: ''
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: podifs.aci.aw
+spec:
+  group: aci.aw
+  names:
+    kind: PodIF
+    listKind: PodIFList
+    plural: podifs
+    singular: podif
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: PodIF describes a pod network interface
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          status:
+            description: PodIFStatus is the status of a PodIF
+            properties:
+              containerID:
+                type: string
+              epg:
+                type: string
+              ifname:
+                type: string
+              ipaddr:
+                type: string
+              macaddr:
+                type: string
+              podname:
+                type: string
+              podns:
+                type: string
+              vtep:
+                type: string
+            type: object
+        required:
+        - status
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatglobalinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatGlobalInfo
+    listKind: SnatGlobalInfoList
+    plural: snatglobalinfos
+    singular: snatglobalinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: SnatGlobalInfo is the Schema for the snatglobalinfos API
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              globalInfos:
+                additionalProperties:
+                  items:
+                    properties:
+                      macAddress:
+                        type: string
+                      portRanges:
+                        items:
+                          properties:
+                            end:
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            start:
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          type: object
+                        type: array
+                      snatIp:
+                        type: string
+                      snatIpUid:
+                        type: string
+                      snatPolicyName:
+                        type: string
+                    required:
+                    - macAddress
+                    - portRanges
+                    - snatIp
+                    - snatIpUid
+                    - snatPolicyName
+                    type: object
+                  type: array
+                type: object
+            required:
+            - globalInfos
+            type: object
+          status:
+            description: SnatGlobalInfoStatus defines the observed state of SnatGlobalInfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatlocalinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatLocalInfo
+    listKind: SnatLocalInfoList
+    plural: snatlocalinfos
+    singular: snatlocalinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SnatLocalInfoSpec defines the desired state of SnatLocalInfo
+            properties:
+              localInfos:
+                items:
+                  properties:
+                    podName:
+                      type: string
+                    podNamespace:
+                      type: string
+                    podUid:
+                      type: string
+                    snatPolicies:
+                      items:
+                        properties:
+                          destIp:
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            type: string
+                          snatIp:
+                            type: string
+                        required:
+                        - destIp
+                        - name
+                        - snatIp
+                        type: object
+                      type: array
+                  required:
+                  - podName
+                  - podNamespace
+                  - podUid
+                  - snatPolicies
+                  type: object
+                type: array
+            required:
+            - localInfos
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatpolicies.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatPolicy
+    listKind: SnatPolicyList
+    plural: snatpolicies
+    singular: snatpolicy
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            properties:
+              selector:
+                type: object
+                properties:
+                  labels:
+                    type: object
+                    description: 'Selection of Pods'
+                    properties:
+                    additionalProperties:
+                      type: string
+                  namespace:
+                    type: string
+                type: object
+              snatIp:
+                type: array
+                items:
+                  type: string
+              destIp:
+                type: array
+                items:
+                  type: string
+            type: object
+          status:
+            type: object
+            properties:
+            additionalProperties:
+              type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nodeinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: NodeInfo
+    listKind: NodeInfoList
+    plural: nodeinfos
+    singular: nodeinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              macaddress:
+                type: string
+              snatpolicynames:
+                additionalProperties:
+                  type: boolean
+                type: object
+            type: object
+          status:
+            description: NodeinfoStatus defines the observed state of Nodeinfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rdconfigs.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: RdConfig
+    listKind: RdConfigList
+    plural: rdconfigs
+    singular: rdconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              discoveredsubnets:
+                items:
+                  type: string
+                type: array
+              usersubnets:
+                items:
+                  type: string
+                type: array
+            required:
+            - usersubnets
+            type: object
+          status:
+            description: NodeinfoStatus defines the observed state of Nodeinfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.aci.netpol
+spec:
+  group: aci.netpol
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Network Policy describes traffic flow at IP address or port level
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              appliedTo:
+                properties:
+                  namespaceSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  podSelector:
+                    description: allow ingress from the same namespace
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+              egress:
+                description: Set of egress rules evaluated based on the order in which they are set.
+                items:
+                  properties:
+                    action:
+                      description: Action specifies the action to be applied on the rule.
+                      type: string
+                    enableLogging:
+                      description: EnableLogging is used to indicate if agent should generate logs default to false.
+                      type: boolean
+                    ports:
+                      description: Set of port and protocol allowed/denied by the rule. If this field is unset or empty, this rule matches all ports.
+                      items:
+                        description: NetworkPolicyPort describes the port and protocol to match in a rule.
+                        properties:
+                          endPort:
+                            description: EndPort defines the end of the port range, being the end included within the range. It can only be specified when a numerical `port` is specified.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can be either a numerical or named port on a Pod. If this field is not provided, this matches all port names and numbers.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            default: TCP
+                            description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      description: Rule is matched if traffic is intended for workloads selected by this field. If this field is empty or missing, this rule matches all destinations.
+                      items:
+                        properties:
+                          ipBlock:
+                            description: IPBlock describes the IPAddresses/IPBlocks that is matched in to/from. IPBlock cannot be set as part of the AppliedTo field. Cannot be set with any other selector.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            description: Select all Pods from Namespaces matched by this selector, as workloads in To/From fields. If set with PodSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except PodSelector or ExternalEntitySelector.
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          podSelector:
+                            description: Select Pods from NetworkPolicy's Namespace as workloads in AppliedTo/To/From fields. If set with NamespaceSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    toFqDn:
+                      properties:
+                        matchNames:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - matchNames
+                      type: object
+                  required:
+                  - enableLogging
+                  - toFqDn
+                  type: object
+                type: array
+              ingress:
+                description: Set of ingress rules evaluated based on the order in which they are set.
+                items:
+                  properties:
+                    action:
+                      description: Action specifies the action to be applied on the rule.
+                      type: string
+                    enableLogging:
+                      description: EnableLogging is used to indicate if agent should generate logs when rules are matched. Should be default to false.
+                      type: boolean
+                    from:
+                      description: Rule is matched if traffic originates from workloads selected by this field. If this field is empty, this rule matches all sources.
+                      items:
+                        properties:
+                          ipBlock:
+                            description: IPBlock describes the IPAddresses/IPBlocks that is matched in to/from. IPBlock cannot be set as part of the AppliedTo field. Cannot be set with any other selector.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          podSelector:
+                            description: Select Pods from NetworkPolicy's Namespace as workloads in AppliedTo/To/From fields. If set with NamespaceSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    ports:
+                      description: Set of port and protocol allowed/denied by the rule. If this field is unset or empty, this rule matches all ports.
+                      items:
+                        description: NetworkPolicyPort describes the port and protocol to match in a rule.
+                        properties:
+                          endPort:
+                            description: EndPort defines the end of the port range, being the end included within the range. It can only be specified when a numerical `port` is specified.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can be either a numerical or named port on a Pod. If this field is not provided, this matches all port names and numbers.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            default: TCP
+                            description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              policyTypes:
+                items:
+                  description: Policy Type string describes the NetworkPolicy type This type is beta-level in 1.8
+                  type: string
+                type: array
+              priority:
+                description: Priority specfies the order of the NetworkPolicy relative to other NetworkPolicies.
+                type: integer
+              type:
+                description: type of the policy.
+                type: string
+            required:
+            - type
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dnsnetworkpolicies.aci.dnsnetpol
+spec:
+  group: aci.dnsnetpol
+  names:
+    kind: DnsNetworkPolicy
+    listKind: DnsNetworkPolicyList
+    plural: dnsnetworkpolicies
+    singular: dnsnetworkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1beta
+    schema:
+      openAPIV3Schema:
+        description: dns network Policy
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              appliedTo:
+                properties:
+                  namespaceSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  podSelector:
+                    description: allow ingress from the same namespace
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+              egress:
+                description: Set of egress rules evaluated based on the order in which they are set.
+                properties:
+                  toFqdn:
+                    properties:
+                      matchNames:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - matchNames
+                    type: object
+                required:
+                - toFqdn
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: qospolicies.aci.qos
+spec:
+  group: aci.qos
+  names:
+    kind: QosPolicy
+    listKind: QosPolicyList
+    plural: qospolicies
+    singular: qospolicy
+  scope: Namespaced
+  preserveUnknownFields: false
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              podSelector:
+                description: 'Selection of Pods'
+                type: object
+                properties:
+                  matchLabels:
+                    type: object
+                    description:
+              ingress:
+                type: object
+                properties:
+                  policing_rate:
+                    type: integer
+                    minimum: 0
+                  policing_burst:
+                    type: integer
+                    minimum: 0
+              egress:
+                type: object
+                properties:
+                  policing_rate:
+                    type: integer
+                    minimum: 0
+                  policing_burst:
+                    type: integer
+                    minimum: 0
+              dscpmark:
+                type: integer
+                default: 0
+                minimum: 0
+                maximum: 63
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: netflowpolicies.aci.netflow
+spec:
+  group: aci.netflow
+  names:
+    kind: NetflowPolicy
+    listKind: NetflowPolicyList
+    plural: netflowpolicies
+    singular: netflowpolicy
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+  - name: v1alpha
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              flowSamplingPolicy:
+                type: object
+                properties:
+                  destIp:
+                    type: string
+                  destPort:
+                    type: integer
+                    minimum: 0
+                    maximum: 65535
+                    default: 2055
+                  flowType:
+                    type: string
+                    enum:
+                      - netflow
+                      - ipfix
+                    default: netflow
+                  activeFlowTimeOut:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                    default: 60
+                  idleFlowTimeOut:
+                    type: integer
+                    minimum: 0
+                    maximum: 600
+                    default: 15
+                  samplingRate:
+                    type: integer
+                    minimum: 0
+                    maximum: 1000
+                    default: 0
+                required:
+                - destIp
+                type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: erspanpolicies.aci.erspan
+spec:
+  group: aci.erspan
+  names:
+    kind: ErspanPolicy
+    listKind: ErspanPolicyList
+    plural: erspanpolicies
+    singular: erspanpolicy
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+  - name: v1alpha
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              selector:
+                type: object
+                description: 'Selection of Pods'
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+                  namespace:
+                    type: string
+              source:
+                type: object
+                properties:
+                  adminState:
+                    description: Administrative state.
+                    default: start
+                    type: string
+                    enum:
+                      - start
+                      - stop
+                  direction:
+                    description: Direction of the packets to monitor.
+                    default: both
+                    type: string
+                    enum:
+                      - in
+                      - out
+                      - both
+              destination:
+                type: object
+                properties:
+                  destIP:
+                    description: Destination IP of the ERSPAN packet.
+                    type: string
+                  flowID:
+                    description: Unique flow ID of the ERSPAN packet.
+                    default: 1
+                    type: integer
+                    minimum: 1
+                    maximum: 1023
+                required:
+                - destIP
+                type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: enabledroplogs.aci.droplog
+spec:
+  group: aci.droplog
+  names:
+    kind: EnableDropLog
+    listKind: EnableDropLogList
+    plural: enabledroplogs
+    singular: enabledroplog
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            description: Defines the desired state of EnableDropLog
+            type: object
+            properties:
+              disableDefaultDropLog:
+                description: Disables the default droplog enabled by acc-provision.
+                default: false
+                type: boolean
+              nodeSelector:
+                type: object
+                description: Drop logging is enabled on nodes selected based on labels
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: prunedroplogs.aci.droplog
+spec:
+  group: aci.droplog
+  names:
+    kind: PruneDropLog
+    listKind: PruneDropLogList
+    plural: prunedroplogs
+    singular: prunedroplog
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            description: Defines the desired state of PruneDropLog
+            type: object
+            properties:
+              nodeSelector:
+                type: object
+                description: Drop logging filters are applied to nodes selected based on labels
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+              dropLogFilters:
+                type: object
+                properties:
+                  srcIP:
+                    type: string
+                  destIP:
+                    type: string
+                  srcMAC:
+                    type: string
+                  destMAC:
+                    type: string
+                  srcPort:
+                    type: integer
+                  destPort:
+                    type: integer
+                  ipProto:
+                    type: integer
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: aciistiooperators.aci.istio
+spec:
+  group: aci.istio
+  names:
+    kind: AciIstioOperator
+    listKind: AciIstioOperatorList
+    plural: aciistiooperators
+    singular: aciistiooperator
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AciIstioOperatorSpec defines the desired state of AciIstioOperator
+            properties:
+              config:
+                type: string
+              profile:
+                type: string
+            required:
+            - config
+            - profile
+            type: object
+          status:
+            description: AciIstioOperatorStatus defines the observed state of AciIstioOperator
+            properties:
+              Successful or Not:
+                type: boolean
+            required:
+            - Successful or Not
+            type: object
+        type: object
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aci-operator-config
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  spec: |-
+    {
+        "flavor": "kubernetes-1.22",
+        "config": "CmFwaVZlcnNpb246IHYxCmtpbmQ6IE5hbWVzcGFjZQptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogIGFubm90YXRpb25zOgogICAgb3BlbnNoaWZ0LmlvL25vZGUtc2VsZWN0b3I6ICcnCi0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogcG9kaWZzLmFjaS5hdwpzcGVjOgogIGdyb3VwOiBhY2kuYXcKICBuYW1lczoKICAgIGtpbmQ6IFBvZElGCiAgICBsaXN0S2luZDogUG9kSUZMaXN0CiAgICBwbHVyYWw6IHBvZGlmcwogICAgc2luZ3VsYXI6IHBvZGlmCiAgc2NvcGU6IE5hbWVzcGFjZWQKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIGRlc2NyaXB0aW9uOiBQb2RJRiBkZXNjcmliZXMgYSBwb2QgbmV0d29yayBpbnRlcmZhY2UKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHN0YXR1czoKICAgICAgICAgICAgZGVzY3JpcHRpb246IFBvZElGU3RhdHVzIGlzIHRoZSBzdGF0dXMgb2YgYSBQb2RJRgogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIGNvbnRhaW5lcklEOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgZXBnOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgaWZuYW1lOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgaXBhZGRyOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgbWFjYWRkcjoKICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgIHBvZG5hbWU6CiAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICBwb2RuczoKICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgIHZ0ZXA6CiAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgLSBzdGF0dXMKICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBzbmF0Z2xvYmFsaW5mb3MuYWNpLnNuYXQKc3BlYzoKICBncm91cDogYWNpLnNuYXQKICBuYW1lczoKICAgIGtpbmQ6IFNuYXRHbG9iYWxJbmZvCiAgICBsaXN0S2luZDogU25hdEdsb2JhbEluZm9MaXN0CiAgICBwbHVyYWw6IHNuYXRnbG9iYWxpbmZvcwogICAgc2luZ3VsYXI6IHNuYXRnbG9iYWxpbmZvCiAgc2NvcGU6IE5hbWVzcGFjZWQKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIGRlc2NyaXB0aW9uOiBTbmF0R2xvYmFsSW5mbyBpcyB0aGUgU2NoZW1hIGZvciB0aGUgc25hdGdsb2JhbGluZm9zIEFQSQogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgbWV0YWRhdGE6CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBnbG9iYWxJbmZvczoKICAgICAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgbWFjQWRkcmVzczoKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICBwb3J0UmFuZ2VzOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZW5kOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXhpbXVtOiA2NTUzNQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAxCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHN0YXJ0OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXhpbXVtOiA2NTUzNQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAxCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgIHNuYXRJcDoKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICBzbmF0SXBVaWQ6CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgc25hdFBvbGljeU5hbWU6CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgIC0gbWFjQWRkcmVzcwogICAgICAgICAgICAgICAgICAgIC0gcG9ydFJhbmdlcwogICAgICAgICAgICAgICAgICAgIC0gc25hdElwCiAgICAgICAgICAgICAgICAgICAgLSBzbmF0SXBVaWQKICAgICAgICAgICAgICAgICAgICAtIHNuYXRQb2xpY3lOYW1lCiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgIC0gZ2xvYmFsSW5mb3MKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzdGF0dXM6CiAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTbmF0R2xvYmFsSW5mb1N0YXR1cyBkZWZpbmVzIHRoZSBvYnNlcnZlZCBzdGF0ZSBvZiBTbmF0R2xvYmFsSW5mbwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBzbmF0bG9jYWxpbmZvcy5hY2kuc25hdApzcGVjOgogIGdyb3VwOiBhY2kuc25hdAogIG5hbWVzOgogICAga2luZDogU25hdExvY2FsSW5mbwogICAgbGlzdEtpbmQ6IFNuYXRMb2NhbEluZm9MaXN0CiAgICBwbHVyYWw6IHNuYXRsb2NhbGluZm9zCiAgICBzaW5ndWxhcjogc25hdGxvY2FsaW5mbwogIHNjb3BlOiBOYW1lc3BhY2VkCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTbmF0TG9jYWxJbmZvU3BlYyBkZWZpbmVzIHRoZSBkZXNpcmVkIHN0YXRlIG9mIFNuYXRMb2NhbEluZm8KICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBsb2NhbEluZm9zOgogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgcG9kTmFtZToKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIHBvZE5hbWVzcGFjZToKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIHBvZFVpZDoKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIHNuYXRQb2xpY2llczoKICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGRlc3RJcDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgbmFtZToKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgIHNuYXRJcDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgLSBkZXN0SXAKICAgICAgICAgICAgICAgICAgICAgICAgLSBuYW1lCiAgICAgICAgICAgICAgICAgICAgICAgIC0gc25hdElwCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgIC0gcG9kTmFtZQogICAgICAgICAgICAgICAgICAtIHBvZE5hbWVzcGFjZQogICAgICAgICAgICAgICAgICAtIHBvZFVpZAogICAgICAgICAgICAgICAgICAtIHNuYXRQb2xpY2llcwogICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAtIGxvY2FsSW5mb3MKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgdHlwZTogb2JqZWN0Ci0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogc25hdHBvbGljaWVzLmFjaS5zbmF0CnNwZWM6CiAgZ3JvdXA6IGFjaS5zbmF0CiAgbmFtZXM6CiAgICBraW5kOiBTbmF0UG9saWN5CiAgICBsaXN0S2luZDogU25hdFBvbGljeUxpc3QKICAgIHBsdXJhbDogc25hdHBvbGljaWVzCiAgICBzaW5ndWxhcjogc25hdHBvbGljeQogIHNjb3BlOiBDbHVzdGVyCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzdWJyZXNvdXJjZXM6CiAgICAgIHN0YXR1czoge30KICAgIHNjaGVtYToKICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgbWV0YWRhdGE6CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgc2VsZWN0b3I6CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIGxhYmVsczoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogJ1NlbGVjdGlvbiBvZiBQb2RzJwogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgbmFtZXNwYWNlOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgc25hdElwOgogICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICBkZXN0SXA6CiAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHN0YXR1czoKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgIHR5cGU6IHN0cmluZwotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IG5vZGVpbmZvcy5hY2kuc25hdApzcGVjOgogIGdyb3VwOiBhY2kuc25hdAogIG5hbWVzOgogICAga2luZDogTm9kZUluZm8KICAgIGxpc3RLaW5kOiBOb2RlSW5mb0xpc3QKICAgIHBsdXJhbDogbm9kZWluZm9zCiAgICBzaW5ndWxhcjogbm9kZWluZm8KICBzY29wZTogTmFtZXNwYWNlZAogIHZlcnNpb25zOgogIC0gbmFtZTogdjEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIG1hY2FkZHJlc3M6CiAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICBzbmF0cG9saWN5bmFtZXM6CiAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgdHlwZTogYm9vbGVhbgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3RhdHVzOgogICAgICAgICAgICBkZXNjcmlwdGlvbjogTm9kZWluZm9TdGF0dXMgZGVmaW5lcyB0aGUgb2JzZXJ2ZWQgc3RhdGUgb2YgTm9kZWluZm8KICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgdHlwZTogb2JqZWN0Ci0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogcmRjb25maWdzLmFjaS5zbmF0CnNwZWM6CiAgZ3JvdXA6IGFjaS5zbmF0CiAgbmFtZXM6CiAgICBraW5kOiBSZENvbmZpZwogICAgbGlzdEtpbmQ6IFJkQ29uZmlnTGlzdAogICAgcGx1cmFsOiByZGNvbmZpZ3MKICAgIHNpbmd1bGFyOiByZGNvbmZpZwogIHNjb3BlOiBOYW1lc3BhY2VkCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgZGlzY292ZXJlZHN1Ym5ldHM6CiAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgIHVzZXJzdWJuZXRzOgogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgIC0gdXNlcnN1Ym5ldHMKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzdGF0dXM6CiAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBOb2RlaW5mb1N0YXR1cyBkZWZpbmVzIHRoZSBvYnNlcnZlZCBzdGF0ZSBvZiBOb2RlaW5mbwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBuZXR3b3JrcG9saWNpZXMuYWNpLm5ldHBvbApzcGVjOgogIGdyb3VwOiBhY2kubmV0cG9sCiAgbmFtZXM6CiAgICBraW5kOiBOZXR3b3JrUG9saWN5CiAgICBsaXN0S2luZDogTmV0d29ya1BvbGljeUxpc3QKICAgIHBsdXJhbDogbmV0d29ya3BvbGljaWVzCiAgICBzaW5ndWxhcjogbmV0d29ya3BvbGljeQogIHNjb3BlOiBOYW1lc3BhY2VkCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgZGVzY3JpcHRpb246IE5ldHdvcmsgUG9saWN5IGRlc2NyaWJlcyB0cmFmZmljIGZsb3cgYXQgSVAgYWRkcmVzcyBvciBwb3J0IGxldmVsCiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIGFwcGxpZWRUbzoKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIG5hbWVzcGFjZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICBwb2RTZWxlY3RvcjoKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogYWxsb3cgaW5ncmVzcyBmcm9tIHRoZSBzYW1lIG5hbWVzcGFjZQogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgZWdyZXNzOgogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNldCBvZiBlZ3Jlc3MgcnVsZXMgZXZhbHVhdGVkIGJhc2VkIG9uIHRoZSBvcmRlciBpbiB3aGljaCB0aGV5IGFyZSBzZXQuCiAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICBhY3Rpb246CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogQWN0aW9uIHNwZWNpZmllcyB0aGUgYWN0aW9uIHRvIGJlIGFwcGxpZWQgb24gdGhlIHJ1bGUuCiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICBlbmFibGVMb2dnaW5nOgogICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEVuYWJsZUxvZ2dpbmcgaXMgdXNlZCB0byBpbmRpY2F0ZSBpZiBhZ2VudCBzaG91bGQgZ2VuZXJhdGUgbG9ncyBkZWZhdWx0IHRvIGZhbHNlLgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYm9vbGVhbgogICAgICAgICAgICAgICAgICAgIHBvcnRzOgogICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNldCBvZiBwb3J0IGFuZCBwcm90b2NvbCBhbGxvd2VkL2RlbmllZCBieSB0aGUgcnVsZS4gSWYgdGhpcyBmaWVsZCBpcyB1bnNldCBvciBlbXB0eSwgdGhpcyBydWxlIG1hdGNoZXMgYWxsIHBvcnRzLgogICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBOZXR3b3JrUG9saWN5UG9ydCBkZXNjcmliZXMgdGhlIHBvcnQgYW5kIHByb3RvY29sIHRvIG1hdGNoIGluIGEgcnVsZS4KICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICBlbmRQb3J0OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEVuZFBvcnQgZGVmaW5lcyB0aGUgZW5kIG9mIHRoZSBwb3J0IHJhbmdlLCBiZWluZyB0aGUgZW5kIGluY2x1ZGVkIHdpdGhpbiB0aGUgcmFuZ2UuIEl0IGNhbiBvbmx5IGJlIHNwZWNpZmllZCB3aGVuIGEgbnVtZXJpY2FsIGBwb3J0YCBpcyBzcGVjaWZpZWQuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBmb3JtYXQ6IGludDMyCiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgICAgICAgcG9ydDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGFueU9mOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgLSB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFRoZSBwb3J0IG9uIHRoZSBnaXZlbiBwcm90b2NvbC4gVGhpcyBjYW4gYmUgZWl0aGVyIGEgbnVtZXJpY2FsIG9yIG5hbWVkIHBvcnQgb24gYSBQb2QuIElmIHRoaXMgZmllbGQgaXMgbm90IHByb3ZpZGVkLCB0aGlzIG1hdGNoZXMgYWxsIHBvcnQgbmFtZXMgYW5kIG51bWJlcnMuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICB4LWt1YmVybmV0ZXMtaW50LW9yLXN0cmluZzogdHJ1ZQogICAgICAgICAgICAgICAgICAgICAgICAgIHByb3RvY29sOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVmYXVsdDogVENQCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogVGhlIHByb3RvY29sIChUQ1AsIFVEUCwgb3IgU0NUUCkgd2hpY2ggdHJhZmZpYyBtdXN0IG1hdGNoLiBJZiBub3Qgc3BlY2lmaWVkLCB0aGlzIGZpZWxkIGRlZmF1bHRzIHRvIFRDUC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgdG86CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogUnVsZSBpcyBtYXRjaGVkIGlmIHRyYWZmaWMgaXMgaW50ZW5kZWQgZm9yIHdvcmtsb2FkcyBzZWxlY3RlZCBieSB0aGlzIGZpZWxkLiBJZiB0aGlzIGZpZWxkIGlzIGVtcHR5IG9yIG1pc3NpbmcsIHRoaXMgcnVsZSBtYXRjaGVzIGFsbCBkZXN0aW5hdGlvbnMuCiAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICBpcEJsb2NrOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IElQQmxvY2sgZGVzY3JpYmVzIHRoZSBJUEFkZHJlc3Nlcy9JUEJsb2NrcyB0aGF0IGlzIG1hdGNoZWQgaW4gdG8vZnJvbS4gSVBCbG9jayBjYW5ub3QgYmUgc2V0IGFzIHBhcnQgb2YgdGhlIEFwcGxpZWRUbyBmaWVsZC4gQ2Fubm90IGJlIHNldCB3aXRoIGFueSBvdGhlciBzZWxlY3Rvci4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNpZHI6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IENJRFIgaXMgYSBzdHJpbmcgcmVwcmVzZW50aW5nIHRoZSBJUCBCbG9jayBWYWxpZCBleGFtcGxlcyBhcmUgIjE5Mi4xNjguMS4xLzI0IiBvciAiMjAwMTpkYjk6Oi82NCIKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZXhjZXB0OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBFeGNlcHQgaXMgYSBzbGljZSBvZiBDSURScyB0aGF0IHNob3VsZCBub3QgYmUgaW5jbHVkZWQgd2l0aGluIGFuIElQIEJsb2NrIFZhbGlkIGV4YW1wbGVzIGFyZSAiMTkyLjE2OC4xLjEvMjQiIG9yICIyMDAxOmRiOTo6LzY0IiBFeGNlcHQgdmFsdWVzIHdpbGwgYmUgcmVqZWN0ZWQgaWYgdGhleSBhcmUgb3V0c2lkZSB0aGUgQ0lEUiByYW5nZQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgLSBjaWRyCiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICBuYW1lc3BhY2VTZWxlY3RvcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTZWxlY3QgYWxsIFBvZHMgZnJvbSBOYW1lc3BhY2VzIG1hdGNoZWQgYnkgdGhpcyBzZWxlY3RvciwgYXMgd29ya2xvYWRzIGluIFRvL0Zyb20gZmllbGRzLiBJZiBzZXQgd2l0aCBQb2RTZWxlY3RvciwgUG9kcyBhcmUgbWF0Y2hlZCBmcm9tIE5hbWVzcGFjZXMgbWF0Y2hlZCBieSB0aGUgTmFtZXNwYWNlU2VsZWN0b3IuIENhbm5vdCBiZSBzZXQgd2l0aCBhbnkgb3RoZXIgc2VsZWN0b3IgZXhjZXB0IFBvZFNlbGVjdG9yIG9yIEV4dGVybmFsRW50aXR5U2VsZWN0b3IuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBvcGVyYXRvcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogb3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuIFZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFsdWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiB2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0ga2V5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgICAgcG9kU2VsZWN0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogU2VsZWN0IFBvZHMgZnJvbSBOZXR3b3JrUG9saWN5J3MgTmFtZXNwYWNlIGFzIHdvcmtsb2FkcyBpbiBBcHBsaWVkVG8vVG8vRnJvbSBmaWVsZHMuIElmIHNldCB3aXRoIE5hbWVzcGFjZVNlbGVjdG9yLCBQb2RzIGFyZSBtYXRjaGVkIGZyb20gTmFtZXNwYWNlcyBtYXRjaGVkIGJ5IHRoZSBOYW1lc3BhY2VTZWxlY3Rvci4gQ2Fubm90IGJlIHNldCB3aXRoIGFueSBvdGhlciBzZWxlY3RvciBleGNlcHQgTmFtZXNwYWNlU2VsZWN0b3IuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBvcGVyYXRvcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogb3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuIFZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFsdWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiB2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0ga2V5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICB0b0ZxRG46CiAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICBtYXRjaE5hbWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgICAgLSBtYXRjaE5hbWVzCiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgIC0gZW5hYmxlTG9nZ2luZwogICAgICAgICAgICAgICAgICAtIHRvRnFEbgogICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgaW5ncmVzczoKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTZXQgb2YgaW5ncmVzcyBydWxlcyBldmFsdWF0ZWQgYmFzZWQgb24gdGhlIG9yZGVyIGluIHdoaWNoIHRoZXkgYXJlIHNldC4KICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgIGFjdGlvbjoKICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBBY3Rpb24gc3BlY2lmaWVzIHRoZSBhY3Rpb24gdG8gYmUgYXBwbGllZCBvbiB0aGUgcnVsZS4KICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIGVuYWJsZUxvZ2dpbmc6CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRW5hYmxlTG9nZ2luZyBpcyB1c2VkIHRvIGluZGljYXRlIGlmIGFnZW50IHNob3VsZCBnZW5lcmF0ZSBsb2dzIHdoZW4gcnVsZXMgYXJlIG1hdGNoZWQuIFNob3VsZCBiZSBkZWZhdWx0IHRvIGZhbHNlLgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYm9vbGVhbgogICAgICAgICAgICAgICAgICAgIGZyb206CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogUnVsZSBpcyBtYXRjaGVkIGlmIHRyYWZmaWMgb3JpZ2luYXRlcyBmcm9tIHdvcmtsb2FkcyBzZWxlY3RlZCBieSB0aGlzIGZpZWxkLiBJZiB0aGlzIGZpZWxkIGlzIGVtcHR5LCB0aGlzIHJ1bGUgbWF0Y2hlcyBhbGwgc291cmNlcy4KICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGlwQmxvY2s6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogSVBCbG9jayBkZXNjcmliZXMgdGhlIElQQWRkcmVzc2VzL0lQQmxvY2tzIHRoYXQgaXMgbWF0Y2hlZCBpbiB0by9mcm9tLiBJUEJsb2NrIGNhbm5vdCBiZSBzZXQgYXMgcGFydCBvZiB0aGUgQXBwbGllZFRvIGZpZWxkLiBDYW5ub3QgYmUgc2V0IHdpdGggYW55IG90aGVyIHNlbGVjdG9yLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgY2lkcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogQ0lEUiBpcyBhIHN0cmluZyByZXByZXNlbnRpbmcgdGhlIElQIEJsb2NrIFZhbGlkIGV4YW1wbGVzIGFyZSAiMTkyLjE2OC4xLjEvMjQiIG9yICIyMDAxOmRiOTo6LzY0IgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBleGNlcHQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEV4Y2VwdCBpcyBhIHNsaWNlIG9mIENJRFJzIHRoYXQgc2hvdWxkIG5vdCBiZSBpbmNsdWRlZCB3aXRoaW4gYW4gSVAgQmxvY2sgVmFsaWQgZXhhbXBsZXMgYXJlICIxOTIuMTY4LjEuMS8yNCIgb3IgIjIwMDE6ZGI5OjovNjQiIEV4Y2VwdCB2YWx1ZXMgd2lsbCBiZSByZWplY3RlZCBpZiB0aGV5IGFyZSBvdXRzaWRlIHRoZSBDSURSIHJhbmdlCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIGNpZHIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgIG5hbWVzcGFjZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbWF0Y2hFeHByZXNzaW9uczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGtleToKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgb3BlcmF0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IG9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLiBWYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogdmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbiwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsIHRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIGtleQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgLSBvcGVyYXRvcgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbWF0Y2hMYWJlbHM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgIHBvZFNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNlbGVjdCBQb2RzIGZyb20gTmV0d29ya1BvbGljeSdzIE5hbWVzcGFjZSBhcyB3b3JrbG9hZHMgaW4gQXBwbGllZFRvL1RvL0Zyb20gZmllbGRzLiBJZiBzZXQgd2l0aCBOYW1lc3BhY2VTZWxlY3RvciwgUG9kcyBhcmUgbWF0Y2hlZCBmcm9tIE5hbWVzcGFjZXMgbWF0Y2hlZCBieSB0aGUgTmFtZXNwYWNlU2VsZWN0b3IuIENhbm5vdCBiZSBzZXQgd2l0aCBhbnkgb3RoZXIgc2VsZWN0b3IgZXhjZXB0IE5hbWVzcGFjZVNlbGVjdG9yLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbWF0Y2hFeHByZXNzaW9uczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogbWF0Y2hFeHByZXNzaW9ucyBpcyBhIGxpc3Qgb2YgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnRzLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGtleToKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgb3BlcmF0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IG9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLiBWYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogdmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbiwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsIHRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIGtleQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgLSBvcGVyYXRvcgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbWF0Y2hMYWJlbHM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgcG9ydHM6CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogU2V0IG9mIHBvcnQgYW5kIHByb3RvY29sIGFsbG93ZWQvZGVuaWVkIGJ5IHRoZSBydWxlLiBJZiB0aGlzIGZpZWxkIGlzIHVuc2V0IG9yIGVtcHR5LCB0aGlzIHJ1bGUgbWF0Y2hlcyBhbGwgcG9ydHMuCiAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IE5ldHdvcmtQb2xpY3lQb3J0IGRlc2NyaWJlcyB0aGUgcG9ydCBhbmQgcHJvdG9jb2wgdG8gbWF0Y2ggaW4gYSBydWxlLgogICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGVuZFBvcnQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRW5kUG9ydCBkZWZpbmVzIHRoZSBlbmQgb2YgdGhlIHBvcnQgcmFuZ2UsIGJlaW5nIHRoZSBlbmQgaW5jbHVkZWQgd2l0aGluIHRoZSByYW5nZS4gSXQgY2FuIG9ubHkgYmUgc3BlY2lmaWVkIHdoZW4gYSBudW1lcmljYWwgYHBvcnRgIGlzIHNwZWNpZmllZC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIGZvcm1hdDogaW50MzIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICBwb3J0OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgYW55T2Y6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0gdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogVGhlIHBvcnQgb24gdGhlIGdpdmVuIHByb3RvY29sLiBUaGlzIGNhbiBiZSBlaXRoZXIgYSBudW1lcmljYWwgb3IgbmFtZWQgcG9ydCBvbiBhIFBvZC4gSWYgdGhpcyBmaWVsZCBpcyBub3QgcHJvdmlkZWQsIHRoaXMgbWF0Y2hlcyBhbGwgcG9ydCBuYW1lcyBhbmQgbnVtYmVycy4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIHgta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nOiB0cnVlCiAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvdG9jb2w6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZWZhdWx0OiBUQ1AKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBUaGUgcHJvdG9jb2wgKFRDUCwgVURQLCBvciBTQ1RQKSB3aGljaCB0cmFmZmljIG11c3QgbWF0Y2guIElmIG5vdCBzcGVjaWZpZWQsIHRoaXMgZmllbGQgZGVmYXVsdHMgdG8gVENQLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgIHBvbGljeVR5cGVzOgogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBQb2xpY3kgVHlwZSBzdHJpbmcgZGVzY3JpYmVzIHRoZSBOZXR3b3JrUG9saWN5IHR5cGUgVGhpcyB0eXBlIGlzIGJldGEtbGV2ZWwgaW4gMS44CiAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICBwcmlvcml0eToKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBQcmlvcml0eSBzcGVjZmllcyB0aGUgb3JkZXIgb2YgdGhlIE5ldHdvcmtQb2xpY3kgcmVsYXRpdmUgdG8gb3RoZXIgTmV0d29ya1BvbGljaWVzLgogICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgIHR5cGU6CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogdHlwZSBvZiB0aGUgcG9saWN5LgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAtIHR5cGUKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgLSBzcGVjCiAgICAgICAgdHlwZTogb2JqZWN0CiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKc3RhdHVzOgogIGFjY2VwdGVkTmFtZXM6CiAgICBraW5kOiAiIgogICAgcGx1cmFsOiAiIgogIGNvbmRpdGlvbnM6IFtdCiAgc3RvcmVkVmVyc2lvbnM6IFtdCi0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogZG5zbmV0d29ya3BvbGljaWVzLmFjaS5kbnNuZXRwb2wKc3BlYzoKICBncm91cDogYWNpLmRuc25ldHBvbAogIG5hbWVzOgogICAga2luZDogRG5zTmV0d29ya1BvbGljeQogICAgbGlzdEtpbmQ6IERuc05ldHdvcmtQb2xpY3lMaXN0CiAgICBwbHVyYWw6IGRuc25ldHdvcmtwb2xpY2llcwogICAgc2luZ3VsYXI6IGRuc25ldHdvcmtwb2xpY3kKICBzY29wZTogTmFtZXNwYWNlZAogIHZlcnNpb25zOgogIC0gbmFtZTogdjFiZXRhCiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICBkZXNjcmlwdGlvbjogZG5zIG5ldHdvcmsgUG9saWN5CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIGFwcGxpZWRUbzoKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIG5hbWVzcGFjZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICBwb2RTZWxlY3RvcjoKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogYWxsb3cgaW5ncmVzcyBmcm9tIHRoZSBzYW1lIG5hbWVzcGFjZQogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogb3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuIFZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YWx1ZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiB2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgZWdyZXNzOgogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNldCBvZiBlZ3Jlc3MgcnVsZXMgZXZhbHVhdGVkIGJhc2VkIG9uIHRoZSBvcmRlciBpbiB3aGljaCB0aGV5IGFyZSBzZXQuCiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICB0b0ZxZG46CiAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgIG1hdGNoTmFtZXM6CiAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgIC0gbWF0Y2hOYW1lcwogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAtIHRvRnFkbgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHJlcXVpcmVkOgogICAgICAgIC0gc3BlYwogICAgICAgIHR5cGU6IG9iamVjdAogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCnN0YXR1czoKICBhY2NlcHRlZE5hbWVzOgogICAga2luZDogIiIKICAgIHBsdXJhbDogIiIKICBjb25kaXRpb25zOiBbXQogIHN0b3JlZFZlcnNpb25zOiBbXQotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IHFvc3BvbGljaWVzLmFjaS5xb3MKc3BlYzoKICBncm91cDogYWNpLnFvcwogIG5hbWVzOgogICAga2luZDogUW9zUG9saWN5CiAgICBsaXN0S2luZDogUW9zUG9saWN5TGlzdAogICAgcGx1cmFsOiBxb3Nwb2xpY2llcwogICAgc2luZ3VsYXI6IHFvc3BvbGljeQogIHNjb3BlOiBOYW1lc3BhY2VkCiAgcHJlc2VydmVVbmtub3duRmllbGRzOiBmYWxzZQogIHZlcnNpb25zOgogIC0gbmFtZTogdjEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc3VicmVzb3VyY2VzOgogICAgICBzdGF0dXM6IHt9CiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIHBvZFNlbGVjdG9yOgogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246ICdTZWxlY3Rpb24gb2YgUG9kcycKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgbWF0Y2hMYWJlbHM6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246CiAgICAgICAgICAgICAgaW5ncmVzczoKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgcG9saWNpbmdfcmF0ZToKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgICBwb2xpY2luZ19idXJzdDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgIGVncmVzczoKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgcG9saWNpbmdfcmF0ZToKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgICBwb2xpY2luZ19idXJzdDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgIGRzY3BtYXJrOgogICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgICAgZGVmYXVsdDogMAogICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgbWF4aW11bTogNjMKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBuZXRmbG93cG9saWNpZXMuYWNpLm5ldGZsb3cKc3BlYzoKICBncm91cDogYWNpLm5ldGZsb3cKICBuYW1lczoKICAgIGtpbmQ6IE5ldGZsb3dQb2xpY3kKICAgIGxpc3RLaW5kOiBOZXRmbG93UG9saWN5TGlzdAogICAgcGx1cmFsOiBuZXRmbG93cG9saWNpZXMKICAgIHNpbmd1bGFyOiBuZXRmbG93cG9saWN5CiAgc2NvcGU6IENsdXN0ZXIKICBwcmVzZXJ2ZVVua25vd25GaWVsZHM6IGZhbHNlCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MWFscGhhCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgIyBvcGVuQVBJVjNTY2hlbWEgaXMgdGhlIHNjaGVtYSBmb3IgdmFsaWRhdGluZyBjdXN0b20gb2JqZWN0cy4KICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgZmxvd1NhbXBsaW5nUG9saWN5OgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBkZXN0SXA6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIGRlc3RQb3J0OgogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAwCiAgICAgICAgICAgICAgICAgICAgbWF4aW11bTogNjU1MzUKICAgICAgICAgICAgICAgICAgICBkZWZhdWx0OiAyMDU1CiAgICAgICAgICAgICAgICAgIGZsb3dUeXBlOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIGVudW06CiAgICAgICAgICAgICAgICAgICAgICAtIG5ldGZsb3cKICAgICAgICAgICAgICAgICAgICAgIC0gaXBmaXgKICAgICAgICAgICAgICAgICAgICBkZWZhdWx0OiBuZXRmbG93CiAgICAgICAgICAgICAgICAgIGFjdGl2ZUZsb3dUaW1lT3V0OgogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAwCiAgICAgICAgICAgICAgICAgICAgbWF4aW11bTogMzYwMAogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IDYwCiAgICAgICAgICAgICAgICAgIGlkbGVGbG93VGltZU91dDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgICAgIG1heGltdW06IDYwMAogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IDE1CiAgICAgICAgICAgICAgICAgIHNhbXBsaW5nUmF0ZToKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgICAgIG1heGltdW06IDEwMDAKICAgICAgICAgICAgICAgICAgICBkZWZhdWx0OiAwCiAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgIC0gZGVzdElwCiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBlcnNwYW5wb2xpY2llcy5hY2kuZXJzcGFuCnNwZWM6CiAgZ3JvdXA6IGFjaS5lcnNwYW4KICBuYW1lczoKICAgIGtpbmQ6IEVyc3BhblBvbGljeQogICAgbGlzdEtpbmQ6IEVyc3BhblBvbGljeUxpc3QKICAgIHBsdXJhbDogZXJzcGFucG9saWNpZXMKICAgIHNpbmd1bGFyOiBlcnNwYW5wb2xpY3kKICBzY29wZTogQ2x1c3RlcgogIHByZXNlcnZlVW5rbm93bkZpZWxkczogZmFsc2UKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxYWxwaGEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBzcGVjOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBzZWxlY3RvcjoKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246ICdTZWxlY3Rpb24gb2YgUG9kcycKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIGxhYmVsczoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIG5hbWVzcGFjZToKICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICBzb3VyY2U6CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIGFkbWluU3RhdGU6CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEFkbWluaXN0cmF0aXZlIHN0YXRlLgogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IHN0YXJ0CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgZW51bToKICAgICAgICAgICAgICAgICAgICAgIC0gc3RhcnQKICAgICAgICAgICAgICAgICAgICAgIC0gc3RvcAogICAgICAgICAgICAgICAgICBkaXJlY3Rpb246CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IERpcmVjdGlvbiBvZiB0aGUgcGFja2V0cyB0byBtb25pdG9yLgogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IGJvdGgKICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICBlbnVtOgogICAgICAgICAgICAgICAgICAgICAgLSBpbgogICAgICAgICAgICAgICAgICAgICAgLSBvdXQKICAgICAgICAgICAgICAgICAgICAgIC0gYm90aAogICAgICAgICAgICAgIGRlc3RpbmF0aW9uOgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBkZXN0SVA6CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IERlc3RpbmF0aW9uIElQIG9mIHRoZSBFUlNQQU4gcGFja2V0LgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICBmbG93SUQ6CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFVuaXF1ZSBmbG93IElEIG9mIHRoZSBFUlNQQU4gcGFja2V0LgogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IDEKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMQogICAgICAgICAgICAgICAgICAgIG1heGltdW06IDEwMjMKICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgLSBkZXN0SVAKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IGVuYWJsZWRyb3Bsb2dzLmFjaS5kcm9wbG9nCnNwZWM6CiAgZ3JvdXA6IGFjaS5kcm9wbG9nCiAgbmFtZXM6CiAgICBraW5kOiBFbmFibGVEcm9wTG9nCiAgICBsaXN0S2luZDogRW5hYmxlRHJvcExvZ0xpc3QKICAgIHBsdXJhbDogZW5hYmxlZHJvcGxvZ3MKICAgIHNpbmd1bGFyOiBlbmFibGVkcm9wbG9nCiAgc2NvcGU6IENsdXN0ZXIKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxYWxwaGExCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgIyBvcGVuQVBJVjNTY2hlbWEgaXMgdGhlIHNjaGVtYSBmb3IgdmFsaWRhdGluZyBjdXN0b20gb2JqZWN0cy4KICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgZGVzY3JpcHRpb246IERlZmluZXMgdGhlIGRlc2lyZWQgc3RhdGUgb2YgRW5hYmxlRHJvcExvZwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBkaXNhYmxlRGVmYXVsdERyb3BMb2c6CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRGlzYWJsZXMgdGhlIGRlZmF1bHQgZHJvcGxvZyBlbmFibGVkIGJ5IGFjYy1wcm92aXNpb24uCiAgICAgICAgICAgICAgICBkZWZhdWx0OiBmYWxzZQogICAgICAgICAgICAgICAgdHlwZTogYm9vbGVhbgogICAgICAgICAgICAgIG5vZGVTZWxlY3RvcjoKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IERyb3AgbG9nZ2luZyBpcyBlbmFibGVkIG9uIG5vZGVzIHNlbGVjdGVkIGJhc2VkIG9uIGxhYmVscwogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgbGFiZWxzOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBwcnVuZWRyb3Bsb2dzLmFjaS5kcm9wbG9nCnNwZWM6CiAgZ3JvdXA6IGFjaS5kcm9wbG9nCiAgbmFtZXM6CiAgICBraW5kOiBQcnVuZURyb3BMb2cKICAgIGxpc3RLaW5kOiBQcnVuZURyb3BMb2dMaXN0CiAgICBwbHVyYWw6IHBydW5lZHJvcGxvZ3MKICAgIHNpbmd1bGFyOiBwcnVuZWRyb3Bsb2cKICBzY29wZTogQ2x1c3RlcgogIHZlcnNpb25zOgogIC0gbmFtZTogdjFhbHBoYTEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAjIG9wZW5BUElWM1NjaGVtYSBpcyB0aGUgc2NoZW1hIGZvciB2YWxpZGF0aW5nIGN1c3RvbSBvYmplY3RzLgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBkZXNjcmlwdGlvbjogRGVmaW5lcyB0aGUgZGVzaXJlZCBzdGF0ZSBvZiBQcnVuZURyb3BMb2cKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgbm9kZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRHJvcCBsb2dnaW5nIGZpbHRlcnMgYXJlIGFwcGxpZWQgdG8gbm9kZXMgc2VsZWN0ZWQgYmFzZWQgb24gbGFiZWxzCiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBsYWJlbHM6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgIGRyb3BMb2dGaWx0ZXJzOgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBzcmNJUDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgZGVzdElQOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICBzcmNNQUM6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIGRlc3RNQUM6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIHNyY1BvcnQ6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgICAgICBkZXN0UG9ydDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgIGlwUHJvdG86CiAgICAgICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IGFjaWlzdGlvb3BlcmF0b3JzLmFjaS5pc3RpbwpzcGVjOgogIGdyb3VwOiBhY2kuaXN0aW8KICBuYW1lczoKICAgIGtpbmQ6IEFjaUlzdGlvT3BlcmF0b3IKICAgIGxpc3RLaW5kOiBBY2lJc3Rpb09wZXJhdG9yTGlzdAogICAgcGx1cmFsOiBhY2lpc3Rpb29wZXJhdG9ycwogICAgc2luZ3VsYXI6IGFjaWlzdGlvb3BlcmF0b3IKICBzY29wZTogTmFtZXNwYWNlZAogIHZlcnNpb25zOgogIC0gbmFtZTogdjEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBkZXNjcmlwdGlvbjogQWNpSXN0aW9PcGVyYXRvclNwZWMgZGVmaW5lcyB0aGUgZGVzaXJlZCBzdGF0ZSBvZiBBY2lJc3Rpb09wZXJhdG9yCiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgY29uZmlnOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgcHJvZmlsZToKICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgLSBjb25maWcKICAgICAgICAgICAgLSBwcm9maWxlCiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3RhdHVzOgogICAgICAgICAgICBkZXNjcmlwdGlvbjogQWNpSXN0aW9PcGVyYXRvclN0YXR1cyBkZWZpbmVzIHRoZSBvYnNlcnZlZCBzdGF0ZSBvZiBBY2lJc3Rpb09wZXJhdG9yCiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgU3VjY2Vzc2Z1bCBvciBOb3Q6CiAgICAgICAgICAgICAgICB0eXBlOiBib29sZWFuCiAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAtIFN1Y2Nlc3NmdWwgb3IgTm90CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHR5cGU6IG9iamVjdAotLS0KYXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnTWFwCm1ldGFkYXRhOgogIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbmZpZwogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCmRhdGE6CiAgY29udHJvbGxlci1jb25maWc6IHwtCiAgICB7CiAgICAgICAgImZsYXZvciI6ICJrdWJlcm5ldGVzLTEuMjIiLAogICAgICAgICJsb2ctbGV2ZWwiOiAiaW5mbyIsCiAgICAgICAgImFwaWMtaG9zdHMiOiBbCiAgICAgICAgICAgICIxMC4zMC4xMjAuMTAwIgogICAgICAgIF0sCiAgICAgICAgImFwaWMtdXNlcm5hbWUiOiAia3ViZSIsCiAgICAgICAgImFwaWMtcHJpdmF0ZS1rZXktcGF0aCI6ICIvdXNyL2xvY2FsL2V0Yy9hY2ktY2VydC91c2VyLmtleSIsCiAgICAgICAgImFjaS1wcmVmaXgiOiAia3ViZSIsCiAgICAgICAgImFjaS12bW0tdHlwZSI6ICJLdWJlcm5ldGVzIiwKICAgICAgICAiYWNpLXZtbS1kb21haW4iOiAia3ViZSIsCiAgICAgICAgImFjaS12bW0tY29udHJvbGxlciI6ICJrdWJlIiwKICAgICAgICAiYWNpLXBvbGljeS10ZW5hbnQiOiAia3ViZSIsCiAgICAgICAgImluc3RhbGwtaXN0aW8iOiB0cnVlLAogICAgICAgICJpc3Rpby1wcm9maWxlIjogImRlbW8iLAogICAgICAgICJhY2ktcG9kYmQtZG4iOiAidW5pL3RuLWt1YmUvQkQta3ViZS1wb2QtYmQiLAogICAgICAgICJhY2ktbm9kZWJkLWRuIjogInVuaS90bi1rdWJlL0JELWt1YmUtbm9kZS1iZCIsCiAgICAgICAgImFjaS1zZXJ2aWNlLXBoeXMtZG9tIjogImt1YmUtcGRvbSIsCiAgICAgICAgImFjaS1zZXJ2aWNlLWVuY2FwIjogInZsYW4tNDAwMyIsCiAgICAgICAgImFjaS1zZXJ2aWNlLW1vbml0b3ItaW50ZXJ2YWwiOiA1LAogICAgICAgICJhY2ktcGJyLXRyYWNraW5nLW5vbi1zbmF0IjogZmFsc2UsCiAgICAgICAgImFjaS12cmYtdGVuYW50IjogImNvbW1vbiIsCiAgICAgICAgImFjaS12cmYtZG4iOiAidW5pL3RuLWNvbW1vbi9jdHgta3ViZSIsCiAgICAgICAgImFjaS1sM291dCI6ICJsM291dCIsCiAgICAgICAgImFjaS1leHQtbmV0d29ya3MiOiBbCiAgICAgICAgICAgICJkZWZhdWx0IgogICAgICAgIF0sCiAgICAgICAgImFjaS12cmYiOiAia3ViZSIsCiAgICAgICAgImRlZmF1bHQtZW5kcG9pbnQtZ3JvdXAiOiB7CiAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAia3ViZSIsCiAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1kZWZhdWx0IgogICAgICAgIH0sCiAgICAgICAgIm1heC1ub2Rlcy1zdmMtZ3JhcGgiOiAzMiwKICAgICAgICAibmFtZXNwYWNlLWRlZmF1bHQtZW5kcG9pbnQtZ3JvdXAiOiB7CiAgICAgICAgICAgICJpc3Rpby1vcGVyYXRvciI6IHsKICAgICAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAia3ViZSIsCiAgICAgICAgICAgICAgICAibmFtZSI6ICJrdWJlcm5ldGVzfGt1YmUtaXN0aW8iCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgICJpc3Rpby1zeXN0ZW0iOiB7CiAgICAgICAgICAgICAgICAicG9saWN5LXNwYWNlIjogImt1YmUiLAogICAgICAgICAgICAgICAgIm5hbWUiOiAia3ViZXJuZXRlc3xrdWJlLWlzdGlvIgogICAgICAgICAgICB9LAogICAgICAgICAgICAia3ViZS1zeXN0ZW0iOiB7CiAgICAgICAgICAgICAgICAicG9saWN5LXNwYWNlIjogImt1YmUiLAogICAgICAgICAgICAgICAgIm5hbWUiOiAia3ViZXJuZXRlc3xrdWJlLXN5c3RlbSIKICAgICAgICAgICAgfSAgICAgICAgfSwKICAgICAgICAic2VydmljZS1pcC1wb29sIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAiZW5kIjogIjEwLjMuMC4yNTQiLAogICAgICAgICAgICAgICAgInN0YXJ0IjogIjEwLjMuMC4yIgogICAgICAgICAgICB9CiAgICAgICAgXSwKICAgICAgICAic25hdC1jb250cmFjdC1zY29wZSI6ICJnbG9iYWwiLAogICAgICAgICJzdGF0aWMtc2VydmljZS1pcC1wb29sIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAiZW5kIjogIjEwLjQuMC4yNTQiLAogICAgICAgICAgICAgICAgInN0YXJ0IjogIjEwLjQuMC4yIgogICAgICAgICAgICB9CiAgICAgICAgXSwKICAgICAgICAicG9kLWlwLXBvb2wiOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJlbmQiOiAiMTAuMi4yNTUuMjU0IiwKICAgICAgICAgICAgICAgICJzdGFydCI6ICIxMC4yLjAuMiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgInBvZC1zdWJuZXQtY2h1bmstc2l6ZSI6IDMyLAogICAgICAgICJub2RlLXNlcnZpY2UtaXAtcG9vbCI6IFsKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgImVuZCI6ICIxMC41LjAuMjU0IiwKICAgICAgICAgICAgICAgICJzdGFydCI6ICIxMC41LjAuMiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgIm5vZGUtc2VydmljZS1zdWJuZXRzIjogWwogICAgICAgICAgICAiMTAuNS4wLjEvMjQiCiAgICAgICAgXQogICAgfQogIGhvc3QtYWdlbnQtY29uZmlnOiB8LQogICAgewogICAgICAgICJmbGF2b3IiOiAia3ViZXJuZXRlcy0xLjIyIiwKICAgICAgICAiYXBwLXByb2ZpbGUiOiAia3ViZXJuZXRlcyIsCiAgICAgICAgImVwLXJlZ2lzdHJ5IjogbnVsbCwKICAgICAgICAib3BmbGV4LW1vZGUiOiBudWxsLAogICAgICAgICJsb2ctbGV2ZWwiOiAiaW5mbyIsCiAgICAgICAgImFjaS1zbmF0LW5hbWVzcGFjZSI6ICJhY2ktY29udGFpbmVycy1zeXN0ZW0iLAogICAgICAgICJhY2ktdm1tLXR5cGUiOiAiS3ViZXJuZXRlcyIsCiAgICAgICAgImFjaS12bW0tZG9tYWluIjogImt1YmUiLAogICAgICAgICJhY2ktdm1tLWNvbnRyb2xsZXIiOiAia3ViZSIsCiAgICAgICAgImFjaS1wcmVmaXgiOiAia3ViZSIsCiAgICAgICAgImFjaS12cmYiOiAia3ViZSIsCiAgICAgICAgImFjaS12cmYtdGVuYW50IjogImNvbW1vbiIsCiAgICAgICAgInNlcnZpY2UtdmxhbiI6IDQwMDMsCiAgICAgICAgImt1YmVhcGktdmxhbiI6IDQwMDEsCiAgICAgICAgInBvZC1zdWJuZXQiOiAiMTAuMi4wLjEvMTYiLAogICAgICAgICJub2RlLXN1Ym5ldCI6ICIxMC4xLjAuMS8xNiIsCiAgICAgICAgImVuY2FwLXR5cGUiOiAidnhsYW4iLAogICAgICAgICJhY2ktaW5mcmEtdmxhbiI6IDQwOTMsCiAgICAgICAgImNuaS1uZXRjb25maWciOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJnYXRld2F5IjogIjEwLjIuMC4xIiwKICAgICAgICAgICAgICAgICJyb3V0ZXMiOiBbCiAgICAgICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgICAgICAiZHN0IjogIjAuMC4wLjAvMCIsCiAgICAgICAgICAgICAgICAgICAgICAgICJndyI6ICIxMC4yLjAuMSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBdLAogICAgICAgICAgICAgICAgInN1Ym5ldCI6ICIxMC4yLjAuMC8xNiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgImRlZmF1bHQtZW5kcG9pbnQtZ3JvdXAiOiB7CiAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAia3ViZSIsCiAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1kZWZhdWx0IgogICAgICAgIH0sCiAgICAgICAgIm5hbWVzcGFjZS1kZWZhdWx0LWVuZHBvaW50LWdyb3VwIjogewogICAgICAgICAgICAiaXN0aW8tb3BlcmF0b3IiOiB7CiAgICAgICAgICAgICAgICAicG9saWN5LXNwYWNlIjogImt1YmUiLAogICAgICAgICAgICAgICAgIm5hbWUiOiAia3ViZXJuZXRlc3xrdWJlLWlzdGlvIgogICAgICAgICAgICB9LAogICAgICAgICAgICAiaXN0aW8tc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJrdWJlIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1pc3RpbyIKICAgICAgICAgICAgfSwKICAgICAgICAgICAgImt1YmUtc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJrdWJlIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1zeXN0ZW0iCiAgICAgICAgICAgIH0gICAgICAgIH0sCiAgICAgICAgImVuYWJsZS1kcm9wLWxvZyI6IHRydWUKICAgIH0KICBvcGZsZXgtYWdlbnQtY29uZmlnOiB8LQogICAgewogICAgICAgICJsb2ciOiB7CiAgICAgICAgICAgICJsZXZlbCI6ICJpbmZvIgogICAgICAgIH0sCiAgICAgICAgIm9wZmxleCI6IHsKICAgICAgICAgICAgIm5vdGlmIiA6IHsgImVuYWJsZWQiIDogImZhbHNlIiB9CiAgICAgICAgfQogICAgfQotLS0KYXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnTWFwCm1ldGFkYXRhOgogIG5hbWU6IHNuYXQtb3BlcmF0b3ItY29uZmlnCiAgbmFtZXNwYWNlOiBhY2ktY29udGFpbmVycy1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCmRhdGE6CiAgICAic3RhcnQiOiAiNTAwMCIKICAgICJlbmQiOiAiNjUwMDAiCiAgICAicG9ydHMtcGVyLW5vZGUiOiAiMzAwMCIKLS0tCmFwaVZlcnNpb246IHYxCmtpbmQ6IFNlY3JldAptZXRhZGF0YToKICBuYW1lOiBhY2ktdXNlci1jZXJ0CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCmRhdGE6CiAgdXNlci5rZXk6IExTMHRMUzFDUlVkSlRpQlFVa2xXUVZSRklFdEZXUzB0TFMwdENrMUpTVU5rWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUlJVWkJRVk5EUVcxQmQyZG5TbU5CWjBWQlFXOUhRa0ZPY2l0QksyZFBTMkpCVmxaeVNuTUtZak1yV2xkaVkyNVdXRzh2WjJSMWVFbFVhM1p0TURsclpXbEdRMjRyVlhBdlUwZGtjWFkyUVdncmFteEtaa1kzZFhZclJtZERTblJEZUVRNE4zRlpkd293Y1RWRVkwZFdURWxqWmtZMFdsVmlPVUk0Y2twWFMwSkpObmRLWm5oMFRXWkdkVlZPV1RJMFkyZDNVWEJLY1hKTlZYRkJSSG92VFZjcmQzSmFaV2h6Q2xOdVJuTjVaWGRZVWpNNE9HVlNOMFZMYWtSWFpXZGtTbmxRWTFoQlowMUNRVUZGUTJkWlFqbEJXR0l4V21aQ1EwSlZlRUlyVldkRlZFZE5OeXMwV0RrS2FraGllVVV3UW14NGJHdG1hbkpzZDJSMmJWTTVUVGMzS3pKYU5tUkxRV2RRTXpOVVVrMHZVSGRGVFU5Wk4xSnVaRUp2SzFnMmVFUnpWbVJqVkVwSmVRbzFWbmM0ZUZWYWJISXJZWFZGVDJ4ek1scHVXbmd4TVdVMWVtZzNjMVV6VG1vMVN6TTFRbGRTT1VkVVdFbzJVRTFrY0ZRME9XeENPV0pzYkUxcVJISk1DamNyTldKRGMyUjFOak5QT0V0aFRqbFpVVXBDUVZCSFRXSndTSEJHYzNSRE1XTlhSM0JTVVhnemFYZEdLMXBNV1VGeVFWVmlRMHRpVjFGbVltbGFWSEFLUTFNNFJHZFBiWGxWTjNWTFZGSkxhVU1yTWxKWlZGTXpjSEpNVmpVM1IzWm1aa1o0U21wVWQwZDVhME5SVVVSdlIwSjNaalZwVDNONWRVMVJUbm8zU3dwU2FYSmlSREJLTjFJMldXVlJhMHBhSzNCRFpVdDNlU3RPZVVseGVHZ3dURUpFYlVKNWJWTkxkbGd3VjBWTFEybDBUMmR3YVRNeVJsZENiM0ZJYW1ZekNrMVJaeTlCYTBKTVFreFNjV1ZLZG5SelQyOHpiVXRQTkdFcmVESmxOM2xTVlV0ck1VTnZTM3BHVGtKSU1HNVZaVmhIYmxCM2FWUk9ZaXRpTVdabVUwWUtOM1pKU21KSVpHMUxaM1ZLZVRCc1ZVNUJOMGhhTnpkWUwybEtVa0ZyUVdwdVltVk1TMXA2YkRScmFWQTNNM0JwVUdaNFRHMHpOMlpRYWtvcmVVUnZOQXBhY0hkVmRWcFNLME5EV0d4SVNIWlBaV1p3T1UxV2NsZGpOV1ZxWTBNdlIyRkROazFYV1hsTmFuVlhUU3Q0UVhCcVkzVjJRV3RGUVhwWkszQXhOREJEQ25oM2NISTVOV3hwYm01MlYyTkROMDQzTURoQlNrWnBiVE12UmxVeE1FZEViemMzZVVsUFNUVm9LelV6TjBwaVdXUnROVFUxYUU5bFNDOUxhbE5sYTJnS1JVWTBUVzE0VWxCdGFYUTVPWGM5UFFvdExTMHRMVVZPUkNCUVVrbFdRVlJGSUV0RldTMHRMUzB0Q2c9PQogIHVzZXIuY3J0OiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VJMlJFTkRRVlpGUTBGblVHOU5RVEJIUTFOeFIxTkpZak5FVVVWQ1FsRlZRVTFFZDNoRGVrRktRbWRPVmtKQldWUkJiRlpVVFZKWmQwWkJXVVFLVmxGUlMwUkJNVVJoV0U1cVlubENWR1ZZVGpCYVZ6RjZUVkpWZDBWM1dVUldVVkZFUkVGNFZtTXlWbmxKUnpGb1ltMVNiRnBZUVhkSWFHTk9UVlJqZHdwT1ZFVXlUV3BGZVU5VVRYZFhhR05PVFdwamQwNVVSVEJOYWtWNVQxUk5kMWRxUVRoTlVYTjNRMUZaUkZaUlVVZEZkMHBXVlhwRlYwMUNVVWRCTVZWRkNrTm5kMDVSTW14NldUSTRaMVV6Ykhwa1IxWjBZM3BGVmsxQ1RVZEJNVlZGUVhkM1RWWllUbXhqYVVKMFdWYzFhMXBYVm5kTlNVZG1UVUV3UjBOVGNVY0tVMGxpTTBSUlJVSkJVVlZCUVRSSFRrRkVRMEpwVVV0Q1oxRkVZUzluVUc5RWFXMTNSbFpoZVdKSE9TOXRWbTB6U2pGV05sQTBTR0p6VTBVMVREVjBVQXBhU0c5b1VYQXZiRXRtTUdodVlYSXJaMGxtYnpWVFdIaGxOM0l2YUZsQmFXSlJjMUV2VHpadFRVNUxkVkV6UW14VGVVaEllR1ZIVmtjdlVXWkxlVlpwQ21kVFQzTkRXRGhpVkVoNFlteEVWMDUxU0VsTlJVdFRZWEY2Umt0blFUZ3Zla1oyYzBzeVdHOWlSWEI0WWsxdWMwWXdaQzlRU0d0bGVFTnZkekZ1YjBnS1UyTnFNMFozU1VSQlVVRkNUVUV3UjBOVGNVZFRTV0l6UkZGRlFrSlJWVUZCTkVkQ1FVaFlLMnRNVkdVMlRFTkJRbVYzYlVOVWRrMXphblZ6U0dSd1dncHJhVEF4SzI1Uk4wdG9ia1ZTWWtKdEwzUmFOWE5qV2tVMFkzUkpjV05vTTI1NU1VVkpWRWhPZEZsWFMwSk9ORU5rVlV0amFuWkVWekpvTW5aclNHVm5DbkowV1dKV0swRmhSWE54TUcwMGRrZEdPVVZ0ZG5ReFkzQTVXVFF4U1hsTlFscFpjWGM0WXk5V01VRjBiVkpSWTFKVVdWRkJPRWd6VDBaRVkyaDVRaklLTUVwSVUwUnVRbTlUTjJabVUySkNlQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09Ci0tLQphcGlWZXJzaW9uOiB2MQpraW5kOiBTZXJ2aWNlQWNjb3VudAptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1jb250cm9sbGVyCiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCi0tLQphcGlWZXJzaW9uOiB2MQpraW5kOiBTZXJ2aWNlQWNjb3VudAptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1ob3N0LWFnZW50CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCi0tLQphcGlWZXJzaW9uOiByYmFjLmF1dGhvcml6YXRpb24uazhzLmlvL3YxCmtpbmQ6IENsdXN0ZXJSb2xlCm1ldGFkYXRhOgogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCiAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKICBuYW1lOiBhY2ktY29udGFpbmVyczpjb250cm9sbGVyCnJ1bGVzOgotIGFwaUdyb3VwczoKICAtICIiCiAgcmVzb3VyY2VzOgogIC0gbm9kZXMKICAtIG5hbWVzcGFjZXMKICAtIHBvZHMKICAtIGVuZHBvaW50cwogIC0gc2VydmljZXMKICAtIGV2ZW50cwogIC0gcmVwbGljYXRpb25jb250cm9sbGVycwogIC0gc2VydmljZWFjY291bnRzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0CiAgLSBwYXRjaAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICIiCiAgcmVzb3VyY2VzOgogIC0gY29uZmlnbWFwcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICJhcGlleHRlbnNpb25zLms4cy5pbyIKICByZXNvdXJjZXM6CiAgLSBjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zCiAgdmVyYnM6CiAgLSAnKicKLSBhcGlHcm91cHM6CiAgLSAicmJhYy5hdXRob3JpemF0aW9uLms4cy5pbyIKICByZXNvdXJjZXM6CiAgLSBjbHVzdGVycm9sZXMKICAtIGNsdXN0ZXJyb2xlYmluZGluZ3MKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtICJpbnN0YWxsLmlzdGlvLmlvIgogIHJlc291cmNlczoKICAtIGlzdGlvY29udHJvbHBsYW5lcwogIC0gaXN0aW9vcGVyYXRvcnMKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtICJhY2kuaXN0aW8iCiAgcmVzb3VyY2VzOgogIC0gYWNpaXN0aW9vcGVyYXRvcnMKICAtIGFjaWlzdGlvb3BlcmF0b3IKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtICJuZXR3b3JraW5nLms4cy5pbyIKICByZXNvdXJjZXM6CiAgLSBuZXR3b3JrcG9saWNpZXMKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAiYXBwcyIKICByZXNvdXJjZXM6CiAgLSBkZXBsb3ltZW50cwogIC0gcmVwbGljYXNldHMKICAtIGRhZW1vbnNldHMKICAtIHN0YXRlZnVsc2V0cwogIHZlcmJzOgogIC0gJyonCi0gYXBpR3JvdXBzOgogIC0gIiIKICByZXNvdXJjZXM6CiAgLSBub2RlcwogIC0gc2VydmljZXMvc3RhdHVzCiAgdmVyYnM6CiAgLSB1cGRhdGUKLSBhcGlHcm91cHM6CiAgLSAibW9uaXRvcmluZy5jb3Jlb3MuY29tIgogIHJlc291cmNlczoKICAtIHNlcnZpY2Vtb25pdG9ycwogIHZlcmJzOgogIC0gZ2V0CiAgLSBjcmVhdGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnNuYXQiCiAgcmVzb3VyY2VzOgogIC0gc25hdHBvbGljaWVzL2ZpbmFsaXplcnMKICAtIHNuYXRwb2xpY2llcy9zdGF0dXMKICAtIG5vZGVpbmZvcwogIHZlcmJzOgogIC0gdXBkYXRlCiAgLSBjcmVhdGUKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICJhY2kuc25hdCIKICByZXNvdXJjZXM6CiAgLSBzbmF0Z2xvYmFsaW5mb3MKICAtIHNuYXRwb2xpY2llcwogIC0gbm9kZWluZm9zCiAgLSByZGNvbmZpZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGNyZWF0ZQogIC0gdXBkYXRlCiAgLSBkZWxldGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnFvcyIKICByZXNvdXJjZXM6CiAgLSBxb3Nwb2xpY2llcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQogIC0gcGF0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYWNpLm5ldGZsb3ciCiAgcmVzb3VyY2VzOgogIC0gbmV0Zmxvd3BvbGljaWVzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0CiAgLSB1cGRhdGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLmVyc3BhbiIKICByZXNvdXJjZXM6CiAgLSBlcnNwYW5wb2xpY2llcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gdXBkYXRlCi0gYXBpR3JvdXBzOgogIC0gImFjaS5hdyIKICByZXNvdXJjZXM6CiAgLSBwb2RpZnMKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtIGFwcHMub3BlbnNoaWZ0LmlvCiAgcmVzb3VyY2VzOgogIC0gZGVwbG95bWVudGNvbmZpZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSBkaXNjb3ZlcnkuazhzLmlvCiAgcmVzb3VyY2VzOgogIC0gZW5kcG9pbnRzbGljZXMKICB2ZXJiczoKICAtIGdldAogIC0gbGlzdAogIC0gd2F0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYWNpLm5ldHBvbCIKICByZXNvdXJjZXM6CiAgLSBuZXR3b3JrcG9saWNpZXMKICB2ZXJiczoKICAtIGdldAogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGNyZWF0ZQogIC0gdXBkYXRlCiAgLSBkZWxldGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLmRuc25ldHBvbCIKICByZXNvdXJjZXM6CiAgLSBkbnNuZXR3b3JrcG9saWNpZXMKICB2ZXJiczoKICAtIGdldAogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGNyZWF0ZQogIC0gdXBkYXRlCiAgLSBkZWxldGUKLS0tCmFwaVZlcnNpb246IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8vdjEKa2luZDogQ2x1c3RlclJvbGUKbWV0YWRhdGE6CiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogIG5hbWU6IGFjaS1jb250YWluZXJzOmhvc3QtYWdlbnQKcnVsZXM6Ci0gYXBpR3JvdXBzOgogIC0gIiIKICByZXNvdXJjZXM6CiAgLSBub2RlcwogIC0gbmFtZXNwYWNlcwogIC0gcG9kcwogIC0gZW5kcG9pbnRzCiAgLSBzZXJ2aWNlcwogIC0gcmVwbGljYXRpb25jb250cm9sbGVycwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gdXBkYXRlCi0gYXBpR3JvdXBzOgogIC0gIiIKICByZXNvdXJjZXM6CiAgLSBldmVudHMKICB2ZXJiczoKICAtIGNyZWF0ZQogIC0gcGF0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYXBpZXh0ZW5zaW9ucy5rOHMuaW8iCiAgcmVzb3VyY2VzOgogIC0gY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAotIGFwaUdyb3VwczoKICAtICJhY2kuYXciCiAgcmVzb3VyY2VzOgogIC0gcG9kaWZzCiAgLSBwb2RpZnMvc3RhdHVzCiAgdmVyYnM6CiAgLSAiKiIKLSBhcGlHcm91cHM6CiAgLSAibmV0d29ya2luZy5rOHMuaW8iCiAgcmVzb3VyY2VzOgogIC0gbmV0d29ya3BvbGljaWVzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0Ci0gYXBpR3JvdXBzOgogIC0gImFwcHMiCiAgcmVzb3VyY2VzOgogIC0gZGVwbG95bWVudHMKICAtIHJlcGxpY2FzZXRzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0Ci0gYXBpR3JvdXBzOgogIC0gImFjaS5zbmF0IgogIHJlc291cmNlczoKICAtIHNuYXRwb2xpY2llcwogIC0gc25hdGdsb2JhbGluZm9zCiAgLSByZGNvbmZpZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnFvcyIKICByZXNvdXJjZXM6CiAgLSBxb3Nwb2xpY2llcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQogIC0gcGF0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYWNpLmRyb3Bsb2ciCiAgcmVzb3VyY2VzOgogIC0gZW5hYmxlZHJvcGxvZ3MKICAtIHBydW5lZHJvcGxvZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnNuYXQiCiAgcmVzb3VyY2VzOgogIC0gbm9kZWluZm9zCiAgLSBzbmF0bG9jYWxpbmZvcwogIHZlcmJzOgogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtIGRpc2NvdmVyeS5rOHMuaW8KICByZXNvdXJjZXM6CiAgLSBlbmRwb2ludHNsaWNlcwogIHZlcmJzOgogIC0gZ2V0CiAgLSBsaXN0CiAgLSB3YXRjaAotIGFwaUdyb3VwczoKICAtICJhY2kubmV0cG9sIgogIHJlc291cmNlczoKICAtIG5ldHdvcmtwb2xpY2llcwogIHZlcmJzOgogIC0gZ2V0CiAgLSBsaXN0CiAgLSB3YXRjaAotLS0KYXBpVmVyc2lvbjogcmJhYy5hdXRob3JpemF0aW9uLms4cy5pby92MQpraW5kOiBDbHVzdGVyUm9sZUJpbmRpbmcKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnM6Y29udHJvbGxlcgogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCnJvbGVSZWY6CiAgYXBpR3JvdXA6IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8KICBraW5kOiBDbHVzdGVyUm9sZQogIG5hbWU6IGFjaS1jb250YWluZXJzOmNvbnRyb2xsZXIKc3ViamVjdHM6Ci0ga2luZDogU2VydmljZUFjY291bnQKICBuYW1lOiBhY2ktY29udGFpbmVycy1jb250cm9sbGVyCiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQotLS0KYXBpVmVyc2lvbjogcmJhYy5hdXRob3JpemF0aW9uLms4cy5pby92MQpraW5kOiBDbHVzdGVyUm9sZUJpbmRpbmcKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnM6aG9zdC1hZ2VudAogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCnJvbGVSZWY6CiAgYXBpR3JvdXA6IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8KICBraW5kOiBDbHVzdGVyUm9sZQogIG5hbWU6IGFjaS1jb250YWluZXJzOmhvc3QtYWdlbnQKc3ViamVjdHM6Ci0ga2luZDogU2VydmljZUFjY291bnQKICBuYW1lOiBhY2ktY29udGFpbmVycy1ob3N0LWFnZW50CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQotLS0KYXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEYWVtb25TZXQKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnMtaG9zdAogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCnNwZWM6CiAgdXBkYXRlU3RyYXRlZ3k6CiAgICB0eXBlOiBSb2xsaW5nVXBkYXRlCiAgc2VsZWN0b3I6CiAgICBtYXRjaExhYmVsczoKICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtaG9zdAogICAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKICB0ZW1wbGF0ZToKICAgIG1ldGFkYXRhOgogICAgICBsYWJlbHM6CiAgICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtaG9zdAogICAgICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogICAgICBhbm5vdGF0aW9uczoKICAgICAgICBzY2hlZHVsZXIuYWxwaGEua3ViZXJuZXRlcy5pby9jcml0aWNhbC1wb2Q6ICcnCiAgICAgICAgcHJvbWV0aGV1cy5pby9zY3JhcGU6ICJ0cnVlIgogICAgICAgIHByb21ldGhldXMuaW8vcG9ydDogIjk2MTIiCiAgICBzcGVjOgogICAgICBob3N0TmV0d29yazogdHJ1ZQogICAgICBob3N0UElEOiB0cnVlCiAgICAgIGhvc3RJUEM6IHRydWUKICAgICAgc2VydmljZUFjY291bnROYW1lOiBhY2ktY29udGFpbmVycy1ob3N0LWFnZW50CiAgICAgIHRvbGVyYXRpb25zOgogICAgICAgIC0gb3BlcmF0b3I6IEV4aXN0cwogICAgICBwcmlvcml0eUNsYXNzTmFtZTogc3lzdGVtLWNsdXN0ZXItY3JpdGljYWwKICAgICAgY29udGFpbmVyczoKICAgICAgICAtIG5hbWU6IGFjaS1jb250YWluZXJzLWhvc3QKICAgICAgICAgIGltYWdlOiBub2lyby9hY2ktY29udGFpbmVycy1ob3N0OjUuMi4yLjAuMGVmNDcxOAogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIHNlY3VyaXR5Q29udGV4dDoKICAgICAgICAgICAgY2FwYWJpbGl0aWVzOgogICAgICAgICAgICAgIGFkZDoKICAgICAgICAgICAgICAgIC0gU1lTX0FETUlOCiAgICAgICAgICAgICAgICAtIE5FVF9BRE1JTgogICAgICAgICAgICAgICAgLSBTWVNfUFRSQUNFCiAgICAgICAgICAgICAgICAtIE5FVF9SQVcKICAgICAgICAgIGVudjoKICAgICAgICAgICAgLSBuYW1lOiBLVUJFUk5FVEVTX05PREVfTkFNRQogICAgICAgICAgICAgIHZhbHVlRnJvbToKICAgICAgICAgICAgICAgIGZpZWxkUmVmOgogICAgICAgICAgICAgICAgICBmaWVsZFBhdGg6IHNwZWMubm9kZU5hbWUKICAgICAgICAgICAgLSBuYW1lOiBURU5BTlQKICAgICAgICAgICAgICB2YWx1ZTogImt1YmUiCiAgICAgICAgICAgIC0gbmFtZTogTk9ERV9FUEcKICAgICAgICAgICAgICB2YWx1ZTogImt1YmVybmV0ZXN8a3ViZS1ub2RlcyIKICAgICAgICAgICAgLSBuYW1lOiBEVVJBVElPTl9XQUlUX0ZPUl9ORVRXT1JLCiAgICAgICAgICAgICAgdmFsdWU6ICIyMTAiCiAgICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgICAgIC0gbmFtZTogY25pLWJpbgogICAgICAgICAgICAgIG1vdW50UGF0aDogL21udC9jbmktYmluCiAgICAgICAgICAgIC0gbmFtZTogY25pLWNvbmYKICAgICAgICAgICAgICBtb3VudFBhdGg6IC9tbnQvY25pLWNvbmYKICAgICAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3ZhcgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3J1bgogICAgICAgICAgICAtIG5hbWU6IG9wZmxleC1ob3N0Y29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvb3BmbGV4LWFnZW50LW92cy9iYXNlLWNvbmYuZAogICAgICAgICAgICAtIG5hbWU6IGhvc3QtY29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvYWNpLWNvbnRhaW5lcnMvCiAgICAgICAgICAgIC0gbW91bnRQYXRoOiAvcnVuL25ldG5zCiAgICAgICAgICAgICAgbmFtZTogaG9zdC1ydW4tbmV0bnMKICAgICAgICAgICAgICByZWFkT25seTogdHJ1ZQogICAgICAgICAgICAgIG1vdW50UHJvcGFnYXRpb246IEhvc3RUb0NvbnRhaW5lcgogICAgICAgICAgbGl2ZW5lc3NQcm9iZToKICAgICAgICAgICAgaHR0cEdldDoKICAgICAgICAgICAgICBwYXRoOiAvc3RhdHVzCiAgICAgICAgICAgICAgcG9ydDogODA5MAogICAgICAgIC0gbmFtZTogb3BmbGV4LWFnZW50CiAgICAgICAgICBlbnY6CiAgICAgICAgICAgIC0gbmFtZTogUkVCT09UX1dJVEhfT1ZTCiAgICAgICAgICAgICAgdmFsdWU6ICJ0cnVlIgogICAgICAgICAgaW1hZ2U6IG5vaXJvL29wZmxleDo1LjIuMi4wLmQyNzM5ZGEKICAgICAgICAgIGltYWdlUHVsbFBvbGljeTogQWx3YXlzCiAgICAgICAgICBzZWN1cml0eUNvbnRleHQ6CiAgICAgICAgICAgIGNhcGFiaWxpdGllczoKICAgICAgICAgICAgICBhZGQ6CiAgICAgICAgICAgICAgICAtIE5FVF9BRE1JTgogICAgICAgICAgdm9sdW1lTW91bnRzOgogICAgICAgICAgICAtIG5hbWU6IGhvc3R2YXIKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvdmFyCiAgICAgICAgICAgIC0gbmFtZTogaG9zdHJ1bgogICAgICAgICAgICAgIG1vdW50UGF0aDogL3J1bgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvcnVuCiAgICAgICAgICAgIC0gbmFtZTogb3BmbGV4LWhvc3Rjb25maWctdm9sdW1lCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL2V0Yy9vcGZsZXgtYWdlbnQtb3ZzL2Jhc2UtY29uZi5kCiAgICAgICAgICAgIC0gbmFtZTogb3BmbGV4LWNvbmZpZy12b2x1bWUKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvZXRjL29wZmxleC1hZ2VudC1vdnMvY29uZi5kCiAgICAgICAgLSBuYW1lOiBtY2FzdC1kYWVtb24KICAgICAgICAgIGltYWdlOiBub2lyby9vcGZsZXg6NS4yLjIuMC5kMjczOWRhCiAgICAgICAgICBjb21tYW5kOiBbIi9iaW4vc2giXQogICAgICAgICAgYXJnczogWyIvdXNyL2xvY2FsL2Jpbi9sYXVuY2gtbWNhc3RkYWVtb24uc2giXQogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIHZvbHVtZU1vdW50czoKICAgICAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3ZhcgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3J1bgogICAgICByZXN0YXJ0UG9saWN5OiBBbHdheXMKICAgICAgdm9sdW1lczoKICAgICAgICAtIG5hbWU6IGNuaS1iaW4KICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvb3B0CiAgICAgICAgLSBuYW1lOiBjbmktY29uZgogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC9ldGMKICAgICAgICAtIG5hbWU6IGhvc3R2YXIKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvdmFyCiAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL3J1bgogICAgICAgIC0gbmFtZTogaG9zdC1jb25maWctdm9sdW1lCiAgICAgICAgICBjb25maWdNYXA6CiAgICAgICAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbmZpZwogICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAtIGtleTogaG9zdC1hZ2VudC1jb25maWcKICAgICAgICAgICAgICAgIHBhdGg6IGhvc3QtYWdlbnQuY29uZgogICAgICAgIC0gbmFtZTogb3BmbGV4LWhvc3Rjb25maWctdm9sdW1lCiAgICAgICAgICBlbXB0eURpcjoKICAgICAgICAgICAgbWVkaXVtOiBNZW1vcnkKICAgICAgICAtIG5hbWU6IG9wZmxleC1jb25maWctdm9sdW1lCiAgICAgICAgICBjb25maWdNYXA6CiAgICAgICAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbmZpZwogICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAtIGtleTogb3BmbGV4LWFnZW50LWNvbmZpZwogICAgICAgICAgICAgICAgcGF0aDogbG9jYWwuY29uZgogICAgICAgIC0gbmFtZTogaG9zdC1ydW4tbmV0bnMKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvcnVuL25ldG5zCi0tLQphcGlWZXJzaW9uOiBhcHBzL3YxCmtpbmQ6IERhZW1vblNldAptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1vcGVudnN3aXRjaAogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCnNwZWM6CiAgdXBkYXRlU3RyYXRlZ3k6CiAgICB0eXBlOiBSb2xsaW5nVXBkYXRlCiAgc2VsZWN0b3I6CiAgICBtYXRjaExhYmVsczoKICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtb3BlbnZzd2l0Y2gKICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgdGVtcGxhdGU6CiAgICBtZXRhZGF0YToKICAgICAgbGFiZWxzOgogICAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLW9wZW52c3dpdGNoCiAgICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgICAgIGFubm90YXRpb25zOgogICAgICAgIHNjaGVkdWxlci5hbHBoYS5rdWJlcm5ldGVzLmlvL2NyaXRpY2FsLXBvZDogJycKICAgIHNwZWM6CiAgICAgIGhvc3ROZXR3b3JrOiB0cnVlCiAgICAgIGhvc3RQSUQ6IHRydWUKICAgICAgaG9zdElQQzogdHJ1ZQogICAgICBzZXJ2aWNlQWNjb3VudE5hbWU6IGFjaS1jb250YWluZXJzLWhvc3QtYWdlbnQKICAgICAgdG9sZXJhdGlvbnM6CiAgICAgICAgLSBvcGVyYXRvcjogRXhpc3RzCiAgICAgIHByaW9yaXR5Q2xhc3NOYW1lOiBzeXN0ZW0tY2x1c3Rlci1jcml0aWNhbAogICAgICBjb250YWluZXJzOgogICAgICAgIC0gbmFtZTogYWNpLWNvbnRhaW5lcnMtb3BlbnZzd2l0Y2gKICAgICAgICAgIGltYWdlOiBub2lyby9vcGVudnN3aXRjaDo1LjIuMi4wLjU2ODFhOWIKICAgICAgICAgIGltYWdlUHVsbFBvbGljeTogQWx3YXlzCiAgICAgICAgICByZXNvdXJjZXM6CiAgICAgICAgICAgIGxpbWl0czoKICAgICAgICAgICAgICBtZW1vcnk6ICIxR2kiCiAgICAgICAgICBzZWN1cml0eUNvbnRleHQ6CiAgICAgICAgICAgIGNhcGFiaWxpdGllczoKICAgICAgICAgICAgICBhZGQ6CiAgICAgICAgICAgICAgICAtIE5FVF9BRE1JTgogICAgICAgICAgICAgICAgLSBTWVNfTU9EVUxFCiAgICAgICAgICAgICAgICAtIFNZU19OSUNFCiAgICAgICAgICAgICAgICAtIElQQ19MT0NLCiAgICAgICAgICBlbnY6CiAgICAgICAgICAgIC0gbmFtZTogT1ZTX1JVTkRJUgogICAgICAgICAgICAgIHZhbHVlOiAvdXNyL2xvY2FsL3Zhci9ydW4vb3BlbnZzd2l0Y2gKICAgICAgICAgIHZvbHVtZU1vdW50czoKICAgICAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3ZhcgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3J1bgogICAgICAgICAgICAtIG5hbWU6IGhvc3RldGMKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvZXRjCiAgICAgICAgICAgIC0gbmFtZTogaG9zdG1vZHVsZXMKICAgICAgICAgICAgICBtb3VudFBhdGg6IC9saWIvbW9kdWxlcwogICAgICAgICAgbGl2ZW5lc3NQcm9iZToKICAgICAgICAgICAgZXhlYzoKICAgICAgICAgICAgICBjb21tYW5kOgogICAgICAgICAgICAgICAgLSAvdXNyL2xvY2FsL2Jpbi9saXZlbmVzcy1vdnMuc2gKICAgICAgcmVzdGFydFBvbGljeTogQWx3YXlzCiAgICAgIHZvbHVtZXM6CiAgICAgICAgLSBuYW1lOiBob3N0ZXRjCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL2V0YwogICAgICAgIC0gbmFtZTogaG9zdHZhcgogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC92YXIKICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvcnVuCiAgICAgICAgLSBuYW1lOiBob3N0bW9kdWxlcwogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC9saWIvbW9kdWxlcwotLS0KYXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEZXBsb3ltZW50Cm1ldGFkYXRhOgogIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgpzcGVjOgogIHJlcGxpY2FzOiAxCiAgc3RyYXRlZ3k6CiAgICB0eXBlOiBSZWNyZWF0ZQogIHNlbGVjdG9yOgogICAgbWF0Y2hMYWJlbHM6CiAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgdGVtcGxhdGU6CiAgICBtZXRhZGF0YToKICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgogICAgICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCiAgICAgIGxhYmVsczoKICAgICAgICBuYW1lOiBhY2ktY29udGFpbmVycy1jb250cm9sbGVyCiAgICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgICAgIGFubm90YXRpb25zOgogICAgICAgIHNjaGVkdWxlci5hbHBoYS5rdWJlcm5ldGVzLmlvL2NyaXRpY2FsLXBvZDogJycKICAgIHNwZWM6CiAgICAgIGhvc3ROZXR3b3JrOiB0cnVlCiAgICAgIHNlcnZpY2VBY2NvdW50TmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgogICAgICB0b2xlcmF0aW9uczoKICAgICAgICAtIG9wZXJhdG9yOiBFeGlzdHMKICAgICAgICAgIGVmZmVjdDogTm9TY2hlZHVsZQogICAgICBwcmlvcml0eUNsYXNzTmFtZTogc3lzdGVtLW5vZGUtY3JpdGljYWwKICAgICAgY29udGFpbmVyczoKICAgICAgICAtIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICAgICAgICAgIGltYWdlOiBub2lyby9hY2ktY29udGFpbmVycy1jb250cm9sbGVyOjUuMi4yLjAuMGVmNDcxOAogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIGVudjoKICAgICAgICAgICAgLSBuYW1lOiBXQVRDSF9OQU1FU1BBQ0UKICAgICAgICAgICAgICB2YWx1ZTogIiIKICAgICAgICAgICAgLSBuYW1lOiBBQ0lfU05BVF9OQU1FU1BBQ0UKICAgICAgICAgICAgICB2YWx1ZTogImFjaS1jb250YWluZXJzLXN5c3RlbSIKICAgICAgICAgICAgLSBuYW1lOiBBQ0lfU05BR0xPQkFMSU5GT19OQU1FCiAgICAgICAgICAgICAgdmFsdWU6ICJzbmF0Z2xvYmFsaW5mbyIKICAgICAgICAgICAgLSBuYW1lOiBBQ0lfUkRDT05GSUdfTkFNRQogICAgICAgICAgICAgIHZhbHVlOiAicm91dGluZ2RvbWFpbi1jb25maWciCiAgICAgICAgICAgIC0gbmFtZTogU1lTVEVNX05BTUVTUEFDRQogICAgICAgICAgICAgIHZhbHVlOiAia3ViZS1zeXN0ZW0iCiAgICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgICAgIC0gbmFtZTogY29udHJvbGxlci1jb25maWctdm9sdW1lCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL2V0Yy9hY2ktY29udGFpbmVycy8KICAgICAgICAgICAgLSBuYW1lOiBhY2ktdXNlci1jZXJ0LXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvYWNpLWNlcnQvCiAgICAgICAgICBsaXZlbmVzc1Byb2JlOgogICAgICAgICAgICBodHRwR2V0OgogICAgICAgICAgICAgIHBhdGg6IC9zdGF0dXMKICAgICAgICAgICAgICBwb3J0OiA4MDkxCiAgICAgIHZvbHVtZXM6CiAgICAgICAgLSBuYW1lOiBhY2ktdXNlci1jZXJ0LXZvbHVtZQogICAgICAgICAgc2VjcmV0OgogICAgICAgICAgICBzZWNyZXROYW1lOiBhY2ktdXNlci1jZXJ0CiAgICAgICAgLSBuYW1lOiBjb250cm9sbGVyLWNvbmZpZy12b2x1bWUKICAgICAgICAgIGNvbmZpZ01hcDoKICAgICAgICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29uZmlnCiAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgIC0ga2V5OiBjb250cm9sbGVyLWNvbmZpZwogICAgICAgICAgICAgICAgcGF0aDogY29udHJvbGxlci5jb25mCi0tLQphcGlWZXJzaW9uOiB2MQpraW5kOiBTZXJ2aWNlQWNjb3VudAptZXRhZGF0YToKICBuYW1lOiBzcmlvdi1kZXZpY2UtcGx1Z2luCiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQotLS0KYXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEYWVtb25TZXQKbWV0YWRhdGE6CiAgbmFtZToga3ViZS1zcmlvdi1kZXZpY2UtcGx1Z2luLWFtZDY0CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIHRpZXI6IG5vZGUKICAgIGFwcDogc3Jpb3ZkcApzcGVjOgogIHNlbGVjdG9yOgogICAgbWF0Y2hMYWJlbHM6CiAgICAgIG5hbWU6IHNyaW92LWRldmljZS1wbHVnaW4KICB0ZW1wbGF0ZToKICAgIG1ldGFkYXRhOgogICAgICBsYWJlbHM6CiAgICAgICAgbmFtZTogc3Jpb3YtZGV2aWNlLXBsdWdpbgogICAgICAgIHRpZXI6IG5vZGUKICAgICAgICBhcHA6IHNyaW92ZHAKICAgIHNwZWM6CiAgICAgIGhvc3ROZXR3b3JrOiB0cnVlCiAgICAgIG5vZGVTZWxlY3RvcjoKICAgICAgICBiZXRhLmt1YmVybmV0ZXMuaW8vYXJjaDogYW1kNjQKICAgICAgdG9sZXJhdGlvbnM6CiAgICAgIC0ga2V5OiBub2RlLXJvbGUua3ViZXJuZXRlcy5pby9tYXN0ZXIKICAgICAgICBvcGVyYXRvcjogRXhpc3RzCiAgICAgICAgZWZmZWN0OiBOb1NjaGVkdWxlCiAgICAgIHNlcnZpY2VBY2NvdW50TmFtZTogc3Jpb3YtZGV2aWNlLXBsdWdpbgogICAgICBjb250YWluZXJzOgogICAgICAtIG5hbWU6IGt1YmUtc3Jpb3ZkcAogICAgICAgIGltYWdlOiBkb2NrZXIuaW8vbmZ2cGUvc3Jpb3YtZGV2aWNlLXBsdWdpbjp2My4zCiAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBJZk5vdFByZXNlbnQKICAgICAgICBhcmdzOgogICAgICAgIC0gLS1sb2ctZGlyPXNyaW92ZHAKICAgICAgICAtIC0tbG9nLWxldmVsPTEwCiAgICAgICAgc2VjdXJpdHlDb250ZXh0OgogICAgICAgICAgcHJpdmlsZWdlZDogdHJ1ZQogICAgICAgIHZvbHVtZU1vdW50czoKICAgICAgICAtIG5hbWU6IGRldmljZXNvY2sKICAgICAgICAgIG1vdW50UGF0aDogL3Zhci9saWIva3ViZWxldC8KICAgICAgICAgIHJlYWRPbmx5OiBmYWxzZQogICAgICAgIC0gbmFtZTogbG9nCiAgICAgICAgICBtb3VudFBhdGg6IC92YXIvbG9nCiAgICAgICAgLSBuYW1lOiBjb25maWctdm9sdW1lCiAgICAgICAgICBtb3VudFBhdGg6IC9ldGMvcGNpZHAKICAgICAgICAtIG5hbWU6IGRldmljZS1pbmZvCiAgICAgICAgICBtb3VudFBhdGg6IC92YXIvcnVuL2s4cy5jbmkuY25jZi5pby9kZXZpbmZvL2RwCiAgICAgIHZvbHVtZXM6CiAgICAgICAgLSBuYW1lOiBkZXZpY2Vzb2NrCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL3Zhci9saWIva3ViZWxldC8KICAgICAgICAtIG5hbWU6IGxvZwogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC92YXIvbG9nCiAgICAgICAgLSBuYW1lOiBkZXZpY2UtaW5mbwogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC92YXIvcnVuL2s4cy5jbmkuY25jZi5pby9kZXZpbmZvL2RwCiAgICAgICAgICAgIHR5cGU6IERpcmVjdG9yeU9yQ3JlYXRlCiAgICAgICAgLSBuYW1lOiBjb25maWctdm9sdW1lCiAgICAgICAgICBjb25maWdNYXA6CiAgICAgICAgICAgIG5hbWU6IHNyaW92ZHAtY29uZmlnCiAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAtIGtleTogY29uZmlnLmpzb24KICAgICAgICAgICAgICBwYXRoOiBjb25maWcuanNvbgotLS0KYXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEYWVtb25TZXQKbWV0YWRhdGE6CiAgbmFtZToga3ViZS1zcmlvdi1kZXZpY2UtcGx1Z2luLXBwYzY0bGUKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCiAgbGFiZWxzOgogICAgdGllcjogbm9kZQogICAgYXBwOiBzcmlvdmRwCnNwZWM6CiAgc2VsZWN0b3I6CiAgICBtYXRjaExhYmVsczoKICAgICAgbmFtZTogc3Jpb3YtZGV2aWNlLXBsdWdpbgogIHRlbXBsYXRlOgogICAgbWV0YWRhdGE6CiAgICAgIGxhYmVsczoKICAgICAgICBuYW1lOiBzcmlvdi1kZXZpY2UtcGx1Z2luCiAgICAgICAgdGllcjogbm9kZQogICAgICAgIGFwcDogc3Jpb3ZkcAogICAgc3BlYzoKICAgICAgaG9zdE5ldHdvcms6IHRydWUKICAgICAgbm9kZVNlbGVjdG9yOgogICAgICAgIGJldGEua3ViZXJuZXRlcy5pby9hcmNoOiBwcGM2NGxlCiAgICAgIHRvbGVyYXRpb25zOgogICAgICAtIGtleTogbm9kZS1yb2xlLmt1YmVybmV0ZXMuaW8vbWFzdGVyCiAgICAgICAgb3BlcmF0b3I6IEV4aXN0cwogICAgICAgIGVmZmVjdDogTm9TY2hlZHVsZQogICAgICBzZXJ2aWNlQWNjb3VudE5hbWU6IHNyaW92LWRldmljZS1wbHVnaW4KICAgICAgY29udGFpbmVyczoKICAgICAgLSBuYW1lOiBrdWJlLXNyaW92ZHAKICAgICAgICBpbWFnZTogZG9ja2VyLmlvL25mdnBlL3NyaW92LWRldmljZS1wbHVnaW46cHBjNjRsZQogICAgICAgIGltYWdlUHVsbFBvbGljeTogSWZOb3RQcmVzZW50CiAgICAgICAgYXJnczoKICAgICAgICAtIC0tbG9nLWRpcj1zcmlvdmRwCiAgICAgICAgLSAtLWxvZy1sZXZlbD0xMAogICAgICAgIHNlY3VyaXR5Q29udGV4dDoKICAgICAgICAgIHByaXZpbGVnZWQ6IHRydWUKICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgLSBuYW1lOiBkZXZpY2Vzb2NrCiAgICAgICAgICBtb3VudFBhdGg6IC92YXIvbGliL2t1YmVsZXQvCiAgICAgICAgICByZWFkT25seTogZmFsc2UKICAgICAgICAtIG5hbWU6IGxvZwogICAgICAgICAgbW91bnRQYXRoOiAvdmFyL2xvZwogICAgICAgIC0gbmFtZTogY29uZmlnLXZvbHVtZQogICAgICAgICAgbW91bnRQYXRoOiAvZXRjL3BjaWRwCiAgICAgICAgLSBuYW1lOiBkZXZpY2UtaW5mbwogICAgICAgICAgbW91bnRQYXRoOiAvdmFyL3J1bi9rOHMuY25pLmNuY2YuaW8vZGV2aW5mby9kcAogICAgICB2b2x1bWVzOgogICAgICAgIC0gbmFtZTogZGV2aWNlc29jawogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC92YXIvbGliL2t1YmVsZXQvCiAgICAgICAgLSBuYW1lOiBsb2cKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvdmFyL2xvZwogICAgICAgIC0gbmFtZTogZGV2aWNlLWluZm8KICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvdmFyL3J1bi9rOHMuY25pLmNuY2YuaW8vZGV2aW5mby9kcAogICAgICAgICAgICB0eXBlOiBEaXJlY3RvcnlPckNyZWF0ZQogICAgICAgIC0gbmFtZTogY29uZmlnLXZvbHVtZQogICAgICAgICAgY29uZmlnTWFwOgogICAgICAgICAgICBuYW1lOiBzcmlvdmRwLWNvbmZpZwogICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgLSBrZXk6IGNvbmZpZy5qc29uCiAgICAgICAgICAgICAgcGF0aDogY29uZmlnLmpzb24KLS0tCmFwaVZlcnNpb246IGFwcHMvdjEKa2luZDogRGFlbW9uU2V0Cm1ldGFkYXRhOgogIG5hbWU6IGt1YmUtc3Jpb3YtZGV2aWNlLXBsdWdpbi1hcm02NAogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KICBsYWJlbHM6CiAgICB0aWVyOiBub2RlCiAgICBhcHA6IHNyaW92ZHAKc3BlYzoKICBzZWxlY3RvcjoKICAgIG1hdGNoTGFiZWxzOgogICAgICBuYW1lOiBzcmlvdi1kZXZpY2UtcGx1Z2luCiAgdGVtcGxhdGU6CiAgICBtZXRhZGF0YToKICAgICAgbGFiZWxzOgogICAgICAgIG5hbWU6IHNyaW92LWRldmljZS1wbHVnaW4KICAgICAgICB0aWVyOiBub2RlCiAgICAgICAgYXBwOiBzcmlvdmRwCiAgICBzcGVjOgogICAgICBob3N0TmV0d29yazogdHJ1ZQogICAgICBub2RlU2VsZWN0b3I6CiAgICAgICAgYmV0YS5rdWJlcm5ldGVzLmlvL2FyY2g6IGFybTY0CiAgICAgIHRvbGVyYXRpb25zOgogICAgICAtIGtleTogbm9kZS1yb2xlLmt1YmVybmV0ZXMuaW8vbWFzdGVyCiAgICAgICAgb3BlcmF0b3I6IEV4aXN0cwogICAgICAgIGVmZmVjdDogTm9TY2hlZHVsZQogICAgICBzZXJ2aWNlQWNjb3VudE5hbWU6IHNyaW92LWRldmljZS1wbHVnaW4KICAgICAgY29udGFpbmVyczoKICAgICAgLSBuYW1lOiBrdWJlLXNyaW92ZHAKIyB0aGlzIGlzIGEgdGVtcG9yYXJ5IGltYWdlIHJlcG9zaXRvcnkgZm9yIGFybTY0IGFyY2hpdGVjdHVyZSwgdXRpbCBDSS9DRCBvZiB0aGUKIyBzcmlvdi1kZXZpY2UtcGx1Z2luIHdpbGwgbm90IGFsbG93IHRvIHJlY3JlYXRlIG11bHRpcGxlIGltYWdlcwogICAgICAgIGltYWdlOiBhbGV4ZXlwZXJldmFsb3YvYXJtNjQtc3Jpb3YtZGV2aWNlLXBsdWdpbgogICAgICAgIGltYWdlUHVsbFBvbGljeTogSWZOb3RQcmVzZW50CiAgICAgICAgYXJnczoKICAgICAgICAtIC0tbG9nLWRpcj1zcmlvdmRwCiAgICAgICAgLSAtLWxvZy1sZXZlbD0xMAogICAgICAgIHNlY3VyaXR5Q29udGV4dDoKICAgICAgICAgIHByaXZpbGVnZWQ6IHRydWUKICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgLSBuYW1lOiBkZXZpY2Vzb2NrCiAgICAgICAgICBtb3VudFBhdGg6IC92YXIvbGliL2t1YmVsZXQvCiAgICAgICAgICByZWFkT25seTogZmFsc2UKICAgICAgICAtIG5hbWU6IGxvZwogICAgICAgICAgbW91bnRQYXRoOiAvdmFyL2xvZwogICAgICAgIC0gbmFtZTogY29uZmlnLXZvbHVtZQogICAgICAgICAgbW91bnRQYXRoOiAvZXRjL3BjaWRwCiAgICAgICAgLSBuYW1lOiBkZXZpY2UtaW5mbwogICAgICAgICAgbW91bnRQYXRoOiAvdmFyL3J1bi9rOHMuY25pLmNuY2YuaW8vZGV2aW5mby9kcAogICAgICB2b2x1bWVzOgogICAgICAgIC0gbmFtZTogZGV2aWNlc29jawogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC92YXIvbGliL2t1YmVsZXQvCiAgICAgICAgLSBuYW1lOiBsb2cKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvdmFyL2xvZwogICAgICAgIC0gbmFtZTogZGV2aWNlLWluZm8KICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvdmFyL3J1bi9rOHMuY25pLmNuY2YuaW8vZGV2aW5mby9kcAogICAgICAgICAgICB0eXBlOiBEaXJlY3RvcnlPckNyZWF0ZQogICAgICAgIC0gbmFtZTogY29uZmlnLXZvbHVtZQogICAgICAgICAgY29uZmlnTWFwOgogICAgICAgICAgICBuYW1lOiBzcmlvdmRwLWNvbmZpZwogICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgLSBrZXk6IGNvbmZpZy5qc29uCiAgICAgICAgICAgICAgcGF0aDogY29uZmlnLmpzb24KLS0tCmFwaVZlcnNpb246IHYxCmtpbmQ6IENvbmZpZ01hcAptZXRhZGF0YToKICBuYW1lOiBzcmlvdmRwLWNvbmZpZwogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KZGF0YToKICBjb25maWcuanNvbjogfAogICAgewogICAgICAgICJyZXNvdXJjZUxpc3QiOiBbCiAgICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgInJlc291cmNlUHJlZml4IjogIm1lbGxhbm94LmNvbSIsCiAgICAgICAgICAgICAgICAgICAicmVzb3VyY2VOYW1lIjogImN4NV9zcmlvdl9zd2l0Y2hkZXYiLAogICAgICAgICAgICAgICAgICAgInNlbGVjdG9ycyI6IHsKICAgICAgICAgICAgICAgICAgICAgICJ2ZW5kb3JzIjogWyIxNWIzIl0sCiAgICAgICAgICAgICAgICAgICAgICAiZGV2aWNlcyI6IFsiMTExMCJdLAogICAgICAgICAgICAgICAgICAgICAgImRyaXZlcnMiOiBbIm1seDVfY29yZSJdLAogICAgICAgICAgICAgICAgICAgICAgImlzUmRtYSI6ICB0cnVlCiAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgfQogICAgICAgIF0KICAgIH0K"
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aci-containers-config
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  controller-config: |-
+    {
+        "flavor": "kubernetes-1.22",
+        "log-level": "info",
+        "apic-hosts": [
+            "10.30.120.100"
+        ],
+        "apic-username": "kube",
+        "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "aci-prefix": "kube",
+        "aci-vmm-type": "Kubernetes",
+        "aci-vmm-domain": "kube",
+        "aci-vmm-controller": "kube",
+        "aci-policy-tenant": "kube",
+        "install-istio": true,
+        "istio-profile": "demo",
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
+        "aci-service-phys-dom": "kube-pdom",
+        "aci-service-encap": "vlan-4003",
+        "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
+        "aci-vrf-tenant": "common",
+        "aci-vrf-dn": "uni/tn-common/ctx-kube",
+        "aci-l3out": "l3out",
+        "aci-ext-networks": [
+            "default"
+        ],
+        "aci-vrf": "kube",
+        "default-endpoint-group": {
+            "policy-space": "kube",
+            "name": "kubernetes|kube-default"
+        },
+        "max-nodes-svc-graph": 32,
+        "namespace-default-endpoint-group": {
+            "istio-operator": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "istio-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "kube-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            }        },
+        "service-ip-pool": [
+            {
+                "end": "10.3.0.254",
+                "start": "10.3.0.2"
+            }
+        ],
+        "snat-contract-scope": "global",
+        "static-service-ip-pool": [
+            {
+                "end": "10.4.0.254",
+                "start": "10.4.0.2"
+            }
+        ],
+        "pod-ip-pool": [
+            {
+                "end": "10.2.255.254",
+                "start": "10.2.0.2"
+            }
+        ],
+        "pod-subnet-chunk-size": 32,
+        "node-service-ip-pool": [
+            {
+                "end": "10.5.0.254",
+                "start": "10.5.0.2"
+            }
+        ],
+        "node-service-subnets": [
+            "10.5.0.1/24"
+        ]
+    }
+  host-agent-config: |-
+    {
+        "flavor": "kubernetes-1.22",
+        "app-profile": "kubernetes",
+        "ep-registry": null,
+        "opflex-mode": null,
+        "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
+        "aci-vmm-type": "Kubernetes",
+        "aci-vmm-domain": "kube",
+        "aci-vmm-controller": "kube",
+        "aci-prefix": "kube",
+        "aci-vrf": "kube",
+        "aci-vrf-tenant": "common",
+        "service-vlan": 4003,
+        "kubeapi-vlan": 4001,
+        "pod-subnet": "10.2.0.1/16",
+        "node-subnet": "10.1.0.1/16",
+        "encap-type": "vxlan",
+        "aci-infra-vlan": 4093,
+        "cni-netconfig": [
+            {
+                "gateway": "10.2.0.1",
+                "routes": [
+                    {
+                        "dst": "0.0.0.0/0",
+                        "gw": "10.2.0.1"
+                    }
+                ],
+                "subnet": "10.2.0.0/16"
+            }
+        ],
+        "default-endpoint-group": {
+            "policy-space": "kube",
+            "name": "kubernetes|kube-default"
+        },
+        "namespace-default-endpoint-group": {
+            "istio-operator": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "istio-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "kube-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            }        },
+        "enable-drop-log": true
+    }
+  opflex-agent-config: |-
+    {
+        "log": {
+            "level": "info"
+        },
+        "opflex": {
+            "notif" : { "enabled" : "false" }
+        }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snat-operator-config
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+    "start": "5000"
+    "end": "65000"
+    "ports-per-node": "3000"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aci-user-cert
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+data:
+  user.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUNkZ0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQW1Bd2dnSmNBZ0VBQW9HQkFOcitBK2dPS2JBVlZySnMKYjMrWldiY25WWG8vZ2R1eElUa3ZtMDlrZWlGQ24rVXAvU0dkcXY2QWgramxKZkY3dXYrRmdDSnRDeEQ4N3FZdwowcTVEY0dWTEljZkY0WlViOUI4ckpXS0JJNndKZnh0TWZGdVVOWTI0Y2d3UXBKcXJNVXFBRHovTVcrd3JaZWhzClNuRnN5ZXdYUjM4OGVSN0VLakRXZWdkSnlQY1hBZ01CQUFFQ2dZQjlBWGIxWmZCQ0JVeEIrVWdFVEdNNys0WDkKakhieUUwQmx4bGtmanJsd2R2bVM5TTc3KzJaNmRLQWdQMzNUUk0vUHdFTU9ZN1JuZEJvK1g2eERzVmRjVEpJeQo1Vnc4eFVabHIrYXVFT2xzMlpuWngxMWU1emg3c1UzTmo1SzM1QldSOUdUWEo2UE1kcFQ0OWxCOWJsbE1qRHJMCjcrNWJDc2R1NjNPOEthTjlZUUpCQVBHTWJwSHBGc3RDMWNXR3BSUXgzaXdGK1pMWUFyQVViQ0tiV1FmYmlaVHAKQ1M4RGdPbXlVN3VLVFJLaUMrMlJZVFMzcHJMVjU3R3ZmZkZ4SmpUd0d5a0NRUURvR0J3ZjVpT3N5dU1RTno3SwpSaXJiRDBKN1I2WWVRa0paK3BDZUt3eStOeUlxeGgwTEJEbUJ5bVNLdlgwV0VLQ2l0T2dwaTMyRldCb3FIamYzCk1RZy9Ba0JMQkxScWVKdnRzT28zbUtPNGEreDJlN3lSVUtrMUNvS3pGTkJIMG5VZVhHblB3aVROYitiMWZmU0YKN3ZJSmJIZG1LZ3VKeTBsVU5BN0haNzdYL2lKUkFrQWpuYmVMS1p6bDRraVA3M3BpUGZ4TG0zN2ZQakoreURvNApacHdVdVpSK0NDWGxISHZPZWZwOU1WcldjNWVqY0MvR2FDNk1XWXlNanVXTSt4QXBqY3V2QWtFQXpZK3AxNDBDCnh3cHI5NWxpbm52V2NDN043MDhBSkZpbTMvRlUxMEdEbzc3eUlPSTVoKzUzN0piWWRtNTU1aE9lSC9LalNla2gKRUY0TW14UlBtaXQ5OXc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==
+  user.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUI2RENDQVZFQ0FnUG9NQTBHQ1NxR1NJYjNEUUVCQlFVQU1Ed3hDekFKQmdOVkJBWVRBbFZUTVJZd0ZBWUQKVlFRS0RBMURhWE5qYnlCVGVYTjBaVzF6TVJVd0V3WURWUVFEREF4VmMyVnlJRzFoYm1SbFpYQXdIaGNOTVRjdwpOVEUyTWpFeU9UTXdXaGNOTWpjd05URTBNakV5T1RNd1dqQThNUXN3Q1FZRFZRUUdFd0pWVXpFV01CUUdBMVVFCkNnd05RMmx6WTI4Z1UzbHpkR1Z0Y3pFVk1CTUdBMVVFQXd3TVZYTmxjaUJ0WVc1a1pXVndNSUdmTUEwR0NTcUcKU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FEYS9nUG9EaW13RlZheWJHOS9tVm0zSjFWNlA0SGJzU0U1TDV0UApaSG9oUXAvbEtmMGhuYXIrZ0lmbzVTWHhlN3IvaFlBaWJRc1EvTzZtTU5LdVEzQmxTeUhIeGVHVkcvUWZLeVZpCmdTT3NDWDhiVEh4YmxEV051SElNRUtTYXF6RktnQTgvekZ2c0syWG9iRXB4Yk1uc0YwZC9QSGtleENvdzFub0gKU2NqM0Z3SURBUUFCTUEwR0NTcUdTSWIzRFFFQkJRVUFBNEdCQUhYK2tMVGU2TENBQmV3bUNUdk1zanVzSGRwWgpraTAxK25RN0tobkVSYkJtL3RaNXNjWkU0Y3RJcWNoM255MUVJVEhOdFlXS0JONENkVUtjanZEVzJoMnZrSGVnCnJ0WWJWK0FhRXNxMG00dkdGOUVtdnQxY3A5WTQxSXlNQlpZcXc4Yy9WMUF0bVJRY1JUWVFBOEgzT0ZEY2h5QjIKMEpIU0RuQm9TN2ZmU2JCeAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-controller
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-host-agent
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers:controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - endpoints
+  - services
+  - events
+  - replicationcontrollers
+  - serviceaccounts
+  verbs:
+  - list
+  - watch
+  - get
+  - patch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - "install.istio.io"
+  resources:
+  - istiocontrolplanes
+  - istiooperators
+  verbs:
+  - '*'
+- apiGroups:
+  - "aci.istio"
+  resources:
+  - aciistiooperators
+  - aciistiooperator
+  verbs:
+  - '*'
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - services/status
+  verbs:
+  - update
+- apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatpolicies/finalizers
+  - snatpolicies/status
+  - nodeinfos
+  verbs:
+  - update
+  - create
+  - list
+  - watch
+  - get
+  - delete
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatglobalinfos
+  - snatpolicies
+  - nodeinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "aci.qos"
+  resources:
+  - qospolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - "aci.netflow"
+  resources:
+  - netflowpolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - "aci.erspan"
+  resources:
+  - erspanpolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - "aci.aw"
+  resources:
+  - podifs
+  verbs:
+  - '*'
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "aci.netpol"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "aci.dnsnetpol"
+  resources:
+  - dnsnetworkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers:host-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - endpoints
+  - services
+  - replicationcontrollers
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.aw"
+  resources:
+  - podifs
+  - podifs/status
+  verbs:
+  - "*"
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatpolicies
+  - snatglobalinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.qos"
+  resources:
+  - qospolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - "aci.droplog"
+  resources:
+  - enabledroplogs
+  - prunedroplogs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - nodeinfos
+  - snatlocalinfos
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+  - delete
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "aci.netpol"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers:controller
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers:controller
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers:host-agent
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers:host-agent
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-host-agent
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aci-containers-host
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-host
+      network-plugin: aci-containers
+  template:
+    metadata:
+      labels:
+        name: aci-containers-host
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9612"
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      serviceAccountName: aci-containers-host-agent
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: aci-containers-host
+          image: noiro/aci-containers-host:5.2.2.0.0ef4718
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - NET_ADMIN
+                - SYS_PTRACE
+                - NET_RAW
+          env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
+            - name: DURATION_WAIT_FOR_NETWORK
+              value: "210"
+          volumeMounts:
+            - name: cni-bin
+              mountPath: /mnt/cni-bin
+            - name: cni-conf
+              mountPath: /mnt/cni-conf
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: opflex-hostconfig-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+            - name: host-config-volume
+              mountPath: /usr/local/etc/aci-containers/
+            - mountPath: /run/netns
+              name: host-run-netns
+              readOnly: true
+              mountPropagation: HostToContainer
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8090
+        - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
+          image: noiro/opflex:5.2.2.0.d2739da
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: opflex-hostconfig-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+            - name: opflex-config-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
+        - name: mcast-daemon
+          image: noiro/opflex:5.2.2.0.d2739da
+          command: ["/bin/sh"]
+          args: ["/usr/local/bin/launch-mcastdaemon.sh"]
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+      restartPolicy: Always
+      volumes:
+        - name: cni-bin
+          hostPath:
+            path: /opt
+        - name: cni-conf
+          hostPath:
+            path: /etc
+        - name: hostvar
+          hostPath:
+            path: /var
+        - name: hostrun
+          hostPath:
+            path: /run
+        - name: host-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: host-agent-config
+                path: host-agent.conf
+        - name: opflex-hostconfig-volume
+          emptyDir:
+            medium: Memory
+        - name: opflex-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: opflex-agent-config
+                path: local.conf
+        - name: host-run-netns
+          hostPath:
+            path: /run/netns
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aci-containers-openvswitch
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-openvswitch
+      network-plugin: aci-containers
+  template:
+    metadata:
+      labels:
+        name: aci-containers-openvswitch
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      serviceAccountName: aci-containers-host-agent
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: aci-containers-openvswitch
+          image: noiro/openvswitch:5.2.2.0.5681a9b
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "1Gi"
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - SYS_MODULE
+                - SYS_NICE
+                - IPC_LOCK
+          env:
+            - name: OVS_RUNDIR
+              value: /usr/local/var/run/openvswitch
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: hostetc
+              mountPath: /usr/local/etc
+            - name: hostmodules
+              mountPath: /lib/modules
+          livenessProbe:
+            exec:
+              command:
+                - /usr/local/bin/liveness-ovs.sh
+      restartPolicy: Always
+      volumes:
+        - name: hostetc
+          hostPath:
+            path: /etc
+        - name: hostvar
+          hostPath:
+            path: /var
+        - name: hostrun
+          hostPath:
+            path: /run
+        - name: hostmodules
+          hostPath:
+            path: /lib/modules
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aci-containers-controller
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+    name: aci-containers-controller
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: aci-containers-controller
+      network-plugin: aci-containers
+  template:
+    metadata:
+      name: aci-containers-controller
+      namespace: kube-system
+      labels:
+        name: aci-containers-controller
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      serviceAccountName: aci-containers-controller
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+      priorityClassName: system-node-critical
+      containers:
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:5.2.2.0.0ef4718
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: ACI_SNAT_NAMESPACE
+              value: "aci-containers-system"
+            - name: ACI_SNAGLOBALINFO_NAME
+              value: "snatglobalinfo"
+            - name: ACI_RDCONFIG_NAME
+              value: "routingdomain-config"
+            - name: SYSTEM_NAMESPACE
+              value: "kube-system"
+          volumeMounts:
+            - name: controller-config-volume
+              mountPath: /usr/local/etc/aci-containers/
+            - name: aci-user-cert-volume
+              mountPath: /usr/local/etc/aci-cert/
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8091
+      volumes:
+        - name: aci-user-cert-volume
+          secret:
+            secretName: aci-user-cert
+        - name: controller-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: controller-config
+                path: controller.conf
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sriov-device-plugin
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-device-plugin-amd64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriovdp
+spec:
+  selector:
+    matchLabels:
+      name: sriov-device-plugin
+  template:
+    metadata:
+      labels:
+        name: sriov-device-plugin
+        tier: node
+        app: sriovdp
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: sriov-device-plugin
+      containers:
+      - name: kube-sriovdp
+        image: docker.io/nfvpe/sriov-device-plugin:v3.3
+        imagePullPolicy: IfNotPresent
+        args:
+        - --log-dir=sriovdp
+        - --log-level=10
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: devicesock
+          mountPath: /var/lib/kubelet/
+          readOnly: false
+        - name: log
+          mountPath: /var/log
+        - name: config-volume
+          mountPath: /etc/pcidp
+        - name: device-info
+          mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
+      volumes:
+        - name: devicesock
+          hostPath:
+            path: /var/lib/kubelet/
+        - name: log
+          hostPath:
+            path: /var/log
+        - name: device-info
+          hostPath:
+            path: /var/run/k8s.cni.cncf.io/devinfo/dp
+            type: DirectoryOrCreate
+        - name: config-volume
+          configMap:
+            name: sriovdp-config
+            items:
+            - key: config.json
+              path: config.json
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-device-plugin-ppc64le
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriovdp
+spec:
+  selector:
+    matchLabels:
+      name: sriov-device-plugin
+  template:
+    metadata:
+      labels:
+        name: sriov-device-plugin
+        tier: node
+        app: sriovdp
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: ppc64le
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: sriov-device-plugin
+      containers:
+      - name: kube-sriovdp
+        image: docker.io/nfvpe/sriov-device-plugin:ppc64le
+        imagePullPolicy: IfNotPresent
+        args:
+        - --log-dir=sriovdp
+        - --log-level=10
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: devicesock
+          mountPath: /var/lib/kubelet/
+          readOnly: false
+        - name: log
+          mountPath: /var/log
+        - name: config-volume
+          mountPath: /etc/pcidp
+        - name: device-info
+          mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
+      volumes:
+        - name: devicesock
+          hostPath:
+            path: /var/lib/kubelet/
+        - name: log
+          hostPath:
+            path: /var/log
+        - name: device-info
+          hostPath:
+            path: /var/run/k8s.cni.cncf.io/devinfo/dp
+            type: DirectoryOrCreate
+        - name: config-volume
+          configMap:
+            name: sriovdp-config
+            items:
+            - key: config.json
+              path: config.json
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-device-plugin-arm64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriovdp
+spec:
+  selector:
+    matchLabels:
+      name: sriov-device-plugin
+  template:
+    metadata:
+      labels:
+        name: sriov-device-plugin
+        tier: node
+        app: sriovdp
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: arm64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: sriov-device-plugin
+      containers:
+      - name: kube-sriovdp
+# this is a temporary image repository for arm64 architecture, util CI/CD of the
+# sriov-device-plugin will not allow to recreate multiple images
+        image: alexeyperevalov/arm64-sriov-device-plugin
+        imagePullPolicy: IfNotPresent
+        args:
+        - --log-dir=sriovdp
+        - --log-level=10
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: devicesock
+          mountPath: /var/lib/kubelet/
+          readOnly: false
+        - name: log
+          mountPath: /var/log
+        - name: config-volume
+          mountPath: /etc/pcidp
+        - name: device-info
+          mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
+      volumes:
+        - name: devicesock
+          hostPath:
+            path: /var/lib/kubelet/
+        - name: log
+          hostPath:
+            path: /var/log
+        - name: device-info
+          hostPath:
+            path: /var/run/k8s.cni.cncf.io/devinfo/dp
+            type: DirectoryOrCreate
+        - name: config-volume
+          configMap:
+            name: sriovdp-config
+            items:
+            - key: config.json
+              path: config.json
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sriovdp-config
+  namespace: kube-system
+data:
+  config.json: |
+    {
+        "resourceList": [
+                 {
+                   "resourcePrefix": "mellanox.com",
+                   "resourceName": "cx5_sriov_switchdev",
+                   "selectors": {
+                      "vendors": ["15b3"],
+                      "devices": ["1110"],
+                      "drivers": ["mlx5_core"],
+                      "isRdma":  true
+                   }
+                 }
+        ]
+    }
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-operator
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers-operator
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  - namespaces
+  - configmaps
+  - secrets
+  - pods
+  - services
+  - serviceaccounts
+  - serviceaccounts/token
+  - endpoints
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.ctrl
+  resources:
+  - acicontainersoperators
+  - acicontainersoperators/status
+  - acicontainersoperators/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.snat
+  resources:
+  - snatpolicies
+  - snatglobalinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - aci.snat
+  resources:
+  - nodeinfos
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+- apiGroups:
+  - config.openshift.io
+  - operator.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers-operator
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers-operator
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-operator
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aci-containers-operator
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    name: aci-containers-operator
+    network-plugin: aci-containers
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: aci-containers-operator
+      network-plugin: aci-containers
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: aci-containers-operator
+      namespace: kube-system
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: aci-containers-operator
+        network-plugin: aci-containers
+    spec:
+      containers:
+      - image: noiro/aci-containers-operator:5.2.2.0.0ef4718
+        imagePullPolicy: Always
+        name: aci-containers-operator
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - name: aci-operator-config
+          mountPath: /usr/local/etc/aci-containers/
+        env:
+        - name: SYSTEM_NAMESPACE
+          value: "kube-system"
+        - name: ACC_PROVISION_FLAVOR
+          value: "kubernetes-1.22"
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: aci-containers-operator
+      serviceAccountName: aci-containers-operator
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - name: aci-operator-config
+        configMap:
+          name: aci-operator-config
+          items:
+            - key: spec
+              path: aci-operator.conf

--- a/provision/testdata/with_sriov_config_no_deviceinfo_input.yaml
+++ b/provision/testdata/with_sriov_config_no_deviceinfo_input.yaml
@@ -1,0 +1,56 @@
+aci_config:
+  system_id: kube
+  use_legacy_kube_naming_convention: True
+  apic_hosts:
+    - 10.30.120.100
+  apic_login:
+    username: admin
+    password: noir0123
+  aep: kube-aep
+  vrf:
+    name: kube
+    tenant: common
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  custom_epgs:
+    - group1
+    - group2
+
+net_config:
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+
+kube_config:
+  controller: 1.1.1.1
+  use_cluster_role: true
+  use_ds_rolling_update: true
+
+registry:
+  image_prefix: noiro
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info
+
+sriov_config:
+  enable: True
+  device_info:
+      isRdma: False
+      devices: "" 

--- a/provision/testdata/with_sriov_config_no_deviceinfo_kube.yaml
+++ b/provision/testdata/with_sriov_config_no_deviceinfo_kube.yaml
@@ -1,0 +1,2405 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: acicontainersoperators.aci.ctrl
+spec:
+  group: aci.ctrl
+  names:
+    kind: AciContainersOperator
+    listKind: AciContainersOperatorList
+    plural: acicontainersoperators
+    singular: acicontainersoperator
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: acicontainersoperator owns the lifecycle of ACI objects in the cluster
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AciContainersOperatorSpec defines the desired spec for ACI Objects
+            properties:
+              flavor:
+                type: string
+              config:
+                type: string
+            type: object
+          status:
+            description: AciContainersOperatorStatus defines the successful completion of AciContainersOperator
+            properties:
+              status:
+                type: boolean
+            type: object
+        required:
+        - spec
+        type: object
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+  annotations:
+    openshift.io/node-selector: ''
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: podifs.aci.aw
+spec:
+  group: aci.aw
+  names:
+    kind: PodIF
+    listKind: PodIFList
+    plural: podifs
+    singular: podif
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: PodIF describes a pod network interface
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          status:
+            description: PodIFStatus is the status of a PodIF
+            properties:
+              containerID:
+                type: string
+              epg:
+                type: string
+              ifname:
+                type: string
+              ipaddr:
+                type: string
+              macaddr:
+                type: string
+              podname:
+                type: string
+              podns:
+                type: string
+              vtep:
+                type: string
+            type: object
+        required:
+        - status
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatglobalinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatGlobalInfo
+    listKind: SnatGlobalInfoList
+    plural: snatglobalinfos
+    singular: snatglobalinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: SnatGlobalInfo is the Schema for the snatglobalinfos API
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              globalInfos:
+                additionalProperties:
+                  items:
+                    properties:
+                      macAddress:
+                        type: string
+                      portRanges:
+                        items:
+                          properties:
+                            end:
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            start:
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          type: object
+                        type: array
+                      snatIp:
+                        type: string
+                      snatIpUid:
+                        type: string
+                      snatPolicyName:
+                        type: string
+                    required:
+                    - macAddress
+                    - portRanges
+                    - snatIp
+                    - snatIpUid
+                    - snatPolicyName
+                    type: object
+                  type: array
+                type: object
+            required:
+            - globalInfos
+            type: object
+          status:
+            description: SnatGlobalInfoStatus defines the observed state of SnatGlobalInfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatlocalinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatLocalInfo
+    listKind: SnatLocalInfoList
+    plural: snatlocalinfos
+    singular: snatlocalinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SnatLocalInfoSpec defines the desired state of SnatLocalInfo
+            properties:
+              localInfos:
+                items:
+                  properties:
+                    podName:
+                      type: string
+                    podNamespace:
+                      type: string
+                    podUid:
+                      type: string
+                    snatPolicies:
+                      items:
+                        properties:
+                          destIp:
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            type: string
+                          snatIp:
+                            type: string
+                        required:
+                        - destIp
+                        - name
+                        - snatIp
+                        type: object
+                      type: array
+                  required:
+                  - podName
+                  - podNamespace
+                  - podUid
+                  - snatPolicies
+                  type: object
+                type: array
+            required:
+            - localInfos
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatpolicies.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatPolicy
+    listKind: SnatPolicyList
+    plural: snatpolicies
+    singular: snatpolicy
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            properties:
+              selector:
+                type: object
+                properties:
+                  labels:
+                    type: object
+                    description: 'Selection of Pods'
+                    properties:
+                    additionalProperties:
+                      type: string
+                  namespace:
+                    type: string
+                type: object
+              snatIp:
+                type: array
+                items:
+                  type: string
+              destIp:
+                type: array
+                items:
+                  type: string
+            type: object
+          status:
+            type: object
+            properties:
+            additionalProperties:
+              type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nodeinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: NodeInfo
+    listKind: NodeInfoList
+    plural: nodeinfos
+    singular: nodeinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              macaddress:
+                type: string
+              snatpolicynames:
+                additionalProperties:
+                  type: boolean
+                type: object
+            type: object
+          status:
+            description: NodeinfoStatus defines the observed state of Nodeinfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rdconfigs.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: RdConfig
+    listKind: RdConfigList
+    plural: rdconfigs
+    singular: rdconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              discoveredsubnets:
+                items:
+                  type: string
+                type: array
+              usersubnets:
+                items:
+                  type: string
+                type: array
+            required:
+            - usersubnets
+            type: object
+          status:
+            description: NodeinfoStatus defines the observed state of Nodeinfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.aci.netpol
+spec:
+  group: aci.netpol
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Network Policy describes traffic flow at IP address or port level
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              appliedTo:
+                properties:
+                  namespaceSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  podSelector:
+                    description: allow ingress from the same namespace
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+              egress:
+                description: Set of egress rules evaluated based on the order in which they are set.
+                items:
+                  properties:
+                    action:
+                      description: Action specifies the action to be applied on the rule.
+                      type: string
+                    enableLogging:
+                      description: EnableLogging is used to indicate if agent should generate logs default to false.
+                      type: boolean
+                    ports:
+                      description: Set of port and protocol allowed/denied by the rule. If this field is unset or empty, this rule matches all ports.
+                      items:
+                        description: NetworkPolicyPort describes the port and protocol to match in a rule.
+                        properties:
+                          endPort:
+                            description: EndPort defines the end of the port range, being the end included within the range. It can only be specified when a numerical `port` is specified.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can be either a numerical or named port on a Pod. If this field is not provided, this matches all port names and numbers.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            default: TCP
+                            description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      description: Rule is matched if traffic is intended for workloads selected by this field. If this field is empty or missing, this rule matches all destinations.
+                      items:
+                        properties:
+                          ipBlock:
+                            description: IPBlock describes the IPAddresses/IPBlocks that is matched in to/from. IPBlock cannot be set as part of the AppliedTo field. Cannot be set with any other selector.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            description: Select all Pods from Namespaces matched by this selector, as workloads in To/From fields. If set with PodSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except PodSelector or ExternalEntitySelector.
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          podSelector:
+                            description: Select Pods from NetworkPolicy's Namespace as workloads in AppliedTo/To/From fields. If set with NamespaceSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    toFqDn:
+                      properties:
+                        matchNames:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - matchNames
+                      type: object
+                  required:
+                  - enableLogging
+                  - toFqDn
+                  type: object
+                type: array
+              ingress:
+                description: Set of ingress rules evaluated based on the order in which they are set.
+                items:
+                  properties:
+                    action:
+                      description: Action specifies the action to be applied on the rule.
+                      type: string
+                    enableLogging:
+                      description: EnableLogging is used to indicate if agent should generate logs when rules are matched. Should be default to false.
+                      type: boolean
+                    from:
+                      description: Rule is matched if traffic originates from workloads selected by this field. If this field is empty, this rule matches all sources.
+                      items:
+                        properties:
+                          ipBlock:
+                            description: IPBlock describes the IPAddresses/IPBlocks that is matched in to/from. IPBlock cannot be set as part of the AppliedTo field. Cannot be set with any other selector.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          podSelector:
+                            description: Select Pods from NetworkPolicy's Namespace as workloads in AppliedTo/To/From fields. If set with NamespaceSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    ports:
+                      description: Set of port and protocol allowed/denied by the rule. If this field is unset or empty, this rule matches all ports.
+                      items:
+                        description: NetworkPolicyPort describes the port and protocol to match in a rule.
+                        properties:
+                          endPort:
+                            description: EndPort defines the end of the port range, being the end included within the range. It can only be specified when a numerical `port` is specified.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can be either a numerical or named port on a Pod. If this field is not provided, this matches all port names and numbers.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            default: TCP
+                            description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              policyTypes:
+                items:
+                  description: Policy Type string describes the NetworkPolicy type This type is beta-level in 1.8
+                  type: string
+                type: array
+              priority:
+                description: Priority specfies the order of the NetworkPolicy relative to other NetworkPolicies.
+                type: integer
+              type:
+                description: type of the policy.
+                type: string
+            required:
+            - type
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dnsnetworkpolicies.aci.dnsnetpol
+spec:
+  group: aci.dnsnetpol
+  names:
+    kind: DnsNetworkPolicy
+    listKind: DnsNetworkPolicyList
+    plural: dnsnetworkpolicies
+    singular: dnsnetworkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1beta
+    schema:
+      openAPIV3Schema:
+        description: dns network Policy
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              appliedTo:
+                properties:
+                  namespaceSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  podSelector:
+                    description: allow ingress from the same namespace
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+              egress:
+                description: Set of egress rules evaluated based on the order in which they are set.
+                properties:
+                  toFqdn:
+                    properties:
+                      matchNames:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - matchNames
+                    type: object
+                required:
+                - toFqdn
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: qospolicies.aci.qos
+spec:
+  group: aci.qos
+  names:
+    kind: QosPolicy
+    listKind: QosPolicyList
+    plural: qospolicies
+    singular: qospolicy
+  scope: Namespaced
+  preserveUnknownFields: false
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              podSelector:
+                description: 'Selection of Pods'
+                type: object
+                properties:
+                  matchLabels:
+                    type: object
+                    description:
+              ingress:
+                type: object
+                properties:
+                  policing_rate:
+                    type: integer
+                    minimum: 0
+                  policing_burst:
+                    type: integer
+                    minimum: 0
+              egress:
+                type: object
+                properties:
+                  policing_rate:
+                    type: integer
+                    minimum: 0
+                  policing_burst:
+                    type: integer
+                    minimum: 0
+              dscpmark:
+                type: integer
+                default: 0
+                minimum: 0
+                maximum: 63
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: netflowpolicies.aci.netflow
+spec:
+  group: aci.netflow
+  names:
+    kind: NetflowPolicy
+    listKind: NetflowPolicyList
+    plural: netflowpolicies
+    singular: netflowpolicy
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+  - name: v1alpha
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              flowSamplingPolicy:
+                type: object
+                properties:
+                  destIp:
+                    type: string
+                  destPort:
+                    type: integer
+                    minimum: 0
+                    maximum: 65535
+                    default: 2055
+                  flowType:
+                    type: string
+                    enum:
+                      - netflow
+                      - ipfix
+                    default: netflow
+                  activeFlowTimeOut:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                    default: 60
+                  idleFlowTimeOut:
+                    type: integer
+                    minimum: 0
+                    maximum: 600
+                    default: 15
+                  samplingRate:
+                    type: integer
+                    minimum: 0
+                    maximum: 1000
+                    default: 0
+                required:
+                - destIp
+                type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: erspanpolicies.aci.erspan
+spec:
+  group: aci.erspan
+  names:
+    kind: ErspanPolicy
+    listKind: ErspanPolicyList
+    plural: erspanpolicies
+    singular: erspanpolicy
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+  - name: v1alpha
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              selector:
+                type: object
+                description: 'Selection of Pods'
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+                  namespace:
+                    type: string
+              source:
+                type: object
+                properties:
+                  adminState:
+                    description: Administrative state.
+                    default: start
+                    type: string
+                    enum:
+                      - start
+                      - stop
+                  direction:
+                    description: Direction of the packets to monitor.
+                    default: both
+                    type: string
+                    enum:
+                      - in
+                      - out
+                      - both
+              destination:
+                type: object
+                properties:
+                  destIP:
+                    description: Destination IP of the ERSPAN packet.
+                    type: string
+                  flowID:
+                    description: Unique flow ID of the ERSPAN packet.
+                    default: 1
+                    type: integer
+                    minimum: 1
+                    maximum: 1023
+                required:
+                - destIP
+                type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: enabledroplogs.aci.droplog
+spec:
+  group: aci.droplog
+  names:
+    kind: EnableDropLog
+    listKind: EnableDropLogList
+    plural: enabledroplogs
+    singular: enabledroplog
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            description: Defines the desired state of EnableDropLog
+            type: object
+            properties:
+              disableDefaultDropLog:
+                description: Disables the default droplog enabled by acc-provision.
+                default: false
+                type: boolean
+              nodeSelector:
+                type: object
+                description: Drop logging is enabled on nodes selected based on labels
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: prunedroplogs.aci.droplog
+spec:
+  group: aci.droplog
+  names:
+    kind: PruneDropLog
+    listKind: PruneDropLogList
+    plural: prunedroplogs
+    singular: prunedroplog
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            description: Defines the desired state of PruneDropLog
+            type: object
+            properties:
+              nodeSelector:
+                type: object
+                description: Drop logging filters are applied to nodes selected based on labels
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+              dropLogFilters:
+                type: object
+                properties:
+                  srcIP:
+                    type: string
+                  destIP:
+                    type: string
+                  srcMAC:
+                    type: string
+                  destMAC:
+                    type: string
+                  srcPort:
+                    type: integer
+                  destPort:
+                    type: integer
+                  ipProto:
+                    type: integer
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: aciistiooperators.aci.istio
+spec:
+  group: aci.istio
+  names:
+    kind: AciIstioOperator
+    listKind: AciIstioOperatorList
+    plural: aciistiooperators
+    singular: aciistiooperator
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AciIstioOperatorSpec defines the desired state of AciIstioOperator
+            properties:
+              config:
+                type: string
+              profile:
+                type: string
+            required:
+            - config
+            - profile
+            type: object
+          status:
+            description: AciIstioOperatorStatus defines the observed state of AciIstioOperator
+            properties:
+              Successful or Not:
+                type: boolean
+            required:
+            - Successful or Not
+            type: object
+        type: object
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aci-operator-config
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  spec: |-
+    {
+        "flavor": "kubernetes-1.22",
+        "config": "CmFwaVZlcnNpb246IHYxCmtpbmQ6IE5hbWVzcGFjZQptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogIGFubm90YXRpb25zOgogICAgb3BlbnNoaWZ0LmlvL25vZGUtc2VsZWN0b3I6ICcnCi0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogcG9kaWZzLmFjaS5hdwpzcGVjOgogIGdyb3VwOiBhY2kuYXcKICBuYW1lczoKICAgIGtpbmQ6IFBvZElGCiAgICBsaXN0S2luZDogUG9kSUZMaXN0CiAgICBwbHVyYWw6IHBvZGlmcwogICAgc2luZ3VsYXI6IHBvZGlmCiAgc2NvcGU6IE5hbWVzcGFjZWQKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIGRlc2NyaXB0aW9uOiBQb2RJRiBkZXNjcmliZXMgYSBwb2QgbmV0d29yayBpbnRlcmZhY2UKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHN0YXR1czoKICAgICAgICAgICAgZGVzY3JpcHRpb246IFBvZElGU3RhdHVzIGlzIHRoZSBzdGF0dXMgb2YgYSBQb2RJRgogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIGNvbnRhaW5lcklEOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgZXBnOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgaWZuYW1lOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgaXBhZGRyOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgbWFjYWRkcjoKICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgIHBvZG5hbWU6CiAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICBwb2RuczoKICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgIHZ0ZXA6CiAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgLSBzdGF0dXMKICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBzbmF0Z2xvYmFsaW5mb3MuYWNpLnNuYXQKc3BlYzoKICBncm91cDogYWNpLnNuYXQKICBuYW1lczoKICAgIGtpbmQ6IFNuYXRHbG9iYWxJbmZvCiAgICBsaXN0S2luZDogU25hdEdsb2JhbEluZm9MaXN0CiAgICBwbHVyYWw6IHNuYXRnbG9iYWxpbmZvcwogICAgc2luZ3VsYXI6IHNuYXRnbG9iYWxpbmZvCiAgc2NvcGU6IE5hbWVzcGFjZWQKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIGRlc2NyaXB0aW9uOiBTbmF0R2xvYmFsSW5mbyBpcyB0aGUgU2NoZW1hIGZvciB0aGUgc25hdGdsb2JhbGluZm9zIEFQSQogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgbWV0YWRhdGE6CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBnbG9iYWxJbmZvczoKICAgICAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgbWFjQWRkcmVzczoKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICBwb3J0UmFuZ2VzOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZW5kOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXhpbXVtOiA2NTUzNQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAxCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHN0YXJ0OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXhpbXVtOiA2NTUzNQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAxCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgIHNuYXRJcDoKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICBzbmF0SXBVaWQ6CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgc25hdFBvbGljeU5hbWU6CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgIC0gbWFjQWRkcmVzcwogICAgICAgICAgICAgICAgICAgIC0gcG9ydFJhbmdlcwogICAgICAgICAgICAgICAgICAgIC0gc25hdElwCiAgICAgICAgICAgICAgICAgICAgLSBzbmF0SXBVaWQKICAgICAgICAgICAgICAgICAgICAtIHNuYXRQb2xpY3lOYW1lCiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgIC0gZ2xvYmFsSW5mb3MKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzdGF0dXM6CiAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTbmF0R2xvYmFsSW5mb1N0YXR1cyBkZWZpbmVzIHRoZSBvYnNlcnZlZCBzdGF0ZSBvZiBTbmF0R2xvYmFsSW5mbwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBzbmF0bG9jYWxpbmZvcy5hY2kuc25hdApzcGVjOgogIGdyb3VwOiBhY2kuc25hdAogIG5hbWVzOgogICAga2luZDogU25hdExvY2FsSW5mbwogICAgbGlzdEtpbmQ6IFNuYXRMb2NhbEluZm9MaXN0CiAgICBwbHVyYWw6IHNuYXRsb2NhbGluZm9zCiAgICBzaW5ndWxhcjogc25hdGxvY2FsaW5mbwogIHNjb3BlOiBOYW1lc3BhY2VkCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTbmF0TG9jYWxJbmZvU3BlYyBkZWZpbmVzIHRoZSBkZXNpcmVkIHN0YXRlIG9mIFNuYXRMb2NhbEluZm8KICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBsb2NhbEluZm9zOgogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgcG9kTmFtZToKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIHBvZE5hbWVzcGFjZToKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIHBvZFVpZDoKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIHNuYXRQb2xpY2llczoKICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGRlc3RJcDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgbmFtZToKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgIHNuYXRJcDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgLSBkZXN0SXAKICAgICAgICAgICAgICAgICAgICAgICAgLSBuYW1lCiAgICAgICAgICAgICAgICAgICAgICAgIC0gc25hdElwCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgIC0gcG9kTmFtZQogICAgICAgICAgICAgICAgICAtIHBvZE5hbWVzcGFjZQogICAgICAgICAgICAgICAgICAtIHBvZFVpZAogICAgICAgICAgICAgICAgICAtIHNuYXRQb2xpY2llcwogICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAtIGxvY2FsSW5mb3MKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgdHlwZTogb2JqZWN0Ci0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogc25hdHBvbGljaWVzLmFjaS5zbmF0CnNwZWM6CiAgZ3JvdXA6IGFjaS5zbmF0CiAgbmFtZXM6CiAgICBraW5kOiBTbmF0UG9saWN5CiAgICBsaXN0S2luZDogU25hdFBvbGljeUxpc3QKICAgIHBsdXJhbDogc25hdHBvbGljaWVzCiAgICBzaW5ndWxhcjogc25hdHBvbGljeQogIHNjb3BlOiBDbHVzdGVyCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzdWJyZXNvdXJjZXM6CiAgICAgIHN0YXR1czoge30KICAgIHNjaGVtYToKICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgbWV0YWRhdGE6CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgc2VsZWN0b3I6CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIGxhYmVsczoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogJ1NlbGVjdGlvbiBvZiBQb2RzJwogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgbmFtZXNwYWNlOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgc25hdElwOgogICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICBkZXN0SXA6CiAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHN0YXR1czoKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgIHR5cGU6IHN0cmluZwotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IG5vZGVpbmZvcy5hY2kuc25hdApzcGVjOgogIGdyb3VwOiBhY2kuc25hdAogIG5hbWVzOgogICAga2luZDogTm9kZUluZm8KICAgIGxpc3RLaW5kOiBOb2RlSW5mb0xpc3QKICAgIHBsdXJhbDogbm9kZWluZm9zCiAgICBzaW5ndWxhcjogbm9kZWluZm8KICBzY29wZTogTmFtZXNwYWNlZAogIHZlcnNpb25zOgogIC0gbmFtZTogdjEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIG1hY2FkZHJlc3M6CiAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICBzbmF0cG9saWN5bmFtZXM6CiAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgdHlwZTogYm9vbGVhbgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3RhdHVzOgogICAgICAgICAgICBkZXNjcmlwdGlvbjogTm9kZWluZm9TdGF0dXMgZGVmaW5lcyB0aGUgb2JzZXJ2ZWQgc3RhdGUgb2YgTm9kZWluZm8KICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgdHlwZTogb2JqZWN0Ci0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogcmRjb25maWdzLmFjaS5zbmF0CnNwZWM6CiAgZ3JvdXA6IGFjaS5zbmF0CiAgbmFtZXM6CiAgICBraW5kOiBSZENvbmZpZwogICAgbGlzdEtpbmQ6IFJkQ29uZmlnTGlzdAogICAgcGx1cmFsOiByZGNvbmZpZ3MKICAgIHNpbmd1bGFyOiByZGNvbmZpZwogIHNjb3BlOiBOYW1lc3BhY2VkCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgZGlzY292ZXJlZHN1Ym5ldHM6CiAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgIHVzZXJzdWJuZXRzOgogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgIC0gdXNlcnN1Ym5ldHMKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzdGF0dXM6CiAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBOb2RlaW5mb1N0YXR1cyBkZWZpbmVzIHRoZSBvYnNlcnZlZCBzdGF0ZSBvZiBOb2RlaW5mbwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBuZXR3b3JrcG9saWNpZXMuYWNpLm5ldHBvbApzcGVjOgogIGdyb3VwOiBhY2kubmV0cG9sCiAgbmFtZXM6CiAgICBraW5kOiBOZXR3b3JrUG9saWN5CiAgICBsaXN0S2luZDogTmV0d29ya1BvbGljeUxpc3QKICAgIHBsdXJhbDogbmV0d29ya3BvbGljaWVzCiAgICBzaW5ndWxhcjogbmV0d29ya3BvbGljeQogIHNjb3BlOiBOYW1lc3BhY2VkCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgZGVzY3JpcHRpb246IE5ldHdvcmsgUG9saWN5IGRlc2NyaWJlcyB0cmFmZmljIGZsb3cgYXQgSVAgYWRkcmVzcyBvciBwb3J0IGxldmVsCiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIGFwcGxpZWRUbzoKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIG5hbWVzcGFjZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICBwb2RTZWxlY3RvcjoKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogYWxsb3cgaW5ncmVzcyBmcm9tIHRoZSBzYW1lIG5hbWVzcGFjZQogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgZWdyZXNzOgogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNldCBvZiBlZ3Jlc3MgcnVsZXMgZXZhbHVhdGVkIGJhc2VkIG9uIHRoZSBvcmRlciBpbiB3aGljaCB0aGV5IGFyZSBzZXQuCiAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICBhY3Rpb246CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogQWN0aW9uIHNwZWNpZmllcyB0aGUgYWN0aW9uIHRvIGJlIGFwcGxpZWQgb24gdGhlIHJ1bGUuCiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICBlbmFibGVMb2dnaW5nOgogICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEVuYWJsZUxvZ2dpbmcgaXMgdXNlZCB0byBpbmRpY2F0ZSBpZiBhZ2VudCBzaG91bGQgZ2VuZXJhdGUgbG9ncyBkZWZhdWx0IHRvIGZhbHNlLgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYm9vbGVhbgogICAgICAgICAgICAgICAgICAgIHBvcnRzOgogICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNldCBvZiBwb3J0IGFuZCBwcm90b2NvbCBhbGxvd2VkL2RlbmllZCBieSB0aGUgcnVsZS4gSWYgdGhpcyBmaWVsZCBpcyB1bnNldCBvciBlbXB0eSwgdGhpcyBydWxlIG1hdGNoZXMgYWxsIHBvcnRzLgogICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBOZXR3b3JrUG9saWN5UG9ydCBkZXNjcmliZXMgdGhlIHBvcnQgYW5kIHByb3RvY29sIHRvIG1hdGNoIGluIGEgcnVsZS4KICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICBlbmRQb3J0OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEVuZFBvcnQgZGVmaW5lcyB0aGUgZW5kIG9mIHRoZSBwb3J0IHJhbmdlLCBiZWluZyB0aGUgZW5kIGluY2x1ZGVkIHdpdGhpbiB0aGUgcmFuZ2UuIEl0IGNhbiBvbmx5IGJlIHNwZWNpZmllZCB3aGVuIGEgbnVtZXJpY2FsIGBwb3J0YCBpcyBzcGVjaWZpZWQuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBmb3JtYXQ6IGludDMyCiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgICAgICAgcG9ydDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGFueU9mOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgLSB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFRoZSBwb3J0IG9uIHRoZSBnaXZlbiBwcm90b2NvbC4gVGhpcyBjYW4gYmUgZWl0aGVyIGEgbnVtZXJpY2FsIG9yIG5hbWVkIHBvcnQgb24gYSBQb2QuIElmIHRoaXMgZmllbGQgaXMgbm90IHByb3ZpZGVkLCB0aGlzIG1hdGNoZXMgYWxsIHBvcnQgbmFtZXMgYW5kIG51bWJlcnMuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICB4LWt1YmVybmV0ZXMtaW50LW9yLXN0cmluZzogdHJ1ZQogICAgICAgICAgICAgICAgICAgICAgICAgIHByb3RvY29sOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVmYXVsdDogVENQCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogVGhlIHByb3RvY29sIChUQ1AsIFVEUCwgb3IgU0NUUCkgd2hpY2ggdHJhZmZpYyBtdXN0IG1hdGNoLiBJZiBub3Qgc3BlY2lmaWVkLCB0aGlzIGZpZWxkIGRlZmF1bHRzIHRvIFRDUC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgdG86CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogUnVsZSBpcyBtYXRjaGVkIGlmIHRyYWZmaWMgaXMgaW50ZW5kZWQgZm9yIHdvcmtsb2FkcyBzZWxlY3RlZCBieSB0aGlzIGZpZWxkLiBJZiB0aGlzIGZpZWxkIGlzIGVtcHR5IG9yIG1pc3NpbmcsIHRoaXMgcnVsZSBtYXRjaGVzIGFsbCBkZXN0aW5hdGlvbnMuCiAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICBpcEJsb2NrOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IElQQmxvY2sgZGVzY3JpYmVzIHRoZSBJUEFkZHJlc3Nlcy9JUEJsb2NrcyB0aGF0IGlzIG1hdGNoZWQgaW4gdG8vZnJvbS4gSVBCbG9jayBjYW5ub3QgYmUgc2V0IGFzIHBhcnQgb2YgdGhlIEFwcGxpZWRUbyBmaWVsZC4gQ2Fubm90IGJlIHNldCB3aXRoIGFueSBvdGhlciBzZWxlY3Rvci4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNpZHI6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IENJRFIgaXMgYSBzdHJpbmcgcmVwcmVzZW50aW5nIHRoZSBJUCBCbG9jayBWYWxpZCBleGFtcGxlcyBhcmUgIjE5Mi4xNjguMS4xLzI0IiBvciAiMjAwMTpkYjk6Oi82NCIKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZXhjZXB0OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBFeGNlcHQgaXMgYSBzbGljZSBvZiBDSURScyB0aGF0IHNob3VsZCBub3QgYmUgaW5jbHVkZWQgd2l0aGluIGFuIElQIEJsb2NrIFZhbGlkIGV4YW1wbGVzIGFyZSAiMTkyLjE2OC4xLjEvMjQiIG9yICIyMDAxOmRiOTo6LzY0IiBFeGNlcHQgdmFsdWVzIHdpbGwgYmUgcmVqZWN0ZWQgaWYgdGhleSBhcmUgb3V0c2lkZSB0aGUgQ0lEUiByYW5nZQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgLSBjaWRyCiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICBuYW1lc3BhY2VTZWxlY3RvcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTZWxlY3QgYWxsIFBvZHMgZnJvbSBOYW1lc3BhY2VzIG1hdGNoZWQgYnkgdGhpcyBzZWxlY3RvciwgYXMgd29ya2xvYWRzIGluIFRvL0Zyb20gZmllbGRzLiBJZiBzZXQgd2l0aCBQb2RTZWxlY3RvciwgUG9kcyBhcmUgbWF0Y2hlZCBmcm9tIE5hbWVzcGFjZXMgbWF0Y2hlZCBieSB0aGUgTmFtZXNwYWNlU2VsZWN0b3IuIENhbm5vdCBiZSBzZXQgd2l0aCBhbnkgb3RoZXIgc2VsZWN0b3IgZXhjZXB0IFBvZFNlbGVjdG9yIG9yIEV4dGVybmFsRW50aXR5U2VsZWN0b3IuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBvcGVyYXRvcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogb3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuIFZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFsdWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiB2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0ga2V5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgICAgcG9kU2VsZWN0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogU2VsZWN0IFBvZHMgZnJvbSBOZXR3b3JrUG9saWN5J3MgTmFtZXNwYWNlIGFzIHdvcmtsb2FkcyBpbiBBcHBsaWVkVG8vVG8vRnJvbSBmaWVsZHMuIElmIHNldCB3aXRoIE5hbWVzcGFjZVNlbGVjdG9yLCBQb2RzIGFyZSBtYXRjaGVkIGZyb20gTmFtZXNwYWNlcyBtYXRjaGVkIGJ5IHRoZSBOYW1lc3BhY2VTZWxlY3Rvci4gQ2Fubm90IGJlIHNldCB3aXRoIGFueSBvdGhlciBzZWxlY3RvciBleGNlcHQgTmFtZXNwYWNlU2VsZWN0b3IuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBvcGVyYXRvcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogb3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuIFZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFsdWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiB2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0ga2V5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICB0b0ZxRG46CiAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICBtYXRjaE5hbWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgICAgLSBtYXRjaE5hbWVzCiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgIC0gZW5hYmxlTG9nZ2luZwogICAgICAgICAgICAgICAgICAtIHRvRnFEbgogICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgaW5ncmVzczoKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTZXQgb2YgaW5ncmVzcyBydWxlcyBldmFsdWF0ZWQgYmFzZWQgb24gdGhlIG9yZGVyIGluIHdoaWNoIHRoZXkgYXJlIHNldC4KICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgIGFjdGlvbjoKICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBBY3Rpb24gc3BlY2lmaWVzIHRoZSBhY3Rpb24gdG8gYmUgYXBwbGllZCBvbiB0aGUgcnVsZS4KICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIGVuYWJsZUxvZ2dpbmc6CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRW5hYmxlTG9nZ2luZyBpcyB1c2VkIHRvIGluZGljYXRlIGlmIGFnZW50IHNob3VsZCBnZW5lcmF0ZSBsb2dzIHdoZW4gcnVsZXMgYXJlIG1hdGNoZWQuIFNob3VsZCBiZSBkZWZhdWx0IHRvIGZhbHNlLgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYm9vbGVhbgogICAgICAgICAgICAgICAgICAgIGZyb206CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogUnVsZSBpcyBtYXRjaGVkIGlmIHRyYWZmaWMgb3JpZ2luYXRlcyBmcm9tIHdvcmtsb2FkcyBzZWxlY3RlZCBieSB0aGlzIGZpZWxkLiBJZiB0aGlzIGZpZWxkIGlzIGVtcHR5LCB0aGlzIHJ1bGUgbWF0Y2hlcyBhbGwgc291cmNlcy4KICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGlwQmxvY2s6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogSVBCbG9jayBkZXNjcmliZXMgdGhlIElQQWRkcmVzc2VzL0lQQmxvY2tzIHRoYXQgaXMgbWF0Y2hlZCBpbiB0by9mcm9tLiBJUEJsb2NrIGNhbm5vdCBiZSBzZXQgYXMgcGFydCBvZiB0aGUgQXBwbGllZFRvIGZpZWxkLiBDYW5ub3QgYmUgc2V0IHdpdGggYW55IG90aGVyIHNlbGVjdG9yLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgY2lkcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogQ0lEUiBpcyBhIHN0cmluZyByZXByZXNlbnRpbmcgdGhlIElQIEJsb2NrIFZhbGlkIGV4YW1wbGVzIGFyZSAiMTkyLjE2OC4xLjEvMjQiIG9yICIyMDAxOmRiOTo6LzY0IgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBleGNlcHQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEV4Y2VwdCBpcyBhIHNsaWNlIG9mIENJRFJzIHRoYXQgc2hvdWxkIG5vdCBiZSBpbmNsdWRlZCB3aXRoaW4gYW4gSVAgQmxvY2sgVmFsaWQgZXhhbXBsZXMgYXJlICIxOTIuMTY4LjEuMS8yNCIgb3IgIjIwMDE6ZGI5OjovNjQiIEV4Y2VwdCB2YWx1ZXMgd2lsbCBiZSByZWplY3RlZCBpZiB0aGV5IGFyZSBvdXRzaWRlIHRoZSBDSURSIHJhbmdlCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIGNpZHIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgIG5hbWVzcGFjZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbWF0Y2hFeHByZXNzaW9uczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGtleToKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgb3BlcmF0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IG9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLiBWYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogdmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbiwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsIHRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIGtleQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgLSBvcGVyYXRvcgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbWF0Y2hMYWJlbHM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgIHBvZFNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNlbGVjdCBQb2RzIGZyb20gTmV0d29ya1BvbGljeSdzIE5hbWVzcGFjZSBhcyB3b3JrbG9hZHMgaW4gQXBwbGllZFRvL1RvL0Zyb20gZmllbGRzLiBJZiBzZXQgd2l0aCBOYW1lc3BhY2VTZWxlY3RvciwgUG9kcyBhcmUgbWF0Y2hlZCBmcm9tIE5hbWVzcGFjZXMgbWF0Y2hlZCBieSB0aGUgTmFtZXNwYWNlU2VsZWN0b3IuIENhbm5vdCBiZSBzZXQgd2l0aCBhbnkgb3RoZXIgc2VsZWN0b3IgZXhjZXB0IE5hbWVzcGFjZVNlbGVjdG9yLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbWF0Y2hFeHByZXNzaW9uczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogbWF0Y2hFeHByZXNzaW9ucyBpcyBhIGxpc3Qgb2YgbGFiZWwgc2VsZWN0b3IgcmVxdWlyZW1lbnRzLiBUaGUgcmVxdWlyZW1lbnRzIGFyZSBBTkRlZC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGtleToKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgb3BlcmF0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IG9wZXJhdG9yIHJlcHJlc2VudHMgYSBrZXkncyByZWxhdGlvbnNoaXAgdG8gYSBzZXQgb2YgdmFsdWVzLiBWYWxpZCBvcGVyYXRvcnMgYXJlIEluLCBOb3RJbiwgRXhpc3RzIGFuZCBEb2VzTm90RXhpc3QuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogdmFsdWVzIGlzIGFuIGFycmF5IG9mIHN0cmluZyB2YWx1ZXMuIElmIHRoZSBvcGVyYXRvciBpcyBJbiBvciBOb3RJbiwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIG5vbi1lbXB0eS4gSWYgdGhlIG9wZXJhdG9yIGlzIEV4aXN0cyBvciBEb2VzTm90RXhpc3QsIHRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBlbXB0eS4gVGhpcyBhcnJheSBpcyByZXBsYWNlZCBkdXJpbmcgYSBzdHJhdGVnaWMgbWVyZ2UgcGF0Y2guCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIGtleQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgLSBvcGVyYXRvcgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbWF0Y2hMYWJlbHM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgcG9ydHM6CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogU2V0IG9mIHBvcnQgYW5kIHByb3RvY29sIGFsbG93ZWQvZGVuaWVkIGJ5IHRoZSBydWxlLiBJZiB0aGlzIGZpZWxkIGlzIHVuc2V0IG9yIGVtcHR5LCB0aGlzIHJ1bGUgbWF0Y2hlcyBhbGwgcG9ydHMuCiAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IE5ldHdvcmtQb2xpY3lQb3J0IGRlc2NyaWJlcyB0aGUgcG9ydCBhbmQgcHJvdG9jb2wgdG8gbWF0Y2ggaW4gYSBydWxlLgogICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGVuZFBvcnQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRW5kUG9ydCBkZWZpbmVzIHRoZSBlbmQgb2YgdGhlIHBvcnQgcmFuZ2UsIGJlaW5nIHRoZSBlbmQgaW5jbHVkZWQgd2l0aGluIHRoZSByYW5nZS4gSXQgY2FuIG9ubHkgYmUgc3BlY2lmaWVkIHdoZW4gYSBudW1lcmljYWwgYHBvcnRgIGlzIHNwZWNpZmllZC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIGZvcm1hdDogaW50MzIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICBwb3J0OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgYW55T2Y6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0gdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogVGhlIHBvcnQgb24gdGhlIGdpdmVuIHByb3RvY29sLiBUaGlzIGNhbiBiZSBlaXRoZXIgYSBudW1lcmljYWwgb3IgbmFtZWQgcG9ydCBvbiBhIFBvZC4gSWYgdGhpcyBmaWVsZCBpcyBub3QgcHJvdmlkZWQsIHRoaXMgbWF0Y2hlcyBhbGwgcG9ydCBuYW1lcyBhbmQgbnVtYmVycy4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIHgta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nOiB0cnVlCiAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvdG9jb2w6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZWZhdWx0OiBUQ1AKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBUaGUgcHJvdG9jb2wgKFRDUCwgVURQLCBvciBTQ1RQKSB3aGljaCB0cmFmZmljIG11c3QgbWF0Y2guIElmIG5vdCBzcGVjaWZpZWQsIHRoaXMgZmllbGQgZGVmYXVsdHMgdG8gVENQLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgIHBvbGljeVR5cGVzOgogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBQb2xpY3kgVHlwZSBzdHJpbmcgZGVzY3JpYmVzIHRoZSBOZXR3b3JrUG9saWN5IHR5cGUgVGhpcyB0eXBlIGlzIGJldGEtbGV2ZWwgaW4gMS44CiAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICBwcmlvcml0eToKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBQcmlvcml0eSBzcGVjZmllcyB0aGUgb3JkZXIgb2YgdGhlIE5ldHdvcmtQb2xpY3kgcmVsYXRpdmUgdG8gb3RoZXIgTmV0d29ya1BvbGljaWVzLgogICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgIHR5cGU6CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogdHlwZSBvZiB0aGUgcG9saWN5LgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAtIHR5cGUKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgLSBzcGVjCiAgICAgICAgdHlwZTogb2JqZWN0CiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKc3RhdHVzOgogIGFjY2VwdGVkTmFtZXM6CiAgICBraW5kOiAiIgogICAgcGx1cmFsOiAiIgogIGNvbmRpdGlvbnM6IFtdCiAgc3RvcmVkVmVyc2lvbnM6IFtdCi0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogZG5zbmV0d29ya3BvbGljaWVzLmFjaS5kbnNuZXRwb2wKc3BlYzoKICBncm91cDogYWNpLmRuc25ldHBvbAogIG5hbWVzOgogICAga2luZDogRG5zTmV0d29ya1BvbGljeQogICAgbGlzdEtpbmQ6IERuc05ldHdvcmtQb2xpY3lMaXN0CiAgICBwbHVyYWw6IGRuc25ldHdvcmtwb2xpY2llcwogICAgc2luZ3VsYXI6IGRuc25ldHdvcmtwb2xpY3kKICBzY29wZTogTmFtZXNwYWNlZAogIHZlcnNpb25zOgogIC0gbmFtZTogdjFiZXRhCiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICBkZXNjcmlwdGlvbjogZG5zIG5ldHdvcmsgUG9saWN5CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIGFwcGxpZWRUbzoKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIG5hbWVzcGFjZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICBwb2RTZWxlY3RvcjoKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogYWxsb3cgaW5ncmVzcyBmcm9tIHRoZSBzYW1lIG5hbWVzcGFjZQogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogb3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuIFZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YWx1ZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiB2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgZWdyZXNzOgogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNldCBvZiBlZ3Jlc3MgcnVsZXMgZXZhbHVhdGVkIGJhc2VkIG9uIHRoZSBvcmRlciBpbiB3aGljaCB0aGV5IGFyZSBzZXQuCiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICB0b0ZxZG46CiAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgIG1hdGNoTmFtZXM6CiAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgIC0gbWF0Y2hOYW1lcwogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAtIHRvRnFkbgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHJlcXVpcmVkOgogICAgICAgIC0gc3BlYwogICAgICAgIHR5cGU6IG9iamVjdAogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCnN0YXR1czoKICBhY2NlcHRlZE5hbWVzOgogICAga2luZDogIiIKICAgIHBsdXJhbDogIiIKICBjb25kaXRpb25zOiBbXQogIHN0b3JlZFZlcnNpb25zOiBbXQotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IHFvc3BvbGljaWVzLmFjaS5xb3MKc3BlYzoKICBncm91cDogYWNpLnFvcwogIG5hbWVzOgogICAga2luZDogUW9zUG9saWN5CiAgICBsaXN0S2luZDogUW9zUG9saWN5TGlzdAogICAgcGx1cmFsOiBxb3Nwb2xpY2llcwogICAgc2luZ3VsYXI6IHFvc3BvbGljeQogIHNjb3BlOiBOYW1lc3BhY2VkCiAgcHJlc2VydmVVbmtub3duRmllbGRzOiBmYWxzZQogIHZlcnNpb25zOgogIC0gbmFtZTogdjEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc3VicmVzb3VyY2VzOgogICAgICBzdGF0dXM6IHt9CiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIHBvZFNlbGVjdG9yOgogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246ICdTZWxlY3Rpb24gb2YgUG9kcycKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgbWF0Y2hMYWJlbHM6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246CiAgICAgICAgICAgICAgaW5ncmVzczoKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgcG9saWNpbmdfcmF0ZToKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgICBwb2xpY2luZ19idXJzdDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgIGVncmVzczoKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgcG9saWNpbmdfcmF0ZToKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgICBwb2xpY2luZ19idXJzdDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgIGRzY3BtYXJrOgogICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgICAgZGVmYXVsdDogMAogICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgbWF4aW11bTogNjMKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBuZXRmbG93cG9saWNpZXMuYWNpLm5ldGZsb3cKc3BlYzoKICBncm91cDogYWNpLm5ldGZsb3cKICBuYW1lczoKICAgIGtpbmQ6IE5ldGZsb3dQb2xpY3kKICAgIGxpc3RLaW5kOiBOZXRmbG93UG9saWN5TGlzdAogICAgcGx1cmFsOiBuZXRmbG93cG9saWNpZXMKICAgIHNpbmd1bGFyOiBuZXRmbG93cG9saWN5CiAgc2NvcGU6IENsdXN0ZXIKICBwcmVzZXJ2ZVVua25vd25GaWVsZHM6IGZhbHNlCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MWFscGhhCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgIyBvcGVuQVBJVjNTY2hlbWEgaXMgdGhlIHNjaGVtYSBmb3IgdmFsaWRhdGluZyBjdXN0b20gb2JqZWN0cy4KICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgZmxvd1NhbXBsaW5nUG9saWN5OgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBkZXN0SXA6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIGRlc3RQb3J0OgogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAwCiAgICAgICAgICAgICAgICAgICAgbWF4aW11bTogNjU1MzUKICAgICAgICAgICAgICAgICAgICBkZWZhdWx0OiAyMDU1CiAgICAgICAgICAgICAgICAgIGZsb3dUeXBlOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIGVudW06CiAgICAgICAgICAgICAgICAgICAgICAtIG5ldGZsb3cKICAgICAgICAgICAgICAgICAgICAgIC0gaXBmaXgKICAgICAgICAgICAgICAgICAgICBkZWZhdWx0OiBuZXRmbG93CiAgICAgICAgICAgICAgICAgIGFjdGl2ZUZsb3dUaW1lT3V0OgogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAwCiAgICAgICAgICAgICAgICAgICAgbWF4aW11bTogMzYwMAogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IDYwCiAgICAgICAgICAgICAgICAgIGlkbGVGbG93VGltZU91dDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgICAgIG1heGltdW06IDYwMAogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IDE1CiAgICAgICAgICAgICAgICAgIHNhbXBsaW5nUmF0ZToKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMAogICAgICAgICAgICAgICAgICAgIG1heGltdW06IDEwMDAKICAgICAgICAgICAgICAgICAgICBkZWZhdWx0OiAwCiAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgIC0gZGVzdElwCiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBlcnNwYW5wb2xpY2llcy5hY2kuZXJzcGFuCnNwZWM6CiAgZ3JvdXA6IGFjaS5lcnNwYW4KICBuYW1lczoKICAgIGtpbmQ6IEVyc3BhblBvbGljeQogICAgbGlzdEtpbmQ6IEVyc3BhblBvbGljeUxpc3QKICAgIHBsdXJhbDogZXJzcGFucG9saWNpZXMKICAgIHNpbmd1bGFyOiBlcnNwYW5wb2xpY3kKICBzY29wZTogQ2x1c3RlcgogIHByZXNlcnZlVW5rbm93bkZpZWxkczogZmFsc2UKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxYWxwaGEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBzcGVjOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBzZWxlY3RvcjoKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246ICdTZWxlY3Rpb24gb2YgUG9kcycKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIGxhYmVsczoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIG5hbWVzcGFjZToKICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICBzb3VyY2U6CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIGFkbWluU3RhdGU6CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEFkbWluaXN0cmF0aXZlIHN0YXRlLgogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IHN0YXJ0CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgZW51bToKICAgICAgICAgICAgICAgICAgICAgIC0gc3RhcnQKICAgICAgICAgICAgICAgICAgICAgIC0gc3RvcAogICAgICAgICAgICAgICAgICBkaXJlY3Rpb246CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IERpcmVjdGlvbiBvZiB0aGUgcGFja2V0cyB0byBtb25pdG9yLgogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IGJvdGgKICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICBlbnVtOgogICAgICAgICAgICAgICAgICAgICAgLSBpbgogICAgICAgICAgICAgICAgICAgICAgLSBvdXQKICAgICAgICAgICAgICAgICAgICAgIC0gYm90aAogICAgICAgICAgICAgIGRlc3RpbmF0aW9uOgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBkZXN0SVA6CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IERlc3RpbmF0aW9uIElQIG9mIHRoZSBFUlNQQU4gcGFja2V0LgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICBmbG93SUQ6CiAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFVuaXF1ZSBmbG93IElEIG9mIHRoZSBFUlNQQU4gcGFja2V0LgogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IDEKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgICAgbWluaW11bTogMQogICAgICAgICAgICAgICAgICAgIG1heGltdW06IDEwMjMKICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgLSBkZXN0SVAKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IGVuYWJsZWRyb3Bsb2dzLmFjaS5kcm9wbG9nCnNwZWM6CiAgZ3JvdXA6IGFjaS5kcm9wbG9nCiAgbmFtZXM6CiAgICBraW5kOiBFbmFibGVEcm9wTG9nCiAgICBsaXN0S2luZDogRW5hYmxlRHJvcExvZ0xpc3QKICAgIHBsdXJhbDogZW5hYmxlZHJvcGxvZ3MKICAgIHNpbmd1bGFyOiBlbmFibGVkcm9wbG9nCiAgc2NvcGU6IENsdXN0ZXIKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxYWxwaGExCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgIyBvcGVuQVBJVjNTY2hlbWEgaXMgdGhlIHNjaGVtYSBmb3IgdmFsaWRhdGluZyBjdXN0b20gb2JqZWN0cy4KICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgZGVzY3JpcHRpb246IERlZmluZXMgdGhlIGRlc2lyZWQgc3RhdGUgb2YgRW5hYmxlRHJvcExvZwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBkaXNhYmxlRGVmYXVsdERyb3BMb2c6CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRGlzYWJsZXMgdGhlIGRlZmF1bHQgZHJvcGxvZyBlbmFibGVkIGJ5IGFjYy1wcm92aXNpb24uCiAgICAgICAgICAgICAgICBkZWZhdWx0OiBmYWxzZQogICAgICAgICAgICAgICAgdHlwZTogYm9vbGVhbgogICAgICAgICAgICAgIG5vZGVTZWxlY3RvcjoKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IERyb3AgbG9nZ2luZyBpcyBlbmFibGVkIG9uIG5vZGVzIHNlbGVjdGVkIGJhc2VkIG9uIGxhYmVscwogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgbGFiZWxzOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBwcnVuZWRyb3Bsb2dzLmFjaS5kcm9wbG9nCnNwZWM6CiAgZ3JvdXA6IGFjaS5kcm9wbG9nCiAgbmFtZXM6CiAgICBraW5kOiBQcnVuZURyb3BMb2cKICAgIGxpc3RLaW5kOiBQcnVuZURyb3BMb2dMaXN0CiAgICBwbHVyYWw6IHBydW5lZHJvcGxvZ3MKICAgIHNpbmd1bGFyOiBwcnVuZWRyb3Bsb2cKICBzY29wZTogQ2x1c3RlcgogIHZlcnNpb25zOgogIC0gbmFtZTogdjFhbHBoYTEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAjIG9wZW5BUElWM1NjaGVtYSBpcyB0aGUgc2NoZW1hIGZvciB2YWxpZGF0aW5nIGN1c3RvbSBvYmplY3RzLgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBkZXNjcmlwdGlvbjogRGVmaW5lcyB0aGUgZGVzaXJlZCBzdGF0ZSBvZiBQcnVuZURyb3BMb2cKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgbm9kZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRHJvcCBsb2dnaW5nIGZpbHRlcnMgYXJlIGFwcGxpZWQgdG8gbm9kZXMgc2VsZWN0ZWQgYmFzZWQgb24gbGFiZWxzCiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBsYWJlbHM6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgIGRyb3BMb2dGaWx0ZXJzOgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBzcmNJUDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgZGVzdElQOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICBzcmNNQUM6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIGRlc3RNQUM6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIHNyY1BvcnQ6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgICAgICBkZXN0UG9ydDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgIGlwUHJvdG86CiAgICAgICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IGFjaWlzdGlvb3BlcmF0b3JzLmFjaS5pc3RpbwpzcGVjOgogIGdyb3VwOiBhY2kuaXN0aW8KICBuYW1lczoKICAgIGtpbmQ6IEFjaUlzdGlvT3BlcmF0b3IKICAgIGxpc3RLaW5kOiBBY2lJc3Rpb09wZXJhdG9yTGlzdAogICAgcGx1cmFsOiBhY2lpc3Rpb29wZXJhdG9ycwogICAgc2luZ3VsYXI6IGFjaWlzdGlvb3BlcmF0b3IKICBzY29wZTogTmFtZXNwYWNlZAogIHZlcnNpb25zOgogIC0gbmFtZTogdjEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBkZXNjcmlwdGlvbjogQWNpSXN0aW9PcGVyYXRvclNwZWMgZGVmaW5lcyB0aGUgZGVzaXJlZCBzdGF0ZSBvZiBBY2lJc3Rpb09wZXJhdG9yCiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgY29uZmlnOgogICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgcHJvZmlsZToKICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgLSBjb25maWcKICAgICAgICAgICAgLSBwcm9maWxlCiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3RhdHVzOgogICAgICAgICAgICBkZXNjcmlwdGlvbjogQWNpSXN0aW9PcGVyYXRvclN0YXR1cyBkZWZpbmVzIHRoZSBvYnNlcnZlZCBzdGF0ZSBvZiBBY2lJc3Rpb09wZXJhdG9yCiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgU3VjY2Vzc2Z1bCBvciBOb3Q6CiAgICAgICAgICAgICAgICB0eXBlOiBib29sZWFuCiAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAtIFN1Y2Nlc3NmdWwgb3IgTm90CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHR5cGU6IG9iamVjdAotLS0KYXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnTWFwCm1ldGFkYXRhOgogIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbmZpZwogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCmRhdGE6CiAgY29udHJvbGxlci1jb25maWc6IHwtCiAgICB7CiAgICAgICAgImZsYXZvciI6ICJrdWJlcm5ldGVzLTEuMjIiLAogICAgICAgICJsb2ctbGV2ZWwiOiAiaW5mbyIsCiAgICAgICAgImFwaWMtaG9zdHMiOiBbCiAgICAgICAgICAgICIxMC4zMC4xMjAuMTAwIgogICAgICAgIF0sCiAgICAgICAgImFwaWMtdXNlcm5hbWUiOiAia3ViZSIsCiAgICAgICAgImFwaWMtcHJpdmF0ZS1rZXktcGF0aCI6ICIvdXNyL2xvY2FsL2V0Yy9hY2ktY2VydC91c2VyLmtleSIsCiAgICAgICAgImFjaS1wcmVmaXgiOiAia3ViZSIsCiAgICAgICAgImFjaS12bW0tdHlwZSI6ICJLdWJlcm5ldGVzIiwKICAgICAgICAiYWNpLXZtbS1kb21haW4iOiAia3ViZSIsCiAgICAgICAgImFjaS12bW0tY29udHJvbGxlciI6ICJrdWJlIiwKICAgICAgICAiYWNpLXBvbGljeS10ZW5hbnQiOiAia3ViZSIsCiAgICAgICAgImluc3RhbGwtaXN0aW8iOiB0cnVlLAogICAgICAgICJpc3Rpby1wcm9maWxlIjogImRlbW8iLAogICAgICAgICJhY2ktcG9kYmQtZG4iOiAidW5pL3RuLWt1YmUvQkQta3ViZS1wb2QtYmQiLAogICAgICAgICJhY2ktbm9kZWJkLWRuIjogInVuaS90bi1rdWJlL0JELWt1YmUtbm9kZS1iZCIsCiAgICAgICAgImFjaS1zZXJ2aWNlLXBoeXMtZG9tIjogImt1YmUtcGRvbSIsCiAgICAgICAgImFjaS1zZXJ2aWNlLWVuY2FwIjogInZsYW4tNDAwMyIsCiAgICAgICAgImFjaS1zZXJ2aWNlLW1vbml0b3ItaW50ZXJ2YWwiOiA1LAogICAgICAgICJhY2ktcGJyLXRyYWNraW5nLW5vbi1zbmF0IjogZmFsc2UsCiAgICAgICAgImFjaS12cmYtdGVuYW50IjogImNvbW1vbiIsCiAgICAgICAgImFjaS12cmYtZG4iOiAidW5pL3RuLWNvbW1vbi9jdHgta3ViZSIsCiAgICAgICAgImFjaS1sM291dCI6ICJsM291dCIsCiAgICAgICAgImFjaS1leHQtbmV0d29ya3MiOiBbCiAgICAgICAgICAgICJkZWZhdWx0IgogICAgICAgIF0sCiAgICAgICAgImFjaS12cmYiOiAia3ViZSIsCiAgICAgICAgImRlZmF1bHQtZW5kcG9pbnQtZ3JvdXAiOiB7CiAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAia3ViZSIsCiAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1kZWZhdWx0IgogICAgICAgIH0sCiAgICAgICAgIm1heC1ub2Rlcy1zdmMtZ3JhcGgiOiAzMiwKICAgICAgICAibmFtZXNwYWNlLWRlZmF1bHQtZW5kcG9pbnQtZ3JvdXAiOiB7CiAgICAgICAgICAgICJpc3Rpby1vcGVyYXRvciI6IHsKICAgICAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAia3ViZSIsCiAgICAgICAgICAgICAgICAibmFtZSI6ICJrdWJlcm5ldGVzfGt1YmUtaXN0aW8iCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgICJpc3Rpby1zeXN0ZW0iOiB7CiAgICAgICAgICAgICAgICAicG9saWN5LXNwYWNlIjogImt1YmUiLAogICAgICAgICAgICAgICAgIm5hbWUiOiAia3ViZXJuZXRlc3xrdWJlLWlzdGlvIgogICAgICAgICAgICB9LAogICAgICAgICAgICAia3ViZS1zeXN0ZW0iOiB7CiAgICAgICAgICAgICAgICAicG9saWN5LXNwYWNlIjogImt1YmUiLAogICAgICAgICAgICAgICAgIm5hbWUiOiAia3ViZXJuZXRlc3xrdWJlLXN5c3RlbSIKICAgICAgICAgICAgfSAgICAgICAgfSwKICAgICAgICAic2VydmljZS1pcC1wb29sIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAiZW5kIjogIjEwLjMuMC4yNTQiLAogICAgICAgICAgICAgICAgInN0YXJ0IjogIjEwLjMuMC4yIgogICAgICAgICAgICB9CiAgICAgICAgXSwKICAgICAgICAic25hdC1jb250cmFjdC1zY29wZSI6ICJnbG9iYWwiLAogICAgICAgICJzdGF0aWMtc2VydmljZS1pcC1wb29sIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAiZW5kIjogIjEwLjQuMC4yNTQiLAogICAgICAgICAgICAgICAgInN0YXJ0IjogIjEwLjQuMC4yIgogICAgICAgICAgICB9CiAgICAgICAgXSwKICAgICAgICAicG9kLWlwLXBvb2wiOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJlbmQiOiAiMTAuMi4yNTUuMjU0IiwKICAgICAgICAgICAgICAgICJzdGFydCI6ICIxMC4yLjAuMiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgInBvZC1zdWJuZXQtY2h1bmstc2l6ZSI6IDMyLAogICAgICAgICJub2RlLXNlcnZpY2UtaXAtcG9vbCI6IFsKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgImVuZCI6ICIxMC41LjAuMjU0IiwKICAgICAgICAgICAgICAgICJzdGFydCI6ICIxMC41LjAuMiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgIm5vZGUtc2VydmljZS1zdWJuZXRzIjogWwogICAgICAgICAgICAiMTAuNS4wLjEvMjQiCiAgICAgICAgXQogICAgfQogIGhvc3QtYWdlbnQtY29uZmlnOiB8LQogICAgewogICAgICAgICJmbGF2b3IiOiAia3ViZXJuZXRlcy0xLjIyIiwKICAgICAgICAiYXBwLXByb2ZpbGUiOiAia3ViZXJuZXRlcyIsCiAgICAgICAgImVwLXJlZ2lzdHJ5IjogbnVsbCwKICAgICAgICAib3BmbGV4LW1vZGUiOiBudWxsLAogICAgICAgICJsb2ctbGV2ZWwiOiAiaW5mbyIsCiAgICAgICAgImFjaS1zbmF0LW5hbWVzcGFjZSI6ICJhY2ktY29udGFpbmVycy1zeXN0ZW0iLAogICAgICAgICJhY2ktdm1tLXR5cGUiOiAiS3ViZXJuZXRlcyIsCiAgICAgICAgImFjaS12bW0tZG9tYWluIjogImt1YmUiLAogICAgICAgICJhY2ktdm1tLWNvbnRyb2xsZXIiOiAia3ViZSIsCiAgICAgICAgImFjaS1wcmVmaXgiOiAia3ViZSIsCiAgICAgICAgImFjaS12cmYiOiAia3ViZSIsCiAgICAgICAgImFjaS12cmYtdGVuYW50IjogImNvbW1vbiIsCiAgICAgICAgInNlcnZpY2UtdmxhbiI6IDQwMDMsCiAgICAgICAgImt1YmVhcGktdmxhbiI6IDQwMDEsCiAgICAgICAgInBvZC1zdWJuZXQiOiAiMTAuMi4wLjEvMTYiLAogICAgICAgICJub2RlLXN1Ym5ldCI6ICIxMC4xLjAuMS8xNiIsCiAgICAgICAgImVuY2FwLXR5cGUiOiAidnhsYW4iLAogICAgICAgICJhY2ktaW5mcmEtdmxhbiI6IDQwOTMsCiAgICAgICAgImNuaS1uZXRjb25maWciOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJnYXRld2F5IjogIjEwLjIuMC4xIiwKICAgICAgICAgICAgICAgICJyb3V0ZXMiOiBbCiAgICAgICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgICAgICAiZHN0IjogIjAuMC4wLjAvMCIsCiAgICAgICAgICAgICAgICAgICAgICAgICJndyI6ICIxMC4yLjAuMSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBdLAogICAgICAgICAgICAgICAgInN1Ym5ldCI6ICIxMC4yLjAuMC8xNiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgImRlZmF1bHQtZW5kcG9pbnQtZ3JvdXAiOiB7CiAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAia3ViZSIsCiAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1kZWZhdWx0IgogICAgICAgIH0sCiAgICAgICAgIm5hbWVzcGFjZS1kZWZhdWx0LWVuZHBvaW50LWdyb3VwIjogewogICAgICAgICAgICAiaXN0aW8tb3BlcmF0b3IiOiB7CiAgICAgICAgICAgICAgICAicG9saWN5LXNwYWNlIjogImt1YmUiLAogICAgICAgICAgICAgICAgIm5hbWUiOiAia3ViZXJuZXRlc3xrdWJlLWlzdGlvIgogICAgICAgICAgICB9LAogICAgICAgICAgICAiaXN0aW8tc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJrdWJlIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1pc3RpbyIKICAgICAgICAgICAgfSwKICAgICAgICAgICAgImt1YmUtc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJrdWJlIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImt1YmVybmV0ZXN8a3ViZS1zeXN0ZW0iCiAgICAgICAgICAgIH0gICAgICAgIH0sCiAgICAgICAgImVuYWJsZS1kcm9wLWxvZyI6IHRydWUKICAgIH0KICBvcGZsZXgtYWdlbnQtY29uZmlnOiB8LQogICAgewogICAgICAgICJsb2ciOiB7CiAgICAgICAgICAgICJsZXZlbCI6ICJpbmZvIgogICAgICAgIH0sCiAgICAgICAgIm9wZmxleCI6IHsKICAgICAgICAgICAgIm5vdGlmIiA6IHsgImVuYWJsZWQiIDogImZhbHNlIiB9CiAgICAgICAgfQogICAgfQotLS0KYXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnTWFwCm1ldGFkYXRhOgogIG5hbWU6IHNuYXQtb3BlcmF0b3ItY29uZmlnCiAgbmFtZXNwYWNlOiBhY2ktY29udGFpbmVycy1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCmRhdGE6CiAgICAic3RhcnQiOiAiNTAwMCIKICAgICJlbmQiOiAiNjUwMDAiCiAgICAicG9ydHMtcGVyLW5vZGUiOiAiMzAwMCIKLS0tCmFwaVZlcnNpb246IHYxCmtpbmQ6IFNlY3JldAptZXRhZGF0YToKICBuYW1lOiBhY2ktdXNlci1jZXJ0CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCmRhdGE6CiAgdXNlci5rZXk6IExTMHRMUzFDUlVkSlRpQlFVa2xXUVZSRklFdEZXUzB0TFMwdENrMUpTVU5rWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUlJVWkJRVk5EUVcxQmQyZG5TbU5CWjBWQlFXOUhRa0ZPY2l0QksyZFBTMkpCVmxaeVNuTUtZak1yV2xkaVkyNVdXRzh2WjJSMWVFbFVhM1p0TURsclpXbEdRMjRyVlhBdlUwZGtjWFkyUVdncmFteEtaa1kzZFhZclJtZERTblJEZUVRNE4zRlpkd293Y1RWRVkwZFdURWxqWmtZMFdsVmlPVUk0Y2twWFMwSkpObmRLWm5oMFRXWkdkVlZPV1RJMFkyZDNVWEJLY1hKTlZYRkJSSG92VFZjcmQzSmFaV2h6Q2xOdVJuTjVaWGRZVWpNNE9HVlNOMFZMYWtSWFpXZGtTbmxRWTFoQlowMUNRVUZGUTJkWlFqbEJXR0l4V21aQ1EwSlZlRUlyVldkRlZFZE5OeXMwV0RrS2FraGllVVV3UW14NGJHdG1hbkpzZDJSMmJWTTVUVGMzS3pKYU5tUkxRV2RRTXpOVVVrMHZVSGRGVFU5Wk4xSnVaRUp2SzFnMmVFUnpWbVJqVkVwSmVRbzFWbmM0ZUZWYWJISXJZWFZGVDJ4ek1scHVXbmd4TVdVMWVtZzNjMVV6VG1vMVN6TTFRbGRTT1VkVVdFbzJVRTFrY0ZRME9XeENPV0pzYkUxcVJISk1DamNyTldKRGMyUjFOak5QT0V0aFRqbFpVVXBDUVZCSFRXSndTSEJHYzNSRE1XTlhSM0JTVVhnemFYZEdLMXBNV1VGeVFWVmlRMHRpVjFGbVltbGFWSEFLUTFNNFJHZFBiWGxWTjNWTFZGSkxhVU1yTWxKWlZGTXpjSEpNVmpVM1IzWm1aa1o0U21wVWQwZDVhME5SVVVSdlIwSjNaalZwVDNONWRVMVJUbm8zU3dwU2FYSmlSREJLTjFJMldXVlJhMHBhSzNCRFpVdDNlU3RPZVVseGVHZ3dURUpFYlVKNWJWTkxkbGd3VjBWTFEybDBUMmR3YVRNeVJsZENiM0ZJYW1ZekNrMVJaeTlCYTBKTVFreFNjV1ZLZG5SelQyOHpiVXRQTkdFcmVESmxOM2xTVlV0ck1VTnZTM3BHVGtKSU1HNVZaVmhIYmxCM2FWUk9ZaXRpTVdabVUwWUtOM1pKU21KSVpHMUxaM1ZLZVRCc1ZVNUJOMGhhTnpkWUwybEtVa0ZyUVdwdVltVk1TMXA2YkRScmFWQTNNM0JwVUdaNFRHMHpOMlpRYWtvcmVVUnZOQXBhY0hkVmRWcFNLME5EV0d4SVNIWlBaV1p3T1UxV2NsZGpOV1ZxWTBNdlIyRkROazFYV1hsTmFuVlhUU3Q0UVhCcVkzVjJRV3RGUVhwWkszQXhOREJEQ25oM2NISTVOV3hwYm01MlYyTkROMDQzTURoQlNrWnBiVE12UmxVeE1FZEViemMzZVVsUFNUVm9LelV6TjBwaVdXUnROVFUxYUU5bFNDOUxhbE5sYTJnS1JVWTBUVzE0VWxCdGFYUTVPWGM5UFFvdExTMHRMVVZPUkNCUVVrbFdRVlJGSUV0RldTMHRMUzB0Q2c9PQogIHVzZXIuY3J0OiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VJMlJFTkRRVlpGUTBGblVHOU5RVEJIUTFOeFIxTkpZak5FVVVWQ1FsRlZRVTFFZDNoRGVrRktRbWRPVmtKQldWUkJiRlpVVFZKWmQwWkJXVVFLVmxGUlMwUkJNVVJoV0U1cVlubENWR1ZZVGpCYVZ6RjZUVkpWZDBWM1dVUldVVkZFUkVGNFZtTXlWbmxKUnpGb1ltMVNiRnBZUVhkSWFHTk9UVlJqZHdwT1ZFVXlUV3BGZVU5VVRYZFhhR05PVFdwamQwNVVSVEJOYWtWNVQxUk5kMWRxUVRoTlVYTjNRMUZaUkZaUlVVZEZkMHBXVlhwRlYwMUNVVWRCTVZWRkNrTm5kMDVSTW14NldUSTRaMVV6Ykhwa1IxWjBZM3BGVmsxQ1RVZEJNVlZGUVhkM1RWWllUbXhqYVVKMFdWYzFhMXBYVm5kTlNVZG1UVUV3UjBOVGNVY0tVMGxpTTBSUlJVSkJVVlZCUVRSSFRrRkVRMEpwVVV0Q1oxRkVZUzluVUc5RWFXMTNSbFpoZVdKSE9TOXRWbTB6U2pGV05sQTBTR0p6VTBVMVREVjBVQXBhU0c5b1VYQXZiRXRtTUdodVlYSXJaMGxtYnpWVFdIaGxOM0l2YUZsQmFXSlJjMUV2VHpadFRVNUxkVkV6UW14VGVVaEllR1ZIVmtjdlVXWkxlVlpwQ21kVFQzTkRXRGhpVkVoNFlteEVWMDUxU0VsTlJVdFRZWEY2Umt0blFUZ3Zla1oyYzBzeVdHOWlSWEI0WWsxdWMwWXdaQzlRU0d0bGVFTnZkekZ1YjBnS1UyTnFNMFozU1VSQlVVRkNUVUV3UjBOVGNVZFRTV0l6UkZGRlFrSlJWVUZCTkVkQ1FVaFlLMnRNVkdVMlRFTkJRbVYzYlVOVWRrMXphblZ6U0dSd1dncHJhVEF4SzI1Uk4wdG9ia1ZTWWtKdEwzUmFOWE5qV2tVMFkzUkpjV05vTTI1NU1VVkpWRWhPZEZsWFMwSk9ORU5rVlV0amFuWkVWekpvTW5aclNHVm5DbkowV1dKV0swRmhSWE54TUcwMGRrZEdPVVZ0ZG5ReFkzQTVXVFF4U1hsTlFscFpjWGM0WXk5V01VRjBiVkpSWTFKVVdWRkJPRWd6VDBaRVkyaDVRaklLTUVwSVUwUnVRbTlUTjJabVUySkNlQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09Ci0tLQphcGlWZXJzaW9uOiB2MQpraW5kOiBTZXJ2aWNlQWNjb3VudAptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1jb250cm9sbGVyCiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCi0tLQphcGlWZXJzaW9uOiB2MQpraW5kOiBTZXJ2aWNlQWNjb3VudAptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1ob3N0LWFnZW50CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCi0tLQphcGlWZXJzaW9uOiByYmFjLmF1dGhvcml6YXRpb24uazhzLmlvL3YxCmtpbmQ6IENsdXN0ZXJSb2xlCm1ldGFkYXRhOgogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCiAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKICBuYW1lOiBhY2ktY29udGFpbmVyczpjb250cm9sbGVyCnJ1bGVzOgotIGFwaUdyb3VwczoKICAtICIiCiAgcmVzb3VyY2VzOgogIC0gbm9kZXMKICAtIG5hbWVzcGFjZXMKICAtIHBvZHMKICAtIGVuZHBvaW50cwogIC0gc2VydmljZXMKICAtIGV2ZW50cwogIC0gcmVwbGljYXRpb25jb250cm9sbGVycwogIC0gc2VydmljZWFjY291bnRzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0CiAgLSBwYXRjaAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICIiCiAgcmVzb3VyY2VzOgogIC0gY29uZmlnbWFwcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICJhcGlleHRlbnNpb25zLms4cy5pbyIKICByZXNvdXJjZXM6CiAgLSBjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zCiAgdmVyYnM6CiAgLSAnKicKLSBhcGlHcm91cHM6CiAgLSAicmJhYy5hdXRob3JpemF0aW9uLms4cy5pbyIKICByZXNvdXJjZXM6CiAgLSBjbHVzdGVycm9sZXMKICAtIGNsdXN0ZXJyb2xlYmluZGluZ3MKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtICJpbnN0YWxsLmlzdGlvLmlvIgogIHJlc291cmNlczoKICAtIGlzdGlvY29udHJvbHBsYW5lcwogIC0gaXN0aW9vcGVyYXRvcnMKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtICJhY2kuaXN0aW8iCiAgcmVzb3VyY2VzOgogIC0gYWNpaXN0aW9vcGVyYXRvcnMKICAtIGFjaWlzdGlvb3BlcmF0b3IKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtICJuZXR3b3JraW5nLms4cy5pbyIKICByZXNvdXJjZXM6CiAgLSBuZXR3b3JrcG9saWNpZXMKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAiYXBwcyIKICByZXNvdXJjZXM6CiAgLSBkZXBsb3ltZW50cwogIC0gcmVwbGljYXNldHMKICAtIGRhZW1vbnNldHMKICAtIHN0YXRlZnVsc2V0cwogIHZlcmJzOgogIC0gJyonCi0gYXBpR3JvdXBzOgogIC0gIiIKICByZXNvdXJjZXM6CiAgLSBub2RlcwogIC0gc2VydmljZXMvc3RhdHVzCiAgdmVyYnM6CiAgLSB1cGRhdGUKLSBhcGlHcm91cHM6CiAgLSAibW9uaXRvcmluZy5jb3Jlb3MuY29tIgogIHJlc291cmNlczoKICAtIHNlcnZpY2Vtb25pdG9ycwogIHZlcmJzOgogIC0gZ2V0CiAgLSBjcmVhdGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnNuYXQiCiAgcmVzb3VyY2VzOgogIC0gc25hdHBvbGljaWVzL2ZpbmFsaXplcnMKICAtIHNuYXRwb2xpY2llcy9zdGF0dXMKICAtIG5vZGVpbmZvcwogIHZlcmJzOgogIC0gdXBkYXRlCiAgLSBjcmVhdGUKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICJhY2kuc25hdCIKICByZXNvdXJjZXM6CiAgLSBzbmF0Z2xvYmFsaW5mb3MKICAtIHNuYXRwb2xpY2llcwogIC0gbm9kZWluZm9zCiAgLSByZGNvbmZpZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGNyZWF0ZQogIC0gdXBkYXRlCiAgLSBkZWxldGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnFvcyIKICByZXNvdXJjZXM6CiAgLSBxb3Nwb2xpY2llcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQogIC0gcGF0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYWNpLm5ldGZsb3ciCiAgcmVzb3VyY2VzOgogIC0gbmV0Zmxvd3BvbGljaWVzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0CiAgLSB1cGRhdGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLmVyc3BhbiIKICByZXNvdXJjZXM6CiAgLSBlcnNwYW5wb2xpY2llcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gdXBkYXRlCi0gYXBpR3JvdXBzOgogIC0gImFjaS5hdyIKICByZXNvdXJjZXM6CiAgLSBwb2RpZnMKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtIGFwcHMub3BlbnNoaWZ0LmlvCiAgcmVzb3VyY2VzOgogIC0gZGVwbG95bWVudGNvbmZpZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSBkaXNjb3ZlcnkuazhzLmlvCiAgcmVzb3VyY2VzOgogIC0gZW5kcG9pbnRzbGljZXMKICB2ZXJiczoKICAtIGdldAogIC0gbGlzdAogIC0gd2F0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYWNpLm5ldHBvbCIKICByZXNvdXJjZXM6CiAgLSBuZXR3b3JrcG9saWNpZXMKICB2ZXJiczoKICAtIGdldAogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGNyZWF0ZQogIC0gdXBkYXRlCiAgLSBkZWxldGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLmRuc25ldHBvbCIKICByZXNvdXJjZXM6CiAgLSBkbnNuZXR3b3JrcG9saWNpZXMKICB2ZXJiczoKICAtIGdldAogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGNyZWF0ZQogIC0gdXBkYXRlCiAgLSBkZWxldGUKLS0tCmFwaVZlcnNpb246IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8vdjEKa2luZDogQ2x1c3RlclJvbGUKbWV0YWRhdGE6CiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogIG5hbWU6IGFjaS1jb250YWluZXJzOmhvc3QtYWdlbnQKcnVsZXM6Ci0gYXBpR3JvdXBzOgogIC0gIiIKICByZXNvdXJjZXM6CiAgLSBub2RlcwogIC0gbmFtZXNwYWNlcwogIC0gcG9kcwogIC0gZW5kcG9pbnRzCiAgLSBzZXJ2aWNlcwogIC0gcmVwbGljYXRpb25jb250cm9sbGVycwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gdXBkYXRlCi0gYXBpR3JvdXBzOgogIC0gIiIKICByZXNvdXJjZXM6CiAgLSBldmVudHMKICB2ZXJiczoKICAtIGNyZWF0ZQogIC0gcGF0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYXBpZXh0ZW5zaW9ucy5rOHMuaW8iCiAgcmVzb3VyY2VzOgogIC0gY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAotIGFwaUdyb3VwczoKICAtICJhY2kuYXciCiAgcmVzb3VyY2VzOgogIC0gcG9kaWZzCiAgLSBwb2RpZnMvc3RhdHVzCiAgdmVyYnM6CiAgLSAiKiIKLSBhcGlHcm91cHM6CiAgLSAibmV0d29ya2luZy5rOHMuaW8iCiAgcmVzb3VyY2VzOgogIC0gbmV0d29ya3BvbGljaWVzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0Ci0gYXBpR3JvdXBzOgogIC0gImFwcHMiCiAgcmVzb3VyY2VzOgogIC0gZGVwbG95bWVudHMKICAtIHJlcGxpY2FzZXRzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0Ci0gYXBpR3JvdXBzOgogIC0gImFjaS5zbmF0IgogIHJlc291cmNlczoKICAtIHNuYXRwb2xpY2llcwogIC0gc25hdGdsb2JhbGluZm9zCiAgLSByZGNvbmZpZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnFvcyIKICByZXNvdXJjZXM6CiAgLSBxb3Nwb2xpY2llcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQogIC0gcGF0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYWNpLmRyb3Bsb2ciCiAgcmVzb3VyY2VzOgogIC0gZW5hYmxlZHJvcGxvZ3MKICAtIHBydW5lZHJvcGxvZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnNuYXQiCiAgcmVzb3VyY2VzOgogIC0gbm9kZWluZm9zCiAgLSBzbmF0bG9jYWxpbmZvcwogIHZlcmJzOgogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtIGRpc2NvdmVyeS5rOHMuaW8KICByZXNvdXJjZXM6CiAgLSBlbmRwb2ludHNsaWNlcwogIHZlcmJzOgogIC0gZ2V0CiAgLSBsaXN0CiAgLSB3YXRjaAotIGFwaUdyb3VwczoKICAtICJhY2kubmV0cG9sIgogIHJlc291cmNlczoKICAtIG5ldHdvcmtwb2xpY2llcwogIHZlcmJzOgogIC0gZ2V0CiAgLSBsaXN0CiAgLSB3YXRjaAotLS0KYXBpVmVyc2lvbjogcmJhYy5hdXRob3JpemF0aW9uLms4cy5pby92MQpraW5kOiBDbHVzdGVyUm9sZUJpbmRpbmcKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnM6Y29udHJvbGxlcgogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCnJvbGVSZWY6CiAgYXBpR3JvdXA6IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8KICBraW5kOiBDbHVzdGVyUm9sZQogIG5hbWU6IGFjaS1jb250YWluZXJzOmNvbnRyb2xsZXIKc3ViamVjdHM6Ci0ga2luZDogU2VydmljZUFjY291bnQKICBuYW1lOiBhY2ktY29udGFpbmVycy1jb250cm9sbGVyCiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQotLS0KYXBpVmVyc2lvbjogcmJhYy5hdXRob3JpemF0aW9uLms4cy5pby92MQpraW5kOiBDbHVzdGVyUm9sZUJpbmRpbmcKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnM6aG9zdC1hZ2VudAogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCnJvbGVSZWY6CiAgYXBpR3JvdXA6IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8KICBraW5kOiBDbHVzdGVyUm9sZQogIG5hbWU6IGFjaS1jb250YWluZXJzOmhvc3QtYWdlbnQKc3ViamVjdHM6Ci0ga2luZDogU2VydmljZUFjY291bnQKICBuYW1lOiBhY2ktY29udGFpbmVycy1ob3N0LWFnZW50CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQotLS0KYXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEYWVtb25TZXQKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnMtaG9zdAogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCnNwZWM6CiAgdXBkYXRlU3RyYXRlZ3k6CiAgICB0eXBlOiBSb2xsaW5nVXBkYXRlCiAgc2VsZWN0b3I6CiAgICBtYXRjaExhYmVsczoKICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtaG9zdAogICAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKICB0ZW1wbGF0ZToKICAgIG1ldGFkYXRhOgogICAgICBsYWJlbHM6CiAgICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtaG9zdAogICAgICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogICAgICBhbm5vdGF0aW9uczoKICAgICAgICBzY2hlZHVsZXIuYWxwaGEua3ViZXJuZXRlcy5pby9jcml0aWNhbC1wb2Q6ICcnCiAgICAgICAgcHJvbWV0aGV1cy5pby9zY3JhcGU6ICJ0cnVlIgogICAgICAgIHByb21ldGhldXMuaW8vcG9ydDogIjk2MTIiCiAgICBzcGVjOgogICAgICBob3N0TmV0d29yazogdHJ1ZQogICAgICBob3N0UElEOiB0cnVlCiAgICAgIGhvc3RJUEM6IHRydWUKICAgICAgc2VydmljZUFjY291bnROYW1lOiBhY2ktY29udGFpbmVycy1ob3N0LWFnZW50CiAgICAgIHRvbGVyYXRpb25zOgogICAgICAgIC0gb3BlcmF0b3I6IEV4aXN0cwogICAgICBwcmlvcml0eUNsYXNzTmFtZTogc3lzdGVtLWNsdXN0ZXItY3JpdGljYWwKICAgICAgY29udGFpbmVyczoKICAgICAgICAtIG5hbWU6IGFjaS1jb250YWluZXJzLWhvc3QKICAgICAgICAgIGltYWdlOiBub2lyby9hY2ktY29udGFpbmVycy1ob3N0OjUuMi4yLjAuMGVmNDcxOAogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIHNlY3VyaXR5Q29udGV4dDoKICAgICAgICAgICAgY2FwYWJpbGl0aWVzOgogICAgICAgICAgICAgIGFkZDoKICAgICAgICAgICAgICAgIC0gU1lTX0FETUlOCiAgICAgICAgICAgICAgICAtIE5FVF9BRE1JTgogICAgICAgICAgICAgICAgLSBTWVNfUFRSQUNFCiAgICAgICAgICAgICAgICAtIE5FVF9SQVcKICAgICAgICAgIGVudjoKICAgICAgICAgICAgLSBuYW1lOiBLVUJFUk5FVEVTX05PREVfTkFNRQogICAgICAgICAgICAgIHZhbHVlRnJvbToKICAgICAgICAgICAgICAgIGZpZWxkUmVmOgogICAgICAgICAgICAgICAgICBmaWVsZFBhdGg6IHNwZWMubm9kZU5hbWUKICAgICAgICAgICAgLSBuYW1lOiBURU5BTlQKICAgICAgICAgICAgICB2YWx1ZTogImt1YmUiCiAgICAgICAgICAgIC0gbmFtZTogTk9ERV9FUEcKICAgICAgICAgICAgICB2YWx1ZTogImt1YmVybmV0ZXN8a3ViZS1ub2RlcyIKICAgICAgICAgICAgLSBuYW1lOiBEVVJBVElPTl9XQUlUX0ZPUl9ORVRXT1JLCiAgICAgICAgICAgICAgdmFsdWU6ICIyMTAiCiAgICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgICAgIC0gbmFtZTogY25pLWJpbgogICAgICAgICAgICAgIG1vdW50UGF0aDogL21udC9jbmktYmluCiAgICAgICAgICAgIC0gbmFtZTogY25pLWNvbmYKICAgICAgICAgICAgICBtb3VudFBhdGg6IC9tbnQvY25pLWNvbmYKICAgICAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3ZhcgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3J1bgogICAgICAgICAgICAtIG5hbWU6IG9wZmxleC1ob3N0Y29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvb3BmbGV4LWFnZW50LW92cy9iYXNlLWNvbmYuZAogICAgICAgICAgICAtIG5hbWU6IGhvc3QtY29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvYWNpLWNvbnRhaW5lcnMvCiAgICAgICAgICAgIC0gbW91bnRQYXRoOiAvcnVuL25ldG5zCiAgICAgICAgICAgICAgbmFtZTogaG9zdC1ydW4tbmV0bnMKICAgICAgICAgICAgICByZWFkT25seTogdHJ1ZQogICAgICAgICAgICAgIG1vdW50UHJvcGFnYXRpb246IEhvc3RUb0NvbnRhaW5lcgogICAgICAgICAgbGl2ZW5lc3NQcm9iZToKICAgICAgICAgICAgaHR0cEdldDoKICAgICAgICAgICAgICBwYXRoOiAvc3RhdHVzCiAgICAgICAgICAgICAgcG9ydDogODA5MAogICAgICAgIC0gbmFtZTogb3BmbGV4LWFnZW50CiAgICAgICAgICBlbnY6CiAgICAgICAgICAgIC0gbmFtZTogUkVCT09UX1dJVEhfT1ZTCiAgICAgICAgICAgICAgdmFsdWU6ICJ0cnVlIgogICAgICAgICAgaW1hZ2U6IG5vaXJvL29wZmxleDo1LjIuMi4wLmQyNzM5ZGEKICAgICAgICAgIGltYWdlUHVsbFBvbGljeTogQWx3YXlzCiAgICAgICAgICBzZWN1cml0eUNvbnRleHQ6CiAgICAgICAgICAgIGNhcGFiaWxpdGllczoKICAgICAgICAgICAgICBhZGQ6CiAgICAgICAgICAgICAgICAtIE5FVF9BRE1JTgogICAgICAgICAgdm9sdW1lTW91bnRzOgogICAgICAgICAgICAtIG5hbWU6IGhvc3R2YXIKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvdmFyCiAgICAgICAgICAgIC0gbmFtZTogaG9zdHJ1bgogICAgICAgICAgICAgIG1vdW50UGF0aDogL3J1bgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvcnVuCiAgICAgICAgICAgIC0gbmFtZTogb3BmbGV4LWhvc3Rjb25maWctdm9sdW1lCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL2V0Yy9vcGZsZXgtYWdlbnQtb3ZzL2Jhc2UtY29uZi5kCiAgICAgICAgICAgIC0gbmFtZTogb3BmbGV4LWNvbmZpZy12b2x1bWUKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvZXRjL29wZmxleC1hZ2VudC1vdnMvY29uZi5kCiAgICAgICAgLSBuYW1lOiBtY2FzdC1kYWVtb24KICAgICAgICAgIGltYWdlOiBub2lyby9vcGZsZXg6NS4yLjIuMC5kMjczOWRhCiAgICAgICAgICBjb21tYW5kOiBbIi9iaW4vc2giXQogICAgICAgICAgYXJnczogWyIvdXNyL2xvY2FsL2Jpbi9sYXVuY2gtbWNhc3RkYWVtb24uc2giXQogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIHZvbHVtZU1vdW50czoKICAgICAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3ZhcgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3J1bgogICAgICByZXN0YXJ0UG9saWN5OiBBbHdheXMKICAgICAgdm9sdW1lczoKICAgICAgICAtIG5hbWU6IGNuaS1iaW4KICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvb3B0CiAgICAgICAgLSBuYW1lOiBjbmktY29uZgogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC9ldGMKICAgICAgICAtIG5hbWU6IGhvc3R2YXIKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvdmFyCiAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL3J1bgogICAgICAgIC0gbmFtZTogaG9zdC1jb25maWctdm9sdW1lCiAgICAgICAgICBjb25maWdNYXA6CiAgICAgICAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbmZpZwogICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAtIGtleTogaG9zdC1hZ2VudC1jb25maWcKICAgICAgICAgICAgICAgIHBhdGg6IGhvc3QtYWdlbnQuY29uZgogICAgICAgIC0gbmFtZTogb3BmbGV4LWhvc3Rjb25maWctdm9sdW1lCiAgICAgICAgICBlbXB0eURpcjoKICAgICAgICAgICAgbWVkaXVtOiBNZW1vcnkKICAgICAgICAtIG5hbWU6IG9wZmxleC1jb25maWctdm9sdW1lCiAgICAgICAgICBjb25maWdNYXA6CiAgICAgICAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbmZpZwogICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAtIGtleTogb3BmbGV4LWFnZW50LWNvbmZpZwogICAgICAgICAgICAgICAgcGF0aDogbG9jYWwuY29uZgogICAgICAgIC0gbmFtZTogaG9zdC1ydW4tbmV0bnMKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvcnVuL25ldG5zCi0tLQphcGlWZXJzaW9uOiBhcHBzL3YxCmtpbmQ6IERhZW1vblNldAptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1vcGVudnN3aXRjaAogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCnNwZWM6CiAgdXBkYXRlU3RyYXRlZ3k6CiAgICB0eXBlOiBSb2xsaW5nVXBkYXRlCiAgc2VsZWN0b3I6CiAgICBtYXRjaExhYmVsczoKICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtb3BlbnZzd2l0Y2gKICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgdGVtcGxhdGU6CiAgICBtZXRhZGF0YToKICAgICAgbGFiZWxzOgogICAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLW9wZW52c3dpdGNoCiAgICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgICAgIGFubm90YXRpb25zOgogICAgICAgIHNjaGVkdWxlci5hbHBoYS5rdWJlcm5ldGVzLmlvL2NyaXRpY2FsLXBvZDogJycKICAgIHNwZWM6CiAgICAgIGhvc3ROZXR3b3JrOiB0cnVlCiAgICAgIGhvc3RQSUQ6IHRydWUKICAgICAgaG9zdElQQzogdHJ1ZQogICAgICBzZXJ2aWNlQWNjb3VudE5hbWU6IGFjaS1jb250YWluZXJzLWhvc3QtYWdlbnQKICAgICAgdG9sZXJhdGlvbnM6CiAgICAgICAgLSBvcGVyYXRvcjogRXhpc3RzCiAgICAgIHByaW9yaXR5Q2xhc3NOYW1lOiBzeXN0ZW0tY2x1c3Rlci1jcml0aWNhbAogICAgICBjb250YWluZXJzOgogICAgICAgIC0gbmFtZTogYWNpLWNvbnRhaW5lcnMtb3BlbnZzd2l0Y2gKICAgICAgICAgIGltYWdlOiBub2lyby9vcGVudnN3aXRjaDo1LjIuMi4wLjU2ODFhOWIKICAgICAgICAgIGltYWdlUHVsbFBvbGljeTogQWx3YXlzCiAgICAgICAgICByZXNvdXJjZXM6CiAgICAgICAgICAgIGxpbWl0czoKICAgICAgICAgICAgICBtZW1vcnk6ICIxR2kiCiAgICAgICAgICBzZWN1cml0eUNvbnRleHQ6CiAgICAgICAgICAgIGNhcGFiaWxpdGllczoKICAgICAgICAgICAgICBhZGQ6CiAgICAgICAgICAgICAgICAtIE5FVF9BRE1JTgogICAgICAgICAgICAgICAgLSBTWVNfTU9EVUxFCiAgICAgICAgICAgICAgICAtIFNZU19OSUNFCiAgICAgICAgICAgICAgICAtIElQQ19MT0NLCiAgICAgICAgICBlbnY6CiAgICAgICAgICAgIC0gbmFtZTogT1ZTX1JVTkRJUgogICAgICAgICAgICAgIHZhbHVlOiAvdXNyL2xvY2FsL3Zhci9ydW4vb3BlbnZzd2l0Y2gKICAgICAgICAgIHZvbHVtZU1vdW50czoKICAgICAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3ZhcgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3J1bgogICAgICAgICAgICAtIG5hbWU6IGhvc3RldGMKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvZXRjCiAgICAgICAgICAgIC0gbmFtZTogaG9zdG1vZHVsZXMKICAgICAgICAgICAgICBtb3VudFBhdGg6IC9saWIvbW9kdWxlcwogICAgICAgICAgbGl2ZW5lc3NQcm9iZToKICAgICAgICAgICAgZXhlYzoKICAgICAgICAgICAgICBjb21tYW5kOgogICAgICAgICAgICAgICAgLSAvdXNyL2xvY2FsL2Jpbi9saXZlbmVzcy1vdnMuc2gKICAgICAgcmVzdGFydFBvbGljeTogQWx3YXlzCiAgICAgIHZvbHVtZXM6CiAgICAgICAgLSBuYW1lOiBob3N0ZXRjCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL2V0YwogICAgICAgIC0gbmFtZTogaG9zdHZhcgogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC92YXIKICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvcnVuCiAgICAgICAgLSBuYW1lOiBob3N0bW9kdWxlcwogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC9saWIvbW9kdWxlcwotLS0KYXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEZXBsb3ltZW50Cm1ldGFkYXRhOgogIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgpzcGVjOgogIHJlcGxpY2FzOiAxCiAgc3RyYXRlZ3k6CiAgICB0eXBlOiBSZWNyZWF0ZQogIHNlbGVjdG9yOgogICAgbWF0Y2hMYWJlbHM6CiAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgdGVtcGxhdGU6CiAgICBtZXRhZGF0YToKICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgogICAgICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCiAgICAgIGxhYmVsczoKICAgICAgICBuYW1lOiBhY2ktY29udGFpbmVycy1jb250cm9sbGVyCiAgICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgICAgIGFubm90YXRpb25zOgogICAgICAgIHNjaGVkdWxlci5hbHBoYS5rdWJlcm5ldGVzLmlvL2NyaXRpY2FsLXBvZDogJycKICAgIHNwZWM6CiAgICAgIGhvc3ROZXR3b3JrOiB0cnVlCiAgICAgIHNlcnZpY2VBY2NvdW50TmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgogICAgICB0b2xlcmF0aW9uczoKICAgICAgICAtIG9wZXJhdG9yOiBFeGlzdHMKICAgICAgICAgIGVmZmVjdDogTm9TY2hlZHVsZQogICAgICBwcmlvcml0eUNsYXNzTmFtZTogc3lzdGVtLW5vZGUtY3JpdGljYWwKICAgICAgY29udGFpbmVyczoKICAgICAgICAtIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICAgICAgICAgIGltYWdlOiBub2lyby9hY2ktY29udGFpbmVycy1jb250cm9sbGVyOjUuMi4yLjAuMGVmNDcxOAogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIGVudjoKICAgICAgICAgICAgLSBuYW1lOiBXQVRDSF9OQU1FU1BBQ0UKICAgICAgICAgICAgICB2YWx1ZTogIiIKICAgICAgICAgICAgLSBuYW1lOiBBQ0lfU05BVF9OQU1FU1BBQ0UKICAgICAgICAgICAgICB2YWx1ZTogImFjaS1jb250YWluZXJzLXN5c3RlbSIKICAgICAgICAgICAgLSBuYW1lOiBBQ0lfU05BR0xPQkFMSU5GT19OQU1FCiAgICAgICAgICAgICAgdmFsdWU6ICJzbmF0Z2xvYmFsaW5mbyIKICAgICAgICAgICAgLSBuYW1lOiBBQ0lfUkRDT05GSUdfTkFNRQogICAgICAgICAgICAgIHZhbHVlOiAicm91dGluZ2RvbWFpbi1jb25maWciCiAgICAgICAgICAgIC0gbmFtZTogU1lTVEVNX05BTUVTUEFDRQogICAgICAgICAgICAgIHZhbHVlOiAia3ViZS1zeXN0ZW0iCiAgICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgICAgIC0gbmFtZTogY29udHJvbGxlci1jb25maWctdm9sdW1lCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL2V0Yy9hY2ktY29udGFpbmVycy8KICAgICAgICAgICAgLSBuYW1lOiBhY2ktdXNlci1jZXJ0LXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvYWNpLWNlcnQvCiAgICAgICAgICBsaXZlbmVzc1Byb2JlOgogICAgICAgICAgICBodHRwR2V0OgogICAgICAgICAgICAgIHBhdGg6IC9zdGF0dXMKICAgICAgICAgICAgICBwb3J0OiA4MDkxCiAgICAgIHZvbHVtZXM6CiAgICAgICAgLSBuYW1lOiBhY2ktdXNlci1jZXJ0LXZvbHVtZQogICAgICAgICAgc2VjcmV0OgogICAgICAgICAgICBzZWNyZXROYW1lOiBhY2ktdXNlci1jZXJ0CiAgICAgICAgLSBuYW1lOiBjb250cm9sbGVyLWNvbmZpZy12b2x1bWUKICAgICAgICAgIGNvbmZpZ01hcDoKICAgICAgICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29uZmlnCiAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgIC0ga2V5OiBjb250cm9sbGVyLWNvbmZpZwogICAgICAgICAgICAgICAgcGF0aDogY29udHJvbGxlci5jb25mCi0tLQphcGlWZXJzaW9uOiB2MQpraW5kOiBTZXJ2aWNlQWNjb3VudAptZXRhZGF0YToKICBuYW1lOiBzcmlvdi1kZXZpY2UtcGx1Z2luCiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQotLS0KYXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEYWVtb25TZXQKbWV0YWRhdGE6CiAgbmFtZToga3ViZS1zcmlvdi1kZXZpY2UtcGx1Z2luLWFtZDY0CiAgbmFtZXNwYWNlOiBrdWJlLXN5c3RlbQogIGxhYmVsczoKICAgIHRpZXI6IG5vZGUKICAgIGFwcDogc3Jpb3ZkcApzcGVjOgogIHNlbGVjdG9yOgogICAgbWF0Y2hMYWJlbHM6CiAgICAgIG5hbWU6IHNyaW92LWRldmljZS1wbHVnaW4KICB0ZW1wbGF0ZToKICAgIG1ldGFkYXRhOgogICAgICBsYWJlbHM6CiAgICAgICAgbmFtZTogc3Jpb3YtZGV2aWNlLXBsdWdpbgogICAgICAgIHRpZXI6IG5vZGUKICAgICAgICBhcHA6IHNyaW92ZHAKICAgIHNwZWM6CiAgICAgIGhvc3ROZXR3b3JrOiB0cnVlCiAgICAgIG5vZGVTZWxlY3RvcjoKICAgICAgICBiZXRhLmt1YmVybmV0ZXMuaW8vYXJjaDogYW1kNjQKICAgICAgdG9sZXJhdGlvbnM6CiAgICAgIC0ga2V5OiBub2RlLXJvbGUua3ViZXJuZXRlcy5pby9tYXN0ZXIKICAgICAgICBvcGVyYXRvcjogRXhpc3RzCiAgICAgICAgZWZmZWN0OiBOb1NjaGVkdWxlCiAgICAgIHNlcnZpY2VBY2NvdW50TmFtZTogc3Jpb3YtZGV2aWNlLXBsdWdpbgogICAgICBjb250YWluZXJzOgogICAgICAtIG5hbWU6IGt1YmUtc3Jpb3ZkcAogICAgICAgIGltYWdlOiBkb2NrZXIuaW8vbmZ2cGUvc3Jpb3YtZGV2aWNlLXBsdWdpbjp2My4zCiAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBJZk5vdFByZXNlbnQKICAgICAgICBhcmdzOgogICAgICAgIC0gLS1sb2ctZGlyPXNyaW92ZHAKICAgICAgICAtIC0tbG9nLWxldmVsPTEwCiAgICAgICAgc2VjdXJpdHlDb250ZXh0OgogICAgICAgICAgcHJpdmlsZWdlZDogdHJ1ZQogICAgICAgIHZvbHVtZU1vdW50czoKICAgICAgICAtIG5hbWU6IGRldmljZXNvY2sKICAgICAgICAgIG1vdW50UGF0aDogL3Zhci9saWIva3ViZWxldC8KICAgICAgICAgIHJlYWRPbmx5OiBmYWxzZQogICAgICAgIC0gbmFtZTogbG9nCiAgICAgICAgICBtb3VudFBhdGg6IC92YXIvbG9nCiAgICAgICAgLSBuYW1lOiBjb25maWctdm9sdW1lCiAgICAgICAgICBtb3VudFBhdGg6IC9ldGMvcGNpZHAKICAgICAgICAtIG5hbWU6IGRldmljZS1pbmZvCiAgICAgICAgICBtb3VudFBhdGg6IC92YXIvcnVuL2s4cy5jbmkuY25jZi5pby9kZXZpbmZvL2RwCiAgICAgIHZvbHVtZXM6CiAgICAgICAgLSBuYW1lOiBkZXZpY2Vzb2NrCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL3Zhci9saWIva3ViZWxldC8KICAgICAgICAtIG5hbWU6IGxvZwogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC92YXIvbG9nCiAgICAgICAgLSBuYW1lOiBkZXZpY2UtaW5mbwogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC92YXIvcnVuL2s4cy5jbmkuY25jZi5pby9kZXZpbmZvL2RwCiAgICAgICAgICAgIHR5cGU6IERpcmVjdG9yeU9yQ3JlYXRlCiAgICAgICAgLSBuYW1lOiBjb25maWctdm9sdW1lCiAgICAgICAgICBjb25maWdNYXA6CiAgICAgICAgICAgIG5hbWU6IHNyaW92ZHAtY29uZmlnCiAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAtIGtleTogY29uZmlnLmpzb24KICAgICAgICAgICAgICBwYXRoOiBjb25maWcuanNvbgotLS0KYXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEYWVtb25TZXQKbWV0YWRhdGE6CiAgbmFtZToga3ViZS1zcmlvdi1kZXZpY2UtcGx1Z2luLXBwYzY0bGUKICBuYW1lc3BhY2U6IGt1YmUtc3lzdGVtCiAgbGFiZWxzOgogICAgdGllcjogbm9kZQogICAgYXBwOiBzcmlvdmRwCnNwZWM6CiAgc2VsZWN0b3I6CiAgICBtYXRjaExhYmVsczoKICAgICAgbmFtZTogc3Jpb3YtZGV2aWNlLXBsdWdpbgogIHRlbXBsYXRlOgogICAgbWV0YWRhdGE6CiAgICAgIGxhYmVsczoKICAgICAgICBuYW1lOiBzcmlvdi1kZXZpY2UtcGx1Z2luCiAgICAgICAgdGllcjogbm9kZQogICAgICAgIGFwcDogc3Jpb3ZkcAogICAgc3BlYzoKICAgICAgaG9zdE5ldHdvcms6IHRydWUKICAgICAgbm9kZVNlbGVjdG9yOgogICAgICAgIGJldGEua3ViZXJuZXRlcy5pby9hcmNoOiBwcGM2NGxlCiAgICAgIHRvbGVyYXRpb25zOgogICAgICAtIGtleTogbm9kZS1yb2xlLmt1YmVybmV0ZXMuaW8vbWFzdGVyCiAgICAgICAgb3BlcmF0b3I6IEV4aXN0cwogICAgICAgIGVmZmVjdDogTm9TY2hlZHVsZQogICAgICBzZXJ2aWNlQWNjb3VudE5hbWU6IHNyaW92LWRldmljZS1wbHVnaW4KICAgICAgY29udGFpbmVyczoKICAgICAgLSBuYW1lOiBrdWJlLXNyaW92ZHAKICAgICAgICBpbWFnZTogZG9ja2VyLmlvL25mdnBlL3NyaW92LWRldmljZS1wbHVnaW46cHBjNjRsZQogICAgICAgIGltYWdlUHVsbFBvbGljeTogSWZOb3RQcmVzZW50CiAgICAgICAgYXJnczoKICAgICAgICAtIC0tbG9nLWRpcj1zcmlvdmRwCiAgICAgICAgLSAtLWxvZy1sZXZlbD0xMAogICAgICAgIHNlY3VyaXR5Q29udGV4dDoKICAgICAgICAgIHByaXZpbGVnZWQ6IHRydWUKICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgLSBuYW1lOiBkZXZpY2Vzb2NrCiAgICAgICAgICBtb3VudFBhdGg6IC92YXIvbGliL2t1YmVsZXQvCiAgICAgICAgICByZWFkT25seTogZmFsc2UKICAgICAgICAtIG5hbWU6IGxvZwogICAgICAgICAgbW91bnRQYXRoOiAvdmFyL2xvZwogICAgICAgIC0gbmFtZTogY29uZmlnLXZvbHVtZQogICAgICAgICAgbW91bnRQYXRoOiAvZXRjL3BjaWRwCiAgICAgICAgLSBuYW1lOiBkZXZpY2UtaW5mbwogICAgICAgICAgbW91bnRQYXRoOiAvdmFyL3J1bi9rOHMuY25pLmNuY2YuaW8vZGV2aW5mby9kcAogICAgICB2b2x1bWVzOgogICAgICAgIC0gbmFtZTogZGV2aWNlc29jawogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC92YXIvbGliL2t1YmVsZXQvCiAgICAgICAgLSBuYW1lOiBsb2cKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvdmFyL2xvZwogICAgICAgIC0gbmFtZTogZGV2aWNlLWluZm8KICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvdmFyL3J1bi9rOHMuY25pLmNuY2YuaW8vZGV2aW5mby9kcAogICAgICAgICAgICB0eXBlOiBEaXJlY3RvcnlPckNyZWF0ZQogICAgICAgIC0gbmFtZTogY29uZmlnLXZvbHVtZQogICAgICAgICAgY29uZmlnTWFwOgogICAgICAgICAgICBuYW1lOiBzcmlvdmRwLWNvbmZpZwogICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgLSBrZXk6IGNvbmZpZy5qc29uCiAgICAgICAgICAgICAgcGF0aDogY29uZmlnLmpzb24KLS0tCmFwaVZlcnNpb246IGFwcHMvdjEKa2luZDogRGFlbW9uU2V0Cm1ldGFkYXRhOgogIG5hbWU6IGt1YmUtc3Jpb3YtZGV2aWNlLXBsdWdpbi1hcm02NAogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KICBsYWJlbHM6CiAgICB0aWVyOiBub2RlCiAgICBhcHA6IHNyaW92ZHAKc3BlYzoKICBzZWxlY3RvcjoKICAgIG1hdGNoTGFiZWxzOgogICAgICBuYW1lOiBzcmlvdi1kZXZpY2UtcGx1Z2luCiAgdGVtcGxhdGU6CiAgICBtZXRhZGF0YToKICAgICAgbGFiZWxzOgogICAgICAgIG5hbWU6IHNyaW92LWRldmljZS1wbHVnaW4KICAgICAgICB0aWVyOiBub2RlCiAgICAgICAgYXBwOiBzcmlvdmRwCiAgICBzcGVjOgogICAgICBob3N0TmV0d29yazogdHJ1ZQogICAgICBub2RlU2VsZWN0b3I6CiAgICAgICAgYmV0YS5rdWJlcm5ldGVzLmlvL2FyY2g6IGFybTY0CiAgICAgIHRvbGVyYXRpb25zOgogICAgICAtIGtleTogbm9kZS1yb2xlLmt1YmVybmV0ZXMuaW8vbWFzdGVyCiAgICAgICAgb3BlcmF0b3I6IEV4aXN0cwogICAgICAgIGVmZmVjdDogTm9TY2hlZHVsZQogICAgICBzZXJ2aWNlQWNjb3VudE5hbWU6IHNyaW92LWRldmljZS1wbHVnaW4KICAgICAgY29udGFpbmVyczoKICAgICAgLSBuYW1lOiBrdWJlLXNyaW92ZHAKIyB0aGlzIGlzIGEgdGVtcG9yYXJ5IGltYWdlIHJlcG9zaXRvcnkgZm9yIGFybTY0IGFyY2hpdGVjdHVyZSwgdXRpbCBDSS9DRCBvZiB0aGUKIyBzcmlvdi1kZXZpY2UtcGx1Z2luIHdpbGwgbm90IGFsbG93IHRvIHJlY3JlYXRlIG11bHRpcGxlIGltYWdlcwogICAgICAgIGltYWdlOiBhbGV4ZXlwZXJldmFsb3YvYXJtNjQtc3Jpb3YtZGV2aWNlLXBsdWdpbgogICAgICAgIGltYWdlUHVsbFBvbGljeTogSWZOb3RQcmVzZW50CiAgICAgICAgYXJnczoKICAgICAgICAtIC0tbG9nLWRpcj1zcmlvdmRwCiAgICAgICAgLSAtLWxvZy1sZXZlbD0xMAogICAgICAgIHNlY3VyaXR5Q29udGV4dDoKICAgICAgICAgIHByaXZpbGVnZWQ6IHRydWUKICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgLSBuYW1lOiBkZXZpY2Vzb2NrCiAgICAgICAgICBtb3VudFBhdGg6IC92YXIvbGliL2t1YmVsZXQvCiAgICAgICAgICByZWFkT25seTogZmFsc2UKICAgICAgICAtIG5hbWU6IGxvZwogICAgICAgICAgbW91bnRQYXRoOiAvdmFyL2xvZwogICAgICAgIC0gbmFtZTogY29uZmlnLXZvbHVtZQogICAgICAgICAgbW91bnRQYXRoOiAvZXRjL3BjaWRwCiAgICAgICAgLSBuYW1lOiBkZXZpY2UtaW5mbwogICAgICAgICAgbW91bnRQYXRoOiAvdmFyL3J1bi9rOHMuY25pLmNuY2YuaW8vZGV2aW5mby9kcAogICAgICB2b2x1bWVzOgogICAgICAgIC0gbmFtZTogZGV2aWNlc29jawogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC92YXIvbGliL2t1YmVsZXQvCiAgICAgICAgLSBuYW1lOiBsb2cKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvdmFyL2xvZwogICAgICAgIC0gbmFtZTogZGV2aWNlLWluZm8KICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvdmFyL3J1bi9rOHMuY25pLmNuY2YuaW8vZGV2aW5mby9kcAogICAgICAgICAgICB0eXBlOiBEaXJlY3RvcnlPckNyZWF0ZQogICAgICAgIC0gbmFtZTogY29uZmlnLXZvbHVtZQogICAgICAgICAgY29uZmlnTWFwOgogICAgICAgICAgICBuYW1lOiBzcmlvdmRwLWNvbmZpZwogICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgLSBrZXk6IGNvbmZpZy5qc29uCiAgICAgICAgICAgICAgcGF0aDogY29uZmlnLmpzb24KLS0tCmFwaVZlcnNpb246IHYxCmtpbmQ6IENvbmZpZ01hcAptZXRhZGF0YToKICBuYW1lOiBzcmlvdmRwLWNvbmZpZwogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0KZGF0YToKICBjb25maWcuanNvbjogfAogICAgewogICAgICAgICJyZXNvdXJjZUxpc3QiOiBbCiAgICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgInJlc291cmNlUHJlZml4IjogIm1lbGxhbm94LmNvbSIsCiAgICAgICAgICAgICAgICAgICAicmVzb3VyY2VOYW1lIjogImN4NV9zcmlvdl9zd2l0Y2hkZXYiLAogICAgICAgICAgICAgICAgICAgInNlbGVjdG9ycyI6IHsKICAgICAgICAgICAgICAgICAgICAgICJ2ZW5kb3JzIjogWyIxNWIzIl0sCiAgICAgICAgICAgICAgICAgICAgICAiZGV2aWNlcyI6IFsiMTAxNCIsIjEwMWUiXSwKICAgICAgICAgICAgICAgICAgICAgICJkcml2ZXJzIjogWyJtbHg1X2NvcmUiXSwKICAgICAgICAgICAgICAgICAgICAgICJpc1JkbWEiOiAgZmFsc2UKICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICB9CiAgICAgICAgXQogICAgfQo="
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aci-containers-config
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  controller-config: |-
+    {
+        "flavor": "kubernetes-1.22",
+        "log-level": "info",
+        "apic-hosts": [
+            "10.30.120.100"
+        ],
+        "apic-username": "kube",
+        "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "aci-prefix": "kube",
+        "aci-vmm-type": "Kubernetes",
+        "aci-vmm-domain": "kube",
+        "aci-vmm-controller": "kube",
+        "aci-policy-tenant": "kube",
+        "install-istio": true,
+        "istio-profile": "demo",
+        "aci-podbd-dn": "uni/tn-kube/BD-kube-pod-bd",
+        "aci-nodebd-dn": "uni/tn-kube/BD-kube-node-bd",
+        "aci-service-phys-dom": "kube-pdom",
+        "aci-service-encap": "vlan-4003",
+        "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
+        "aci-vrf-tenant": "common",
+        "aci-vrf-dn": "uni/tn-common/ctx-kube",
+        "aci-l3out": "l3out",
+        "aci-ext-networks": [
+            "default"
+        ],
+        "aci-vrf": "kube",
+        "default-endpoint-group": {
+            "policy-space": "kube",
+            "name": "kubernetes|kube-default"
+        },
+        "max-nodes-svc-graph": 32,
+        "namespace-default-endpoint-group": {
+            "istio-operator": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "istio-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "kube-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            }        },
+        "service-ip-pool": [
+            {
+                "end": "10.3.0.254",
+                "start": "10.3.0.2"
+            }
+        ],
+        "snat-contract-scope": "global",
+        "static-service-ip-pool": [
+            {
+                "end": "10.4.0.254",
+                "start": "10.4.0.2"
+            }
+        ],
+        "pod-ip-pool": [
+            {
+                "end": "10.2.255.254",
+                "start": "10.2.0.2"
+            }
+        ],
+        "pod-subnet-chunk-size": 32,
+        "node-service-ip-pool": [
+            {
+                "end": "10.5.0.254",
+                "start": "10.5.0.2"
+            }
+        ],
+        "node-service-subnets": [
+            "10.5.0.1/24"
+        ]
+    }
+  host-agent-config: |-
+    {
+        "flavor": "kubernetes-1.22",
+        "app-profile": "kubernetes",
+        "ep-registry": null,
+        "opflex-mode": null,
+        "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
+        "aci-vmm-type": "Kubernetes",
+        "aci-vmm-domain": "kube",
+        "aci-vmm-controller": "kube",
+        "aci-prefix": "kube",
+        "aci-vrf": "kube",
+        "aci-vrf-tenant": "common",
+        "service-vlan": 4003,
+        "kubeapi-vlan": 4001,
+        "pod-subnet": "10.2.0.1/16",
+        "node-subnet": "10.1.0.1/16",
+        "encap-type": "vxlan",
+        "aci-infra-vlan": 4093,
+        "cni-netconfig": [
+            {
+                "gateway": "10.2.0.1",
+                "routes": [
+                    {
+                        "dst": "0.0.0.0/0",
+                        "gw": "10.2.0.1"
+                    }
+                ],
+                "subnet": "10.2.0.0/16"
+            }
+        ],
+        "default-endpoint-group": {
+            "policy-space": "kube",
+            "name": "kubernetes|kube-default"
+        },
+        "namespace-default-endpoint-group": {
+            "istio-operator": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "istio-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-istio"
+            },
+            "kube-system": {
+                "policy-space": "kube",
+                "name": "kubernetes|kube-system"
+            }        },
+        "enable-drop-log": true
+    }
+  opflex-agent-config: |-
+    {
+        "log": {
+            "level": "info"
+        },
+        "opflex": {
+            "notif" : { "enabled" : "false" }
+        }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snat-operator-config
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+    "start": "5000"
+    "end": "65000"
+    "ports-per-node": "3000"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aci-user-cert
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+data:
+  user.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUNkZ0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQW1Bd2dnSmNBZ0VBQW9HQkFOcitBK2dPS2JBVlZySnMKYjMrWldiY25WWG8vZ2R1eElUa3ZtMDlrZWlGQ24rVXAvU0dkcXY2QWgramxKZkY3dXYrRmdDSnRDeEQ4N3FZdwowcTVEY0dWTEljZkY0WlViOUI4ckpXS0JJNndKZnh0TWZGdVVOWTI0Y2d3UXBKcXJNVXFBRHovTVcrd3JaZWhzClNuRnN5ZXdYUjM4OGVSN0VLakRXZWdkSnlQY1hBZ01CQUFFQ2dZQjlBWGIxWmZCQ0JVeEIrVWdFVEdNNys0WDkKakhieUUwQmx4bGtmanJsd2R2bVM5TTc3KzJaNmRLQWdQMzNUUk0vUHdFTU9ZN1JuZEJvK1g2eERzVmRjVEpJeQo1Vnc4eFVabHIrYXVFT2xzMlpuWngxMWU1emg3c1UzTmo1SzM1QldSOUdUWEo2UE1kcFQ0OWxCOWJsbE1qRHJMCjcrNWJDc2R1NjNPOEthTjlZUUpCQVBHTWJwSHBGc3RDMWNXR3BSUXgzaXdGK1pMWUFyQVViQ0tiV1FmYmlaVHAKQ1M4RGdPbXlVN3VLVFJLaUMrMlJZVFMzcHJMVjU3R3ZmZkZ4SmpUd0d5a0NRUURvR0J3ZjVpT3N5dU1RTno3SwpSaXJiRDBKN1I2WWVRa0paK3BDZUt3eStOeUlxeGgwTEJEbUJ5bVNLdlgwV0VLQ2l0T2dwaTMyRldCb3FIamYzCk1RZy9Ba0JMQkxScWVKdnRzT28zbUtPNGEreDJlN3lSVUtrMUNvS3pGTkJIMG5VZVhHblB3aVROYitiMWZmU0YKN3ZJSmJIZG1LZ3VKeTBsVU5BN0haNzdYL2lKUkFrQWpuYmVMS1p6bDRraVA3M3BpUGZ4TG0zN2ZQakoreURvNApacHdVdVpSK0NDWGxISHZPZWZwOU1WcldjNWVqY0MvR2FDNk1XWXlNanVXTSt4QXBqY3V2QWtFQXpZK3AxNDBDCnh3cHI5NWxpbm52V2NDN043MDhBSkZpbTMvRlUxMEdEbzc3eUlPSTVoKzUzN0piWWRtNTU1aE9lSC9LalNla2gKRUY0TW14UlBtaXQ5OXc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==
+  user.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUI2RENDQVZFQ0FnUG9NQTBHQ1NxR1NJYjNEUUVCQlFVQU1Ed3hDekFKQmdOVkJBWVRBbFZUTVJZd0ZBWUQKVlFRS0RBMURhWE5qYnlCVGVYTjBaVzF6TVJVd0V3WURWUVFEREF4VmMyVnlJRzFoYm1SbFpYQXdIaGNOTVRjdwpOVEUyTWpFeU9UTXdXaGNOTWpjd05URTBNakV5T1RNd1dqQThNUXN3Q1FZRFZRUUdFd0pWVXpFV01CUUdBMVVFCkNnd05RMmx6WTI4Z1UzbHpkR1Z0Y3pFVk1CTUdBMVVFQXd3TVZYTmxjaUJ0WVc1a1pXVndNSUdmTUEwR0NTcUcKU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FEYS9nUG9EaW13RlZheWJHOS9tVm0zSjFWNlA0SGJzU0U1TDV0UApaSG9oUXAvbEtmMGhuYXIrZ0lmbzVTWHhlN3IvaFlBaWJRc1EvTzZtTU5LdVEzQmxTeUhIeGVHVkcvUWZLeVZpCmdTT3NDWDhiVEh4YmxEV051SElNRUtTYXF6RktnQTgvekZ2c0syWG9iRXB4Yk1uc0YwZC9QSGtleENvdzFub0gKU2NqM0Z3SURBUUFCTUEwR0NTcUdTSWIzRFFFQkJRVUFBNEdCQUhYK2tMVGU2TENBQmV3bUNUdk1zanVzSGRwWgpraTAxK25RN0tobkVSYkJtL3RaNXNjWkU0Y3RJcWNoM255MUVJVEhOdFlXS0JONENkVUtjanZEVzJoMnZrSGVnCnJ0WWJWK0FhRXNxMG00dkdGOUVtdnQxY3A5WTQxSXlNQlpZcXc4Yy9WMUF0bVJRY1JUWVFBOEgzT0ZEY2h5QjIKMEpIU0RuQm9TN2ZmU2JCeAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-controller
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-host-agent
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers:controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - endpoints
+  - services
+  - events
+  - replicationcontrollers
+  - serviceaccounts
+  verbs:
+  - list
+  - watch
+  - get
+  - patch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - "install.istio.io"
+  resources:
+  - istiocontrolplanes
+  - istiooperators
+  verbs:
+  - '*'
+- apiGroups:
+  - "aci.istio"
+  resources:
+  - aciistiooperators
+  - aciistiooperator
+  verbs:
+  - '*'
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - services/status
+  verbs:
+  - update
+- apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatpolicies/finalizers
+  - snatpolicies/status
+  - nodeinfos
+  verbs:
+  - update
+  - create
+  - list
+  - watch
+  - get
+  - delete
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatglobalinfos
+  - snatpolicies
+  - nodeinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "aci.qos"
+  resources:
+  - qospolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - "aci.netflow"
+  resources:
+  - netflowpolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - "aci.erspan"
+  resources:
+  - erspanpolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - "aci.aw"
+  resources:
+  - podifs
+  verbs:
+  - '*'
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "aci.netpol"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "aci.dnsnetpol"
+  resources:
+  - dnsnetworkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers:host-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - endpoints
+  - services
+  - replicationcontrollers
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.aw"
+  resources:
+  - podifs
+  - podifs/status
+  verbs:
+  - "*"
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatpolicies
+  - snatglobalinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.qos"
+  resources:
+  - qospolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - "aci.droplog"
+  resources:
+  - enabledroplogs
+  - prunedroplogs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - nodeinfos
+  - snatlocalinfos
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+  - delete
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "aci.netpol"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers:controller
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers:controller
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers:host-agent
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers:host-agent
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-host-agent
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aci-containers-host
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-host
+      network-plugin: aci-containers
+  template:
+    metadata:
+      labels:
+        name: aci-containers-host
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9612"
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      serviceAccountName: aci-containers-host-agent
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: aci-containers-host
+          image: noiro/aci-containers-host:5.2.2.0.0ef4718
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - NET_ADMIN
+                - SYS_PTRACE
+                - NET_RAW
+          env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: TENANT
+              value: "kube"
+            - name: NODE_EPG
+              value: "kubernetes|kube-nodes"
+            - name: DURATION_WAIT_FOR_NETWORK
+              value: "210"
+          volumeMounts:
+            - name: cni-bin
+              mountPath: /mnt/cni-bin
+            - name: cni-conf
+              mountPath: /mnt/cni-conf
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: opflex-hostconfig-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+            - name: host-config-volume
+              mountPath: /usr/local/etc/aci-containers/
+            - mountPath: /run/netns
+              name: host-run-netns
+              readOnly: true
+              mountPropagation: HostToContainer
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8090
+        - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
+          image: noiro/opflex:5.2.2.0.d2739da
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: opflex-hostconfig-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+            - name: opflex-config-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
+        - name: mcast-daemon
+          image: noiro/opflex:5.2.2.0.d2739da
+          command: ["/bin/sh"]
+          args: ["/usr/local/bin/launch-mcastdaemon.sh"]
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+      restartPolicy: Always
+      volumes:
+        - name: cni-bin
+          hostPath:
+            path: /opt
+        - name: cni-conf
+          hostPath:
+            path: /etc
+        - name: hostvar
+          hostPath:
+            path: /var
+        - name: hostrun
+          hostPath:
+            path: /run
+        - name: host-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: host-agent-config
+                path: host-agent.conf
+        - name: opflex-hostconfig-volume
+          emptyDir:
+            medium: Memory
+        - name: opflex-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: opflex-agent-config
+                path: local.conf
+        - name: host-run-netns
+          hostPath:
+            path: /run/netns
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aci-containers-openvswitch
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-openvswitch
+      network-plugin: aci-containers
+  template:
+    metadata:
+      labels:
+        name: aci-containers-openvswitch
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      serviceAccountName: aci-containers-host-agent
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: aci-containers-openvswitch
+          image: noiro/openvswitch:5.2.2.0.5681a9b
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "1Gi"
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - SYS_MODULE
+                - SYS_NICE
+                - IPC_LOCK
+          env:
+            - name: OVS_RUNDIR
+              value: /usr/local/var/run/openvswitch
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: hostetc
+              mountPath: /usr/local/etc
+            - name: hostmodules
+              mountPath: /lib/modules
+          livenessProbe:
+            exec:
+              command:
+                - /usr/local/bin/liveness-ovs.sh
+      restartPolicy: Always
+      volumes:
+        - name: hostetc
+          hostPath:
+            path: /etc
+        - name: hostvar
+          hostPath:
+            path: /var
+        - name: hostrun
+          hostPath:
+            path: /run
+        - name: hostmodules
+          hostPath:
+            path: /lib/modules
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aci-containers-controller
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+    name: aci-containers-controller
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: aci-containers-controller
+      network-plugin: aci-containers
+  template:
+    metadata:
+      name: aci-containers-controller
+      namespace: kube-system
+      labels:
+        name: aci-containers-controller
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      serviceAccountName: aci-containers-controller
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+      priorityClassName: system-node-critical
+      containers:
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:5.2.2.0.0ef4718
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: ACI_SNAT_NAMESPACE
+              value: "aci-containers-system"
+            - name: ACI_SNAGLOBALINFO_NAME
+              value: "snatglobalinfo"
+            - name: ACI_RDCONFIG_NAME
+              value: "routingdomain-config"
+            - name: SYSTEM_NAMESPACE
+              value: "kube-system"
+          volumeMounts:
+            - name: controller-config-volume
+              mountPath: /usr/local/etc/aci-containers/
+            - name: aci-user-cert-volume
+              mountPath: /usr/local/etc/aci-cert/
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8091
+      volumes:
+        - name: aci-user-cert-volume
+          secret:
+            secretName: aci-user-cert
+        - name: controller-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: controller-config
+                path: controller.conf
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sriov-device-plugin
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-device-plugin-amd64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriovdp
+spec:
+  selector:
+    matchLabels:
+      name: sriov-device-plugin
+  template:
+    metadata:
+      labels:
+        name: sriov-device-plugin
+        tier: node
+        app: sriovdp
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: sriov-device-plugin
+      containers:
+      - name: kube-sriovdp
+        image: docker.io/nfvpe/sriov-device-plugin:v3.3
+        imagePullPolicy: IfNotPresent
+        args:
+        - --log-dir=sriovdp
+        - --log-level=10
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: devicesock
+          mountPath: /var/lib/kubelet/
+          readOnly: false
+        - name: log
+          mountPath: /var/log
+        - name: config-volume
+          mountPath: /etc/pcidp
+        - name: device-info
+          mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
+      volumes:
+        - name: devicesock
+          hostPath:
+            path: /var/lib/kubelet/
+        - name: log
+          hostPath:
+            path: /var/log
+        - name: device-info
+          hostPath:
+            path: /var/run/k8s.cni.cncf.io/devinfo/dp
+            type: DirectoryOrCreate
+        - name: config-volume
+          configMap:
+            name: sriovdp-config
+            items:
+            - key: config.json
+              path: config.json
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-device-plugin-ppc64le
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriovdp
+spec:
+  selector:
+    matchLabels:
+      name: sriov-device-plugin
+  template:
+    metadata:
+      labels:
+        name: sriov-device-plugin
+        tier: node
+        app: sriovdp
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: ppc64le
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: sriov-device-plugin
+      containers:
+      - name: kube-sriovdp
+        image: docker.io/nfvpe/sriov-device-plugin:ppc64le
+        imagePullPolicy: IfNotPresent
+        args:
+        - --log-dir=sriovdp
+        - --log-level=10
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: devicesock
+          mountPath: /var/lib/kubelet/
+          readOnly: false
+        - name: log
+          mountPath: /var/log
+        - name: config-volume
+          mountPath: /etc/pcidp
+        - name: device-info
+          mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
+      volumes:
+        - name: devicesock
+          hostPath:
+            path: /var/lib/kubelet/
+        - name: log
+          hostPath:
+            path: /var/log
+        - name: device-info
+          hostPath:
+            path: /var/run/k8s.cni.cncf.io/devinfo/dp
+            type: DirectoryOrCreate
+        - name: config-volume
+          configMap:
+            name: sriovdp-config
+            items:
+            - key: config.json
+              path: config.json
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-device-plugin-arm64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriovdp
+spec:
+  selector:
+    matchLabels:
+      name: sriov-device-plugin
+  template:
+    metadata:
+      labels:
+        name: sriov-device-plugin
+        tier: node
+        app: sriovdp
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: arm64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: sriov-device-plugin
+      containers:
+      - name: kube-sriovdp
+# this is a temporary image repository for arm64 architecture, util CI/CD of the
+# sriov-device-plugin will not allow to recreate multiple images
+        image: alexeyperevalov/arm64-sriov-device-plugin
+        imagePullPolicy: IfNotPresent
+        args:
+        - --log-dir=sriovdp
+        - --log-level=10
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: devicesock
+          mountPath: /var/lib/kubelet/
+          readOnly: false
+        - name: log
+          mountPath: /var/log
+        - name: config-volume
+          mountPath: /etc/pcidp
+        - name: device-info
+          mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
+      volumes:
+        - name: devicesock
+          hostPath:
+            path: /var/lib/kubelet/
+        - name: log
+          hostPath:
+            path: /var/log
+        - name: device-info
+          hostPath:
+            path: /var/run/k8s.cni.cncf.io/devinfo/dp
+            type: DirectoryOrCreate
+        - name: config-volume
+          configMap:
+            name: sriovdp-config
+            items:
+            - key: config.json
+              path: config.json
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sriovdp-config
+  namespace: kube-system
+data:
+  config.json: |
+    {
+        "resourceList": [
+                 {
+                   "resourcePrefix": "mellanox.com",
+                   "resourceName": "cx5_sriov_switchdev",
+                   "selectors": {
+                      "vendors": ["15b3"],
+                      "devices": ["1014","101e"],
+                      "drivers": ["mlx5_core"],
+                      "isRdma":  false
+                   }
+                 }
+        ]
+    }
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-operator
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers-operator
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  - namespaces
+  - configmaps
+  - secrets
+  - pods
+  - services
+  - serviceaccounts
+  - serviceaccounts/token
+  - endpoints
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.ctrl
+  resources:
+  - acicontainersoperators
+  - acicontainersoperators/status
+  - acicontainersoperators/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.snat
+  resources:
+  - snatpolicies
+  - snatglobalinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - aci.snat
+  resources:
+  - nodeinfos
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+- apiGroups:
+  - config.openshift.io
+  - operator.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers-operator
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers-operator
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-operator
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aci-containers-operator
+  namespace: kube-system
+  labels:
+    aci-containers-config-version: "dummy"
+    name: aci-containers-operator
+    network-plugin: aci-containers
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: aci-containers-operator
+      network-plugin: aci-containers
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: aci-containers-operator
+      namespace: kube-system
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: aci-containers-operator
+        network-plugin: aci-containers
+    spec:
+      containers:
+      - image: noiro/aci-containers-operator:5.2.2.0.0ef4718
+        imagePullPolicy: Always
+        name: aci-containers-operator
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - name: aci-operator-config
+          mountPath: /usr/local/etc/aci-containers/
+        env:
+        - name: SYSTEM_NAMESPACE
+          value: "kube-system"
+        - name: ACC_PROVISION_FLAVOR
+          value: "kubernetes-1.22"
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: aci-containers-operator
+      serviceAccountName: aci-containers-operator
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - name: aci-operator-config
+        configMap:
+          name: aci-operator-config
+          items:
+            - key: spec
+              path: aci-operator.conf


### PR DESCRIPTION
Now that we are planning to support ovs hardware offloading using smart nics, sriov device plugin will be deployed as a  daemonset for discovering and advertising SR-IOV virtual functions which are available on k8s clusters. Provided we enable the "sriov_config" knob in the acc_provision input file(overlay and on-prem), sriov network plugin daemonset and config map will be generated as a part of aci_deployment file.  

acc_provision changes are tested on the setup and verified the generated yaml file from test cases thats been added.

