### PR TITLE
Fix tenant fields inside acc-provision-operator resources

### DIFF
--- a/provision/acc_provision/templates/acc-provision-configmap.yaml
+++ b/provision/acc_provision/templates/acc-provision-configmap.yaml
@@ -20,6 +20,11 @@ data:
                 {% if config.user_config.aci_config.aep %}
                 "aep": {{config.aci_config.aep|json}},
                 {% endif %}
+                {% if config.user_config.aci_config.tenant %}
+                "tenant": {
+                    "name": {{config.user_config.aci_config.tenant.name|json}}
+                },
+                {% endif %}
                 "vrf": {
                     "name": {{config.aci_config.vrf.name|json}},
                     "tenant": {{config.aci_config.vrf.tenant|json}}

--- a/provision/acc_provision/templates/acc-provision-crd.yaml
+++ b/provision/acc_provision/templates/acc-provision-crd.yaml
@@ -36,8 +36,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/base_case_operator_mode.kube.yaml
+++ b/provision/testdata/base_case_operator_mode.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/base_case_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/base_case_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -32,8 +32,6 @@ spec:
                     properties:
                       client_ssl:
                         type: boolean
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         properties:
                           certfile:

--- a/provision/testdata/base_case_upgrade.kube.yaml
+++ b/provision/testdata/base_case_upgrade.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/cloud_tar/cluster-network-21-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/cloud_tar/cluster-network-21-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -32,8 +32,6 @@ spec:
                     properties:
                       client_ssl:
                         type: boolean
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         properties:
                           certfile:

--- a/provision/testdata/cloud_tar/cluster-network-23-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/cloud_tar/cluster-network-23-ConfigMap-acc-provision-config.yaml
@@ -2,11 +2,12 @@ apiVersion: v1
 data:
   spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
     \  \"system_id\": \"clusterjj\",\n            \"apic_hosts\": [\n            \
-    \    \"localhost:50000\"\n            ],\n            \"vrf\": {\n           \
-    \     \"name\": \"ULjj\",\n                \"tenant\": \"csrtest\"\n         \
-    \   },\n            \"l3out\": {\n                \"name\": null,\n          \
-    \      \"external_networks\": null\n            }\n        },\n        \"registry\"\
-    : {\n            \"image_prefix\": \"noirolabs\", \n            \"aci_containers_host_version\"\
+    \    \"localhost:50000\"\n            ],\n            \"tenant\": {\n        \
+    \        \"name\": \"csrtest\"\n            },\n            \"vrf\": {\n     \
+    \           \"name\": \"ULjj\",\n                \"tenant\": \"csrtest\"\n   \
+    \         },\n            \"l3out\": {\n                \"name\": null,\n    \
+    \            \"external_networks\": null\n            }\n        },\n        \"\
+    registry\": {\n            \"image_prefix\": \"noirolabs\", \n            \"aci_containers_host_version\"\
     : \"ci_test\", \n            \"opflex_agent_version\": \"ci_test\", \n       \
     \     \"opflex_server_version\": \"ci_test\", \n            \"openvswitch_version\"\
     : \"ci_test\", \n            \"gbp_version\": \"ci_test\", \n            \"aci_containers_controller_version\"\

--- a/provision/testdata/flavor_aks.kube.yaml
+++ b/provision/testdata/flavor_aks.kube.yaml
@@ -1240,8 +1240,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:
@@ -1396,6 +1394,9 @@ data:
                 "apic_hosts": [
                     "localhost:50001"
                 ],
+                "tenant": {
+                    "name": "aks1"
+                },
                 "vrf": {
                     "name": "ul_akstest",
                     "tenant": "aks1"

--- a/provision/testdata/flavor_cloud.kube.yaml
+++ b/provision/testdata/flavor_cloud.kube.yaml
@@ -1241,8 +1241,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:
@@ -1397,6 +1395,9 @@ data:
                 "apic_hosts": [
                     "localhost:50000"
                 ],
+                "tenant": {
+                    "name": "csrtest"
+                },
                 "vrf": {
                     "name": "ULjj",
                     "tenant": "csrtest"

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/flavor_eks.kube.yaml
+++ b/provision/testdata/flavor_eks.kube.yaml
@@ -1240,8 +1240,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:
@@ -1396,6 +1394,9 @@ data:
                 "apic_hosts": [
                     "localhost:50002"
                 ],
+                "tenant": {
+                    "name": "csrtest"
+                },
                 "vrf": {
                     "name": "ULinteg",
                     "tenant": "csrtest"

--- a/provision/testdata/flavor_openshift_310.kube.yaml
+++ b/provision/testdata/flavor_openshift_310.kube.yaml
@@ -1147,8 +1147,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/flavor_openshift_311.kube.yaml
+++ b/provision/testdata/flavor_openshift_311.kube.yaml
@@ -1147,8 +1147,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/flavor_openshift_43.kube.yaml
+++ b/provision/testdata/flavor_openshift_43.kube.yaml
@@ -1156,8 +1156,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/flavor_openshift_43_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_43_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -32,8 +32,6 @@ spec:
                     properties:
                       client_ssl:
                         type: boolean
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         properties:
                           certfile:

--- a/provision/testdata/flavor_openshift_44_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_44_esx.kube.yaml
@@ -1156,8 +1156,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -32,8 +32,6 @@ spec:
                     properties:
                       client_ssl:
                         type: boolean
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         properties:
                           certfile:

--- a/provision/testdata/flavor_openshift_44_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_44_openstack.kube.yaml
@@ -1156,8 +1156,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/flavor_openshift_44_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_44_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -32,8 +32,6 @@ spec:
                     properties:
                       client_ssl:
                         type: boolean
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         properties:
                           certfile:

--- a/provision/testdata/flavor_openshift_45_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_45_esx.kube.yaml
@@ -1156,8 +1156,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -32,8 +32,6 @@ spec:
                     properties:
                       client_ssl:
                         type: boolean
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         properties:
                           certfile:

--- a/provision/testdata/flavor_openshift_45_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_45_openstack.kube.yaml
@@ -1156,8 +1156,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/flavor_openshift_45_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_45_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -32,8 +32,6 @@ spec:
                     properties:
                       client_ssl:
                         type: boolean
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         properties:
                           certfile:

--- a/provision/testdata/flavor_openshift_46_baremetal.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_baremetal.kube.yaml
@@ -1156,8 +1156,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/flavor_openshift_46_baremetal_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_46_baremetal_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -32,8 +32,6 @@ spec:
                     properties:
                       client_ssl:
                         type: boolean
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         properties:
                           certfile:

--- a/provision/testdata/flavor_openshift_46_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_esx.kube.yaml
@@ -1156,8 +1156,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -32,8 +32,6 @@ spec:
                     properties:
                       client_ssl:
                         type: boolean
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         properties:
                           certfile:

--- a/provision/testdata/flavor_openshift_46_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_openstack.kube.yaml
@@ -1156,8 +1156,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/flavor_openshift_46_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_46_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -32,8 +32,6 @@ spec:
                     properties:
                       client_ssl:
                         type: boolean
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         properties:
                           certfile:

--- a/provision/testdata/flavor_openshift_47_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_47_esx.kube.yaml
@@ -1156,8 +1156,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -32,8 +32,6 @@ spec:
                     properties:
                       client_ssl:
                         type: boolean
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         properties:
                           certfile:

--- a/provision/testdata/flavor_openshift_47_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_47_openstack.kube.yaml
@@ -1156,8 +1156,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/flavor_openshift_47_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_47_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -32,8 +32,6 @@ spec:
                     properties:
                       client_ssl:
                         type: boolean
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         properties:
                           certfile:

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -1193,8 +1193,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_istio_default_profile.kube.yaml
+++ b/provision/testdata/with_istio_default_profile.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_new_naming_convention.kube.yaml
+++ b/provision/testdata/with_new_naming_convention.kube.yaml
@@ -1193,8 +1193,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_new_naming_convention_dockerucp.kube.yaml
+++ b/provision/testdata/with_new_naming_convention_dockerucp.kube.yaml
@@ -1193,8 +1193,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_new_naming_convention_openshift.kube.yaml
+++ b/provision/testdata/with_new_naming_convention_openshift.kube.yaml
@@ -1147,8 +1147,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_no_drop_log.kube.yaml
+++ b/provision/testdata/with_no_drop_log.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_no_install_istio.kube.yaml
+++ b/provision/testdata/with_no_install_istio.kube.yaml
@@ -1146,8 +1146,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_no_sriov_config_kube.yaml
+++ b/provision/testdata/with_no_sriov_config_kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_preexisting_tenant.kube.yaml
+++ b/provision/testdata/with_preexisting_tenant.kube.yaml
@@ -1193,8 +1193,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:
@@ -1350,6 +1348,9 @@ data:
                     "10.30.120.100"
                 ],
                 "aep": "kube-aep",
+                "tenant": {
+                    "name": "old_tenant"
+                },
                 "vrf": {
                     "name": "kube",
                     "tenant": "common"

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_sriov_config_kube.yaml
+++ b/provision/testdata/with_sriov_config_kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_sriov_config_no_deviceinfo_kube.yaml
+++ b/provision/testdata/with_sriov_config_no_deviceinfo_kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:

--- a/provision/testdata/with_wait_for_network.kube.yaml
+++ b/provision/testdata/with_wait_for_network.kube.yaml
@@ -1192,8 +1192,6 @@ spec:
                   aci_config:
                     type: object
                     properties:
-                      cluster_tenant:
-                        type: string
                       sync_login:
                         type: object
                         properties:


### PR DESCRIPTION
Add tenant.name field to acc-provision-operator config map as this is required to correctly compute pre-existing tenant

Remove cluster_tenant field from the CRD