### PR TITLE
Disable ansible operator based upgrades by default

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -122,6 +122,9 @@ def deep_merge(user, default):
 def config_default():
     # Default values for configuration
     default_config = {
+        "operator_managed_config": {
+            "enable_updates": False,
+        },
         "aci_config": {
             "apic_version": "1.0",
             "system_id": None,

--- a/provision/acc_provision/templates/acc-provision-configmap.yaml
+++ b/provision/acc_provision/templates/acc-provision-configmap.yaml
@@ -11,6 +11,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": {{config.operator_managed_config.enable_updates|json}}
+            },
             "aci_config": {
                 "system_id": {{config.aci_config.system_id|json}},
                 {% if config.user_config.aci_config.apic_hosts %}

--- a/provision/acc_provision/templates/acc-provision-crd.yaml
+++ b/provision/acc_provision/templates/acc-provision-crd.yaml
@@ -33,6 +33,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/base_case_operator_mode.kube.yaml
+++ b/provision/testdata/base_case_operator_mode.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/base_case_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/base_case_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -113,6 +113,11 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  operator_managed_config:
+                    properties:
+                      enable_updates:
+                        type: boolean
+                    type: object
                   registry:
                     properties:
                       acc_provision_operator_version:

--- a/provision/testdata/base_case_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/base_case_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -1,18 +1,19 @@
 apiVersion: v1
 data:
-  spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
-    \  \"system_id\": \"kube\",\n            \"apic_hosts\": [\n                \"\
-    10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\",\n        \
-    \    \"vrf\": {\n                \"name\": \"kube\",\n                \"tenant\"\
-    : \"common\"\n            },\n            \"sync_login\": {\n                \"\
-    certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\n      \
-    \      },\n            \"l3out\": {\n                \"name\": \"l3out\",\n  \
-    \              \"external_networks\": [\n                    \"default\"\n   \
-    \             ]\n            }\n        },\n        \"registry\": {\n        \
-    \    \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n   \
-    \         \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\": true,\
-    \ \n            \"use_ds_rolling_update\": true\n\n        },\n        \"logging\"\
-    : {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
+  spec: "{\n    \"acc_provision_input\": {\n        \"operator_managed_config\": {\n\
+    \            \"enable_updates\": false\n        },\n        \"aci_config\": {\n\
+    \            \"system_id\": \"kube\",\n            \"apic_hosts\": [\n       \
+    \         \"10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\"\
+    ,\n            \"vrf\": {\n                \"name\": \"kube\",\n             \
+    \   \"tenant\": \"common\"\n            },\n            \"sync_login\": {\n  \
+    \              \"certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\
+    \n            },\n            \"l3out\": {\n                \"name\": \"l3out\"\
+    ,\n                \"external_networks\": [\n                    \"default\"\n\
+    \                ]\n            }\n        },\n        \"registry\": {\n     \
+    \       \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n\
+    \            \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\":\
+    \ true, \n            \"use_ds_rolling_update\": true\n\n        },\n        \"\
+    logging\": {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
     : \"info\", \n           \"opflexagent_log_level\": \"info\"\n        },\n   \
     \     \"net_config\": {\n            \"infra_vlan\": 4093,\n            \"service_vlan\"\
     : 4003, \n            \"kubeapi_vlan\": 4001,\n            \"extern_static\":\

--- a/provision/testdata/base_case_upgrade.kube.yaml
+++ b/provision/testdata/base_case_upgrade.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/cloud_tar/cluster-network-21-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/cloud_tar/cluster-network-21-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -113,6 +113,11 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  operator_managed_config:
+                    properties:
+                      enable_updates:
+                        type: boolean
+                    type: object
                   registry:
                     properties:
                       acc_provision_operator_version:

--- a/provision/testdata/cloud_tar/cluster-network-23-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/cloud_tar/cluster-network-23-ConfigMap-acc-provision-config.yaml
@@ -1,24 +1,26 @@
 apiVersion: v1
 data:
-  spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
-    \  \"system_id\": \"clusterjj\",\n            \"apic_hosts\": [\n            \
-    \    \"localhost:50000\"\n            ],\n            \"tenant\": {\n        \
-    \        \"name\": \"csrtest\"\n            },\n            \"vrf\": {\n     \
-    \           \"name\": \"ULjj\",\n                \"tenant\": \"csrtest\"\n   \
-    \         },\n            \"l3out\": {\n                \"name\": null,\n    \
-    \            \"external_networks\": null\n            }\n        },\n        \"\
-    registry\": {\n            \"image_prefix\": \"noirolabs\", \n            \"aci_containers_host_version\"\
-    : \"ci_test\", \n            \"opflex_agent_version\": \"ci_test\", \n       \
-    \     \"opflex_server_version\": \"ci_test\", \n            \"openvswitch_version\"\
-    : \"ci_test\", \n            \"gbp_version\": \"ci_test\", \n            \"aci_containers_controller_version\"\
-    : \"ci_test\"\n        },\n        \"kube_config\": {\n            \"run_snat_container\"\
-    : false, \n            \"run_gbp_container\": true, \n            \"ep_registry\"\
-    : \"k8s\", \n            \"opflex_mode\": \"overlay\"\n\n        },\n        \"\
-    istio_config\": {\n           \"install_istio\": false\n        },\n        \"\
-    net_config\": {\n            \"extern_static\": \"10.4.0.1/24\",\n           \
-    \ \"extern_dynamic\": \"10.3.0.1/24\",\n            \"node_svc_subnet\": \"10.5.0.1/24\"\
-    ,\n            \"node_subnet\": \"31.0.1.0/24\",\n            \"pod_subnet\":\
-    \ \"14.3.0.1/16\"\n        }\n    }\n }"
+  spec: "{\n    \"acc_provision_input\": {\n        \"operator_managed_config\": {\n\
+    \            \"enable_updates\": false\n        },\n        \"aci_config\": {\n\
+    \            \"system_id\": \"clusterjj\",\n            \"apic_hosts\": [\n  \
+    \              \"localhost:50000\"\n            ],\n            \"tenant\": {\n\
+    \                \"name\": \"csrtest\"\n            },\n            \"vrf\": {\n\
+    \                \"name\": \"ULjj\",\n                \"tenant\": \"csrtest\"\n\
+    \            },\n            \"l3out\": {\n                \"name\": null,\n \
+    \               \"external_networks\": null\n            }\n        },\n     \
+    \   \"registry\": {\n            \"image_prefix\": \"noirolabs\", \n         \
+    \   \"aci_containers_host_version\": \"ci_test\", \n            \"opflex_agent_version\"\
+    : \"ci_test\", \n            \"opflex_server_version\": \"ci_test\", \n      \
+    \      \"openvswitch_version\": \"ci_test\", \n            \"gbp_version\": \"\
+    ci_test\", \n            \"aci_containers_controller_version\": \"ci_test\"\n\
+    \        },\n        \"kube_config\": {\n            \"run_snat_container\": false,\
+    \ \n            \"run_gbp_container\": true, \n            \"ep_registry\": \"\
+    k8s\", \n            \"opflex_mode\": \"overlay\"\n\n        },\n        \"istio_config\"\
+    : {\n           \"install_istio\": false\n        },\n        \"net_config\":\
+    \ {\n            \"extern_static\": \"10.4.0.1/24\",\n            \"extern_dynamic\"\
+    : \"10.3.0.1/24\",\n            \"node_svc_subnet\": \"10.5.0.1/24\",\n      \
+    \      \"node_subnet\": \"31.0.1.0/24\",\n            \"pod_subnet\": \"14.3.0.1/16\"\
+    \n        }\n    }\n }"
 kind: ConfigMap
 metadata:
   labels:

--- a/provision/testdata/flavor_aks.kube.yaml
+++ b/provision/testdata/flavor_aks.kube.yaml
@@ -1237,6 +1237,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1388,6 +1393,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "akstest",
                 "apic_hosts": [

--- a/provision/testdata/flavor_cloud.kube.yaml
+++ b/provision/testdata/flavor_cloud.kube.yaml
@@ -1238,6 +1238,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1389,6 +1394,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "clusterjj",
                 "apic_hosts": [

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_eks.kube.yaml
+++ b/provision/testdata/flavor_eks.kube.yaml
@@ -1237,6 +1237,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1388,6 +1393,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "ekstest2",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_310.kube.yaml
+++ b/provision/testdata/flavor_openshift_310.kube.yaml
@@ -1144,6 +1144,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1295,6 +1300,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_311.kube.yaml
+++ b/provision/testdata/flavor_openshift_311.kube.yaml
@@ -1144,6 +1144,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1295,6 +1300,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_43.kube.yaml
+++ b/provision/testdata/flavor_openshift_43.kube.yaml
@@ -1153,6 +1153,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1304,6 +1309,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_43_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_43_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -113,6 +113,11 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  operator_managed_config:
+                    properties:
+                      enable_updates:
+                        type: boolean
+                    type: object
                   registry:
                     properties:
                       acc_provision_operator_version:

--- a/provision/testdata/flavor_openshift_43_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_43_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -1,18 +1,19 @@
 apiVersion: v1
 data:
-  spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
-    \  \"system_id\": \"kube\",\n            \"apic_hosts\": [\n                \"\
-    10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\",\n        \
-    \    \"vrf\": {\n                \"name\": \"kube\",\n                \"tenant\"\
-    : \"common\"\n            },\n            \"sync_login\": {\n                \"\
-    certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\n      \
-    \      },\n            \"l3out\": {\n                \"name\": \"l3out\",\n  \
-    \              \"external_networks\": [\n                    \"default\"\n   \
-    \             ]\n            }\n        },\n        \"registry\": {\n        \
-    \    \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n   \
-    \         \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\": true,\
-    \ \n            \"use_ds_rolling_update\": true\n\n        },\n        \"logging\"\
-    : {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
+  spec: "{\n    \"acc_provision_input\": {\n        \"operator_managed_config\": {\n\
+    \            \"enable_updates\": false\n        },\n        \"aci_config\": {\n\
+    \            \"system_id\": \"kube\",\n            \"apic_hosts\": [\n       \
+    \         \"10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\"\
+    ,\n            \"vrf\": {\n                \"name\": \"kube\",\n             \
+    \   \"tenant\": \"common\"\n            },\n            \"sync_login\": {\n  \
+    \              \"certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\
+    \n            },\n            \"l3out\": {\n                \"name\": \"l3out\"\
+    ,\n                \"external_networks\": [\n                    \"default\"\n\
+    \                ]\n            }\n        },\n        \"registry\": {\n     \
+    \       \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n\
+    \            \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\":\
+    \ true, \n            \"use_ds_rolling_update\": true\n\n        },\n        \"\
+    logging\": {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
     : \"info\", \n           \"opflexagent_log_level\": \"info\"\n        },\n   \
     \     \"net_config\": {\n            \"infra_vlan\": 4093,\n            \"service_vlan\"\
     : 4003, \n            \"kubeapi_vlan\": 4001,\n            \"extern_dynamic\"\

--- a/provision/testdata/flavor_openshift_44_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_44_esx.kube.yaml
@@ -1153,6 +1153,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1304,6 +1309,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -113,6 +113,11 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  operator_managed_config:
+                    properties:
+                      enable_updates:
+                        type: boolean
+                    type: object
                   registry:
                     properties:
                       acc_provision_operator_version:

--- a/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -1,14 +1,15 @@
 apiVersion: v1
 data:
-  spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
-    \  \"system_id\": \"kube\",\n            \"apic_hosts\": [\n                \"\
-    10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\",\n        \
-    \    \"vrf\": {\n                \"name\": \"kube\",\n                \"tenant\"\
-    : \"common\"\n            },\n            \"sync_login\": {\n                \"\
-    certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\n      \
-    \      },\n            \"vmm_domain\": {\n              \"nested_inside\": {\n\
-    \                \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n       \
-    \       }\n            },\n            \"l3out\": {\n                \"name\"\
+  spec: "{\n    \"acc_provision_input\": {\n        \"operator_managed_config\": {\n\
+    \            \"enable_updates\": false\n        },\n        \"aci_config\": {\n\
+    \            \"system_id\": \"kube\",\n            \"apic_hosts\": [\n       \
+    \         \"10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\"\
+    ,\n            \"vrf\": {\n                \"name\": \"kube\",\n             \
+    \   \"tenant\": \"common\"\n            },\n            \"sync_login\": {\n  \
+    \              \"certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\
+    \n            },\n            \"vmm_domain\": {\n              \"nested_inside\"\
+    : {\n                \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n   \
+    \           }\n            },\n            \"l3out\": {\n                \"name\"\
     : \"l3out\",\n                \"external_networks\": [\n                    \"\
     default\"\n                ]\n            }\n        },\n        \"registry\"\
     : {\n            \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\"\

--- a/provision/testdata/flavor_openshift_44_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_44_openstack.kube.yaml
@@ -1153,6 +1153,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1304,6 +1309,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_44_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_44_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -113,6 +113,11 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  operator_managed_config:
+                    properties:
+                      enable_updates:
+                        type: boolean
+                    type: object
                   registry:
                     properties:
                       acc_provision_operator_version:

--- a/provision/testdata/flavor_openshift_44_openstack_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_44_openstack_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -1,18 +1,19 @@
 apiVersion: v1
 data:
-  spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
-    \  \"system_id\": \"kube\",\n            \"apic_hosts\": [\n                \"\
-    10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\",\n        \
-    \    \"vrf\": {\n                \"name\": \"kube\",\n                \"tenant\"\
-    : \"common\"\n            },\n            \"sync_login\": {\n                \"\
-    certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\n      \
-    \      },\n            \"l3out\": {\n                \"name\": \"l3out\",\n  \
-    \              \"external_networks\": [\n                    \"default\"\n   \
-    \             ]\n            }\n        },\n        \"registry\": {\n        \
-    \    \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n   \
-    \         \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\": true,\
-    \ \n            \"use_ds_rolling_update\": true\n\n        },\n        \"logging\"\
-    : {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
+  spec: "{\n    \"acc_provision_input\": {\n        \"operator_managed_config\": {\n\
+    \            \"enable_updates\": false\n        },\n        \"aci_config\": {\n\
+    \            \"system_id\": \"kube\",\n            \"apic_hosts\": [\n       \
+    \         \"10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\"\
+    ,\n            \"vrf\": {\n                \"name\": \"kube\",\n             \
+    \   \"tenant\": \"common\"\n            },\n            \"sync_login\": {\n  \
+    \              \"certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\
+    \n            },\n            \"l3out\": {\n                \"name\": \"l3out\"\
+    ,\n                \"external_networks\": [\n                    \"default\"\n\
+    \                ]\n            }\n        },\n        \"registry\": {\n     \
+    \       \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n\
+    \            \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\":\
+    \ true, \n            \"use_ds_rolling_update\": true\n\n        },\n        \"\
+    logging\": {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
     : \"info\", \n           \"opflexagent_log_level\": \"info\"\n        },\n   \
     \     \"net_config\": {\n            \"infra_vlan\": 4093,\n            \"service_vlan\"\
     : 4003, \n            \"extern_dynamic\": \"10.3.0.1/24\",\n            \"node_svc_subnet\"\

--- a/provision/testdata/flavor_openshift_45_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_45_esx.kube.yaml
@@ -1153,6 +1153,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1304,6 +1309,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -113,6 +113,11 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  operator_managed_config:
+                    properties:
+                      enable_updates:
+                        type: boolean
+                    type: object
                   registry:
                     properties:
                       acc_provision_operator_version:

--- a/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -1,14 +1,15 @@
 apiVersion: v1
 data:
-  spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
-    \  \"system_id\": \"kube\",\n            \"apic_hosts\": [\n                \"\
-    10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\",\n        \
-    \    \"vrf\": {\n                \"name\": \"kube\",\n                \"tenant\"\
-    : \"common\"\n            },\n            \"sync_login\": {\n                \"\
-    certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\n      \
-    \      },\n            \"vmm_domain\": {\n              \"nested_inside\": {\n\
-    \                \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n       \
-    \       }\n            },\n            \"l3out\": {\n                \"name\"\
+  spec: "{\n    \"acc_provision_input\": {\n        \"operator_managed_config\": {\n\
+    \            \"enable_updates\": false\n        },\n        \"aci_config\": {\n\
+    \            \"system_id\": \"kube\",\n            \"apic_hosts\": [\n       \
+    \         \"10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\"\
+    ,\n            \"vrf\": {\n                \"name\": \"kube\",\n             \
+    \   \"tenant\": \"common\"\n            },\n            \"sync_login\": {\n  \
+    \              \"certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\
+    \n            },\n            \"vmm_domain\": {\n              \"nested_inside\"\
+    : {\n                \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n   \
+    \           }\n            },\n            \"l3out\": {\n                \"name\"\
     : \"l3out\",\n                \"external_networks\": [\n                    \"\
     default\"\n                ]\n            }\n        },\n        \"registry\"\
     : {\n            \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\"\

--- a/provision/testdata/flavor_openshift_45_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_45_openstack.kube.yaml
@@ -1153,6 +1153,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1304,6 +1309,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_45_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_45_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -113,6 +113,11 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  operator_managed_config:
+                    properties:
+                      enable_updates:
+                        type: boolean
+                    type: object
                   registry:
                     properties:
                       acc_provision_operator_version:

--- a/provision/testdata/flavor_openshift_45_openstack_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_45_openstack_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -1,18 +1,19 @@
 apiVersion: v1
 data:
-  spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
-    \  \"system_id\": \"kube\",\n            \"apic_hosts\": [\n                \"\
-    10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\",\n        \
-    \    \"vrf\": {\n                \"name\": \"kube\",\n                \"tenant\"\
-    : \"common\"\n            },\n            \"sync_login\": {\n                \"\
-    certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\n      \
-    \      },\n            \"l3out\": {\n                \"name\": \"l3out\",\n  \
-    \              \"external_networks\": [\n                    \"default\"\n   \
-    \             ]\n            }\n        },\n        \"registry\": {\n        \
-    \    \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n   \
-    \         \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\": true,\
-    \ \n            \"use_ds_rolling_update\": true\n\n        },\n        \"logging\"\
-    : {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
+  spec: "{\n    \"acc_provision_input\": {\n        \"operator_managed_config\": {\n\
+    \            \"enable_updates\": false\n        },\n        \"aci_config\": {\n\
+    \            \"system_id\": \"kube\",\n            \"apic_hosts\": [\n       \
+    \         \"10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\"\
+    ,\n            \"vrf\": {\n                \"name\": \"kube\",\n             \
+    \   \"tenant\": \"common\"\n            },\n            \"sync_login\": {\n  \
+    \              \"certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\
+    \n            },\n            \"l3out\": {\n                \"name\": \"l3out\"\
+    ,\n                \"external_networks\": [\n                    \"default\"\n\
+    \                ]\n            }\n        },\n        \"registry\": {\n     \
+    \       \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n\
+    \            \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\":\
+    \ true, \n            \"use_ds_rolling_update\": true\n\n        },\n        \"\
+    logging\": {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
     : \"info\", \n           \"opflexagent_log_level\": \"info\"\n        },\n   \
     \     \"net_config\": {\n            \"infra_vlan\": 4093,\n            \"service_vlan\"\
     : 4003, \n            \"extern_dynamic\": \"10.3.0.1/24\",\n            \"node_svc_subnet\"\

--- a/provision/testdata/flavor_openshift_46_baremetal.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_baremetal.kube.yaml
@@ -1153,6 +1153,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1304,6 +1309,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_46_baremetal_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_46_baremetal_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -113,6 +113,11 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  operator_managed_config:
+                    properties:
+                      enable_updates:
+                        type: boolean
+                    type: object
                   registry:
                     properties:
                       acc_provision_operator_version:

--- a/provision/testdata/flavor_openshift_46_baremetal_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_46_baremetal_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -1,14 +1,15 @@
 apiVersion: v1
 data:
-  spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
-    \  \"system_id\": \"kube\",\n            \"apic_hosts\": [\n                \"\
-    10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\",\n        \
-    \    \"vrf\": {\n                \"name\": \"kube\",\n                \"tenant\"\
-    : \"common\"\n            },\n            \"sync_login\": {\n                \"\
-    certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\n      \
-    \      },\n            \"vmm_domain\": {\n              \"nested_inside\": {\n\
-    \                \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n       \
-    \       }\n            },\n            \"l3out\": {\n                \"name\"\
+  spec: "{\n    \"acc_provision_input\": {\n        \"operator_managed_config\": {\n\
+    \            \"enable_updates\": false\n        },\n        \"aci_config\": {\n\
+    \            \"system_id\": \"kube\",\n            \"apic_hosts\": [\n       \
+    \         \"10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\"\
+    ,\n            \"vrf\": {\n                \"name\": \"kube\",\n             \
+    \   \"tenant\": \"common\"\n            },\n            \"sync_login\": {\n  \
+    \              \"certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\
+    \n            },\n            \"vmm_domain\": {\n              \"nested_inside\"\
+    : {\n                \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n   \
+    \           }\n            },\n            \"l3out\": {\n                \"name\"\
     : \"l3out\",\n                \"external_networks\": [\n                    \"\
     default\"\n                ]\n            }\n        },\n        \"registry\"\
     : {\n            \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\"\

--- a/provision/testdata/flavor_openshift_46_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_esx.kube.yaml
@@ -1153,6 +1153,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1304,6 +1309,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -113,6 +113,11 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  operator_managed_config:
+                    properties:
+                      enable_updates:
+                        type: boolean
+                    type: object
                   registry:
                     properties:
                       acc_provision_operator_version:

--- a/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -1,14 +1,15 @@
 apiVersion: v1
 data:
-  spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
-    \  \"system_id\": \"kube\",\n            \"apic_hosts\": [\n                \"\
-    10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\",\n        \
-    \    \"vrf\": {\n                \"name\": \"kube\",\n                \"tenant\"\
-    : \"common\"\n            },\n            \"sync_login\": {\n                \"\
-    certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\n      \
-    \      },\n            \"vmm_domain\": {\n              \"nested_inside\": {\n\
-    \                \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n       \
-    \       }\n            },\n            \"l3out\": {\n                \"name\"\
+  spec: "{\n    \"acc_provision_input\": {\n        \"operator_managed_config\": {\n\
+    \            \"enable_updates\": false\n        },\n        \"aci_config\": {\n\
+    \            \"system_id\": \"kube\",\n            \"apic_hosts\": [\n       \
+    \         \"10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\"\
+    ,\n            \"vrf\": {\n                \"name\": \"kube\",\n             \
+    \   \"tenant\": \"common\"\n            },\n            \"sync_login\": {\n  \
+    \              \"certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\
+    \n            },\n            \"vmm_domain\": {\n              \"nested_inside\"\
+    : {\n                \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n   \
+    \           }\n            },\n            \"l3out\": {\n                \"name\"\
     : \"l3out\",\n                \"external_networks\": [\n                    \"\
     default\"\n                ]\n            }\n        },\n        \"registry\"\
     : {\n            \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\"\

--- a/provision/testdata/flavor_openshift_46_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_openstack.kube.yaml
@@ -1153,6 +1153,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1304,6 +1309,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_46_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_46_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -113,6 +113,11 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  operator_managed_config:
+                    properties:
+                      enable_updates:
+                        type: boolean
+                    type: object
                   registry:
                     properties:
                       acc_provision_operator_version:

--- a/provision/testdata/flavor_openshift_46_openstack_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_46_openstack_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -1,18 +1,19 @@
 apiVersion: v1
 data:
-  spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
-    \  \"system_id\": \"kube\",\n            \"apic_hosts\": [\n                \"\
-    10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\",\n        \
-    \    \"vrf\": {\n                \"name\": \"kube\",\n                \"tenant\"\
-    : \"common\"\n            },\n            \"sync_login\": {\n                \"\
-    certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\n      \
-    \      },\n            \"l3out\": {\n                \"name\": \"l3out\",\n  \
-    \              \"external_networks\": [\n                    \"default\"\n   \
-    \             ]\n            }\n        },\n        \"registry\": {\n        \
-    \    \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n   \
-    \         \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\": true,\
-    \ \n            \"use_ds_rolling_update\": true\n\n        },\n        \"logging\"\
-    : {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
+  spec: "{\n    \"acc_provision_input\": {\n        \"operator_managed_config\": {\n\
+    \            \"enable_updates\": false\n        },\n        \"aci_config\": {\n\
+    \            \"system_id\": \"kube\",\n            \"apic_hosts\": [\n       \
+    \         \"10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\"\
+    ,\n            \"vrf\": {\n                \"name\": \"kube\",\n             \
+    \   \"tenant\": \"common\"\n            },\n            \"sync_login\": {\n  \
+    \              \"certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\
+    \n            },\n            \"l3out\": {\n                \"name\": \"l3out\"\
+    ,\n                \"external_networks\": [\n                    \"default\"\n\
+    \                ]\n            }\n        },\n        \"registry\": {\n     \
+    \       \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n\
+    \            \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\":\
+    \ true, \n            \"use_ds_rolling_update\": true\n\n        },\n        \"\
+    logging\": {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
     : \"info\", \n           \"opflexagent_log_level\": \"info\"\n        },\n   \
     \     \"net_config\": {\n            \"infra_vlan\": 4093,\n            \"service_vlan\"\
     : 4003, \n            \"extern_dynamic\": \"10.3.0.1/24\",\n            \"node_svc_subnet\"\

--- a/provision/testdata/flavor_openshift_47_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_47_esx.kube.yaml
@@ -1153,6 +1153,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1304,6 +1309,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -113,6 +113,11 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  operator_managed_config:
+                    properties:
+                      enable_updates:
+                        type: boolean
+                    type: object
                   registry:
                     properties:
                       acc_provision_operator_version:

--- a/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -1,14 +1,15 @@
 apiVersion: v1
 data:
-  spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
-    \  \"system_id\": \"kube\",\n            \"apic_hosts\": [\n                \"\
-    10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\",\n        \
-    \    \"vrf\": {\n                \"name\": \"kube\",\n                \"tenant\"\
-    : \"common\"\n            },\n            \"sync_login\": {\n                \"\
-    certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\n      \
-    \      },\n            \"vmm_domain\": {\n              \"nested_inside\": {\n\
-    \                \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n       \
-    \       }\n            },\n            \"l3out\": {\n                \"name\"\
+  spec: "{\n    \"acc_provision_input\": {\n        \"operator_managed_config\": {\n\
+    \            \"enable_updates\": false\n        },\n        \"aci_config\": {\n\
+    \            \"system_id\": \"kube\",\n            \"apic_hosts\": [\n       \
+    \         \"10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\"\
+    ,\n            \"vrf\": {\n                \"name\": \"kube\",\n             \
+    \   \"tenant\": \"common\"\n            },\n            \"sync_login\": {\n  \
+    \              \"certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\
+    \n            },\n            \"vmm_domain\": {\n              \"nested_inside\"\
+    : {\n                \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n   \
+    \           }\n            },\n            \"l3out\": {\n                \"name\"\
     : \"l3out\",\n                \"external_networks\": [\n                    \"\
     default\"\n                ]\n            }\n        },\n        \"registry\"\
     : {\n            \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\"\

--- a/provision/testdata/flavor_openshift_47_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_47_openstack.kube.yaml
@@ -1153,6 +1153,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1304,6 +1309,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_47_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_47_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -113,6 +113,11 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  operator_managed_config:
+                    properties:
+                      enable_updates:
+                        type: boolean
+                    type: object
                   registry:
                     properties:
                       acc_provision_operator_version:

--- a/provision/testdata/flavor_openshift_47_openstack_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_47_openstack_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -1,18 +1,19 @@
 apiVersion: v1
 data:
-  spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
-    \  \"system_id\": \"kube\",\n            \"apic_hosts\": [\n                \"\
-    10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\",\n        \
-    \    \"vrf\": {\n                \"name\": \"kube\",\n                \"tenant\"\
-    : \"common\"\n            },\n            \"sync_login\": {\n                \"\
-    certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\n      \
-    \      },\n            \"l3out\": {\n                \"name\": \"l3out\",\n  \
-    \              \"external_networks\": [\n                    \"default\"\n   \
-    \             ]\n            }\n        },\n        \"registry\": {\n        \
-    \    \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n   \
-    \         \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\": true,\
-    \ \n            \"use_ds_rolling_update\": true\n\n        },\n        \"logging\"\
-    : {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
+  spec: "{\n    \"acc_provision_input\": {\n        \"operator_managed_config\": {\n\
+    \            \"enable_updates\": false\n        },\n        \"aci_config\": {\n\
+    \            \"system_id\": \"kube\",\n            \"apic_hosts\": [\n       \
+    \         \"10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\"\
+    ,\n            \"vrf\": {\n                \"name\": \"kube\",\n             \
+    \   \"tenant\": \"common\"\n            },\n            \"sync_login\": {\n  \
+    \              \"certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\
+    \n            },\n            \"l3out\": {\n                \"name\": \"l3out\"\
+    ,\n                \"external_networks\": [\n                    \"default\"\n\
+    \                ]\n            }\n        },\n        \"registry\": {\n     \
+    \       \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n\
+    \            \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\":\
+    \ true, \n            \"use_ds_rolling_update\": true\n\n        },\n        \"\
+    logging\": {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
     : \"info\", \n           \"opflexagent_log_level\": \"info\"\n        },\n   \
     \     \"net_config\": {\n            \"infra_vlan\": 4093,\n            \"service_vlan\"\
     : 4003, \n            \"extern_dynamic\": \"10.3.0.1/24\",\n            \"node_svc_subnet\"\

--- a/provision/testdata/flavor_openshift_48_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_48_esx.kube.yaml
@@ -1153,6 +1153,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1304,6 +1309,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/flavor_openshift_48_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_48_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -113,6 +113,11 @@ spec:
                       enable:
                         type: boolean
                     type: object
+                  operator_managed_config:
+                    properties:
+                      enable_updates:
+                        type: boolean
+                    type: object
                   registry:
                     properties:
                       acc_provision_operator_version:

--- a/provision/testdata/flavor_openshift_48_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_48_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -1,14 +1,15 @@
 apiVersion: v1
 data:
-  spec: "{\n    \"acc_provision_input\": {\n        \"aci_config\": {\n          \
-    \  \"system_id\": \"kube\",\n            \"apic_hosts\": [\n                \"\
-    10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\",\n        \
-    \    \"vrf\": {\n                \"name\": \"kube\",\n                \"tenant\"\
-    : \"common\"\n            },\n            \"sync_login\": {\n                \"\
-    certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\n      \
-    \      },\n            \"vmm_domain\": {\n              \"nested_inside\": {\n\
-    \                \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n       \
-    \       }\n            },\n            \"l3out\": {\n                \"name\"\
+  spec: "{\n    \"acc_provision_input\": {\n        \"operator_managed_config\": {\n\
+    \            \"enable_updates\": false\n        },\n        \"aci_config\": {\n\
+    \            \"system_id\": \"kube\",\n            \"apic_hosts\": [\n       \
+    \         \"10.30.120.100\"\n            ],\n            \"aep\": \"kube-aep\"\
+    ,\n            \"vrf\": {\n                \"name\": \"kube\",\n             \
+    \   \"tenant\": \"common\"\n            },\n            \"sync_login\": {\n  \
+    \              \"certfile\": \"user.crt\", \n                \"keyfile\": \"user.key\"\
+    \n            },\n            \"vmm_domain\": {\n              \"nested_inside\"\
+    : {\n                \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n   \
+    \           }\n            },\n            \"l3out\": {\n                \"name\"\
     : \"l3out\",\n                \"external_networks\": [\n                    \"\
     default\"\n                ]\n            }\n        },\n        \"registry\"\
     : {\n            \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\"\

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -1190,6 +1190,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1341,6 +1346,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "mykube",
                 "apic_hosts": [

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_interface_mtu_headroom.kube.yaml
+++ b/provision/testdata/with_interface_mtu_headroom.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_istio_default_profile.kube.yaml
+++ b/provision/testdata/with_istio_default_profile.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_new_naming_convention.kube.yaml
+++ b/provision/testdata/with_new_naming_convention.kube.yaml
@@ -1190,6 +1190,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1341,6 +1346,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_new_naming_convention_dockerucp.kube.yaml
+++ b/provision/testdata/with_new_naming_convention_dockerucp.kube.yaml
@@ -1190,6 +1190,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1341,6 +1346,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_new_naming_convention_openshift.kube.yaml
+++ b/provision/testdata/with_new_naming_convention_openshift.kube.yaml
@@ -1144,6 +1144,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1295,6 +1300,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_no_drop_log.kube.yaml
+++ b/provision/testdata/with_no_drop_log.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_no_install_istio.kube.yaml
+++ b/provision/testdata/with_no_install_istio.kube.yaml
@@ -1143,6 +1143,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1294,6 +1299,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_no_sriov_config_kube.yaml
+++ b/provision/testdata/with_no_sriov_config_kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_preexisting_tenant.kube.yaml
+++ b/provision/testdata/with_preexisting_tenant.kube.yaml
@@ -1190,6 +1190,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1341,6 +1346,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_sriov_config_kube.yaml
+++ b/provision/testdata/with_sriov_config_kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_sriov_config_no_deviceinfo_kube.yaml
+++ b/provision/testdata/with_sriov_config_no_deviceinfo_kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [

--- a/provision/testdata/with_wait_for_network.kube.yaml
+++ b/provision/testdata/with_wait_for_network.kube.yaml
@@ -1189,6 +1189,11 @@ spec:
               acc_provision_input:
                 type: object
                 properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
                   aci_config:
                     type: object
                     properties:
@@ -1340,6 +1345,9 @@ data:
   spec: |-
     {
         "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
             "aci_config": {
                 "system_id": "kube",
                 "apic_hosts": [


### PR DESCRIPTION
Can be turned on by editing the acc_provision input file or CR, with this option

```
operator_managed_config:
  enable_updates: true
```