### PR TITLE
fix ansible-operator port conflicts

### DIFF
--- a/provision/acc_provision/templates/aci-operators.yaml
+++ b/provision/acc_provision/templates/aci-operators.yaml
@@ -182,6 +182,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: {{ config.registry.image_prefix }}/aci-containers-operator:{{ config.registry.aci_containers_operator_version }}
         imagePullPolicy: {{ config.kube_config.image_pull_policy }}

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -2345,6 +2345,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -2345,6 +2345,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/base_case_operator_mode.kube.yaml
+++ b/provision/testdata/base_case_operator_mode.kube.yaml
@@ -2334,6 +2334,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -2358,6 +2358,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/base_case_tar/cluster-network-37-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/base_case_tar/cluster-network-37-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: kube-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/base_case_upgrade.kube.yaml
+++ b/provision/testdata/base_case_upgrade.kube.yaml
@@ -2345,6 +2345,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/cloud_tar/cluster-network-41-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/cloud_tar/cluster-network-41-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_aks.kube.yaml
+++ b/provision/testdata/flavor_aks.kube.yaml
@@ -2564,6 +2564,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noirolabs/aci-containers-operator:5.0.1.0.r57
         imagePullPolicy: Always

--- a/provision/testdata/flavor_cloud.kube.yaml
+++ b/provision/testdata/flavor_cloud.kube.yaml
@@ -2570,6 +2570,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noirolabs/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -2346,6 +2346,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_eks.kube.yaml
+++ b/provision/testdata/flavor_eks.kube.yaml
@@ -2567,6 +2567,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noirolabs/aci-containers-operator:jefferson-test
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_310.kube.yaml
+++ b/provision/testdata/flavor_openshift_310.kube.yaml
@@ -2453,6 +2453,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_311.kube.yaml
+++ b/provision/testdata/flavor_openshift_311.kube.yaml
@@ -2454,6 +2454,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_43.kube.yaml
+++ b/provision/testdata/flavor_openshift_43.kube.yaml
@@ -2429,6 +2429,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_43_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_43_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_44_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_44_esx.kube.yaml
@@ -2448,6 +2448,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_44_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_44_openstack.kube.yaml
@@ -2435,6 +2435,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_44_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_44_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_45_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_45_esx.kube.yaml
@@ -2448,6 +2448,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_45_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_45_openstack.kube.yaml
@@ -2435,6 +2435,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_45_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_45_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_46_baremetal.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_baremetal.kube.yaml
@@ -2442,6 +2442,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_46_baremetal_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_46_baremetal_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_46_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_esx.kube.yaml
@@ -2448,6 +2448,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_46_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_openstack.kube.yaml
@@ -2435,6 +2435,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_46_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_46_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_47_baremetal.kube.yaml
+++ b/provision/testdata/flavor_openshift_47_baremetal.kube.yaml
@@ -2442,6 +2442,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_47_baremetal_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_47_baremetal_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_47_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_47_esx.kube.yaml
@@ -2448,6 +2448,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_47_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_47_openstack.kube.yaml
@@ -2435,6 +2435,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_47_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_47_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_48_baremetal.kube.yaml
+++ b/provision/testdata/flavor_openshift_48_baremetal.kube.yaml
@@ -2442,6 +2442,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_48_baremetal_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_48_baremetal_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_48_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_48_esx.kube.yaml
@@ -2448,6 +2448,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_48_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_48_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_48_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_48_openstack.kube.yaml
@@ -2435,6 +2435,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_48_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_48_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_49_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_49_esx.kube.yaml
@@ -2448,6 +2448,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_49_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_49_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_49_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_49_openstack.kube.yaml
@@ -2435,6 +2435,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_49_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_49_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -2345,6 +2345,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -2345,6 +2345,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -2345,6 +2345,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -2345,6 +2345,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -2347,6 +2347,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -2339,6 +2339,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -2345,6 +2345,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -2346,6 +2346,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -2347,6 +2347,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_interface_mtu_headroom.kube.yaml
+++ b/provision/testdata/with_interface_mtu_headroom.kube.yaml
@@ -2348,6 +2348,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_istio_default_profile.kube.yaml
+++ b/provision/testdata/with_istio_default_profile.kube.yaml
@@ -2411,6 +2411,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_new_naming_convention.kube.yaml
+++ b/provision/testdata/with_new_naming_convention.kube.yaml
@@ -2354,6 +2354,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_new_naming_convention_dockerucp.kube.yaml
+++ b/provision/testdata/with_new_naming_convention_dockerucp.kube.yaml
@@ -2355,6 +2355,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_new_naming_convention_openshift.kube.yaml
+++ b/provision/testdata/with_new_naming_convention_openshift.kube.yaml
@@ -2459,6 +2459,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_no_drop_log.kube.yaml
+++ b/provision/testdata/with_no_drop_log.kube.yaml
@@ -2340,6 +2340,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_no_install_istio.kube.yaml
+++ b/provision/testdata/with_no_install_istio.kube.yaml
@@ -2348,6 +2348,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_no_sriov_config_kube.yaml
+++ b/provision/testdata/with_no_sriov_config_kube.yaml
@@ -2345,6 +2345,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -2399,6 +2399,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:AciCniOperatorTag
         imagePullPolicy: IfNotPresent

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -2350,6 +2350,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_preexisting_tenant.kube.yaml
+++ b/provision/testdata/with_preexisting_tenant.kube.yaml
@@ -2357,6 +2357,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -2348,6 +2348,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_sriov_config_kube.yaml
+++ b/provision/testdata/with_sriov_config_kube.yaml
@@ -2617,6 +2617,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_sriov_config_no_deviceinfo_kube.yaml
+++ b/provision/testdata/with_sriov_config_no_deviceinfo_kube.yaml
@@ -2617,6 +2617,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -2345,6 +2345,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: Always

--- a/provision/testdata/with_wait_for_network.kube.yaml
+++ b/provision/testdata/with_wait_for_network.kube.yaml
@@ -2394,6 +2394,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:6.0.0.0.0ef4718
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
addressing: https://github.com/noironetworks/support/issues/1756
We can schedule the ansible-operator in specific node by labeling i with `allowed-operator=aci` so that it doesn't conflict with customers ansible operator.