### PR TITLE
Added nodAffinity rule for aci operator scheduling

### DIFF
--- a/provision/acc_provision/templates/aci-operators.yaml
+++ b/provision/acc_provision/templates/aci-operators.yaml
@@ -182,6 +182,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: {{ config.registry.image_prefix }}/aci-containers-operator:{{ config.registry.aci_containers_operator_version }}
         imagePullPolicy: {{ config.kube_config.image_pull_policy }}

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -2344,6 +2344,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -2344,6 +2344,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/base_case_operator_mode.kube.yaml
+++ b/provision/testdata/base_case_operator_mode.kube.yaml
@@ -2333,6 +2333,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -2357,6 +2357,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/base_case_tar/cluster-network-37-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/base_case_tar/cluster-network-37-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: kube-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/base_case_upgrade.kube.yaml
+++ b/provision/testdata/base_case_upgrade.kube.yaml
@@ -2344,6 +2344,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/cloud_tar/cluster-network-41-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/cloud_tar/cluster-network-41-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_aks.kube.yaml
+++ b/provision/testdata/flavor_aks.kube.yaml
@@ -2563,6 +2563,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noirolabs/aci-containers-operator:5.0.1.0.r57
         imagePullPolicy: Always

--- a/provision/testdata/flavor_cloud.kube.yaml
+++ b/provision/testdata/flavor_cloud.kube.yaml
@@ -2569,6 +2569,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noirolabs/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -2345,6 +2345,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_eks.kube.yaml
+++ b/provision/testdata/flavor_eks.kube.yaml
@@ -2566,6 +2566,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noirolabs/aci-containers-operator:jefferson-test
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_310.kube.yaml
+++ b/provision/testdata/flavor_openshift_310.kube.yaml
@@ -2452,6 +2452,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_311.kube.yaml
+++ b/provision/testdata/flavor_openshift_311.kube.yaml
@@ -2453,6 +2453,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_43.kube.yaml
+++ b/provision/testdata/flavor_openshift_43.kube.yaml
@@ -2428,6 +2428,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_43_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_43_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_44_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_44_esx.kube.yaml
@@ -2447,6 +2447,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_44_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_44_openstack.kube.yaml
@@ -2434,6 +2434,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_44_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_44_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_45_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_45_esx.kube.yaml
@@ -2447,6 +2447,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_45_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_45_openstack.kube.yaml
@@ -2434,6 +2434,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_45_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_45_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_46_baremetal.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_baremetal.kube.yaml
@@ -2441,6 +2441,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_46_baremetal_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_46_baremetal_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_46_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_esx.kube.yaml
@@ -2447,6 +2447,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_46_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_openstack.kube.yaml
@@ -2434,6 +2434,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_46_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_46_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_47_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_47_esx.kube.yaml
@@ -2447,6 +2447,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_47_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_47_openstack.kube.yaml
@@ -2434,6 +2434,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_47_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_47_openstack_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/flavor_openshift_48_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_48_esx.kube.yaml
@@ -2447,6 +2447,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/flavor_openshift_48_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
+++ b/provision/testdata/flavor_openshift_48_esx_tar/cluster-network-38-Deployment-aci-containers-operator.yaml
@@ -27,6 +27,16 @@ spec:
       name: aci-containers-operator
       namespace: aci-containers-system
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - env:
         - name: SYSTEM_NAMESPACE

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -2344,6 +2344,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -2344,6 +2344,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -2344,6 +2344,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -2344,6 +2344,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -2346,6 +2346,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -2338,6 +2338,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -2344,6 +2344,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -2345,6 +2345,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -2346,6 +2346,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_interface_mtu_headroom.kube.yaml
+++ b/provision/testdata/with_interface_mtu_headroom.kube.yaml
@@ -2347,6 +2347,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_istio_default_profile.kube.yaml
+++ b/provision/testdata/with_istio_default_profile.kube.yaml
@@ -2410,6 +2410,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_new_naming_convention.kube.yaml
+++ b/provision/testdata/with_new_naming_convention.kube.yaml
@@ -2353,6 +2353,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_new_naming_convention_dockerucp.kube.yaml
+++ b/provision/testdata/with_new_naming_convention_dockerucp.kube.yaml
@@ -2354,6 +2354,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_new_naming_convention_openshift.kube.yaml
+++ b/provision/testdata/with_new_naming_convention_openshift.kube.yaml
@@ -2458,6 +2458,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_no_drop_log.kube.yaml
+++ b/provision/testdata/with_no_drop_log.kube.yaml
@@ -2339,6 +2339,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_no_install_istio.kube.yaml
+++ b/provision/testdata/with_no_install_istio.kube.yaml
@@ -2347,6 +2347,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_no_sriov_config_kube.yaml
+++ b/provision/testdata/with_no_sriov_config_kube.yaml
@@ -2344,6 +2344,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -2398,6 +2398,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:AciCniOperatorTag
         imagePullPolicy: IfNotPresent

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -2349,6 +2349,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_preexisting_tenant.kube.yaml
+++ b/provision/testdata/with_preexisting_tenant.kube.yaml
@@ -2356,6 +2356,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -2347,6 +2347,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_sriov_config_kube.yaml
+++ b/provision/testdata/with_sriov_config_kube.yaml
@@ -2617,6 +2617,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_sriov_config_no_deviceinfo_kube.yaml
+++ b/provision/testdata/with_sriov_config_no_deviceinfo_kube.yaml
@@ -2617,6 +2617,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -2344,6 +2344,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: Always

--- a/provision/testdata/with_wait_for_network.kube.yaml
+++ b/provision/testdata/with_wait_for_network.kube.yaml
@@ -2393,6 +2393,16 @@ spec:
         name: aci-containers-operator
         network-plugin: aci-containers
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
       containers:
       - image: noiro/aci-containers-operator:5.2.3.2.1d150da
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Issue:- The ports of aci-operator conflicts with any other ansible
operators, if deployed on same node.

Sol - Currently, the port cannot be configured for ansible operator.
This patch adds Node Affinity rule
"preferredDuringSchedulingIgnoredDuringExecutionfor" aci operator pod
for scheduling. aci operator will get provisioned on the node with label:

preferred-node=aci-containers-operator-2577247291

If no node with above label exists, then it will get scheduled on any other
non-preferred node.

(cherry picked from commit dad36213d704230e71b6ce5d910fe2fe5522f07a)