### PR TITLE
Allows the log file size to be specified in acc-provision

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -230,6 +230,7 @@ def config_default():
             "aci_cni_operator_version": None,
         },
         "logging": {
+            "size": None,
             "controller_log_level": "info",
             "hostagent_log_level": "info",
             "opflexagent_log_level": "info",

--- a/provision/acc_provision/templates/acc-provision-crd.yaml
+++ b/provision/acc_provision/templates/acc-provision-crd.yaml
@@ -93,6 +93,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/acc_provision/templates/aci-network-provider-cluster.yaml
+++ b/provision/acc_provision/templates/aci-network-provider-cluster.yaml
@@ -51,6 +51,9 @@ network:
     {% if config.drop_log_config.enable != True %}
     droplog_enable: "{{ config.drop_log_config.enable|lower() }}"
     {% endif %}
+    {% if config.logging.size %}
+    size: {{ config.logging.size }}
+    {% endif %}
     {% if config.logging.controller_log_level != "info" %}
     controller_log_level: "{{ config.logging.controller_log_level }}"
     {% endif %}

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/base_case_operator_mode.kube.yaml
+++ b/provision/testdata/base_case_operator_mode.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/base_case_snat.kube.yaml
+++ b/provision/testdata/base_case_snat.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/base_case_tar/cluster-network-19-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/base_case_tar/cluster-network-19-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -87,6 +87,8 @@ spec:
                         type: string
                       opflexagent_log_level:
                         type: string
+                      size:
+                        type: integer
                     type: object
                   multus:
                     properties:

--- a/provision/testdata/base_case_upgrade.kube.yaml
+++ b/provision/testdata/base_case_upgrade.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/cloud_tar/cluster-network-21-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/cloud_tar/cluster-network-21-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -87,6 +87,8 @@ spec:
                         type: string
                       opflexagent_log_level:
                         type: string
+                      size:
+                        type: integer
                     type: object
                   multus:
                     properties:

--- a/provision/testdata/flavor_aks.kube.yaml
+++ b/provision/testdata/flavor_aks.kube.yaml
@@ -1295,6 +1295,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_cloud.kube.yaml
+++ b/provision/testdata/flavor_cloud.kube.yaml
@@ -1296,6 +1296,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_dockerucp.kube.yaml
+++ b/provision/testdata/flavor_dockerucp.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_eks.kube.yaml
+++ b/provision/testdata/flavor_eks.kube.yaml
@@ -1295,6 +1295,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_310.kube.yaml
+++ b/provision/testdata/flavor_openshift_310.kube.yaml
@@ -1202,6 +1202,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_311.kube.yaml
+++ b/provision/testdata/flavor_openshift_311.kube.yaml
@@ -1202,6 +1202,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_43.kube.yaml
+++ b/provision/testdata/flavor_openshift_43.kube.yaml
@@ -1211,6 +1211,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_43_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_43_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -87,6 +87,8 @@ spec:
                         type: string
                       opflexagent_log_level:
                         type: string
+                      size:
+                        type: integer
                     type: object
                   multus:
                     properties:

--- a/provision/testdata/flavor_openshift_44_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_44_esx.kube.yaml
@@ -1211,6 +1211,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -87,6 +87,8 @@ spec:
                         type: string
                       opflexagent_log_level:
                         type: string
+                      size:
+                        type: integer
                     type: object
                   multus:
                     properties:

--- a/provision/testdata/flavor_openshift_44_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_44_openstack.kube.yaml
@@ -1211,6 +1211,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_44_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_44_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -87,6 +87,8 @@ spec:
                         type: string
                       opflexagent_log_level:
                         type: string
+                      size:
+                        type: integer
                     type: object
                   multus:
                     properties:

--- a/provision/testdata/flavor_openshift_45_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_45_esx.kube.yaml
@@ -1211,6 +1211,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -87,6 +87,8 @@ spec:
                         type: string
                       opflexagent_log_level:
                         type: string
+                      size:
+                        type: integer
                     type: object
                   multus:
                     properties:

--- a/provision/testdata/flavor_openshift_45_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_45_openstack.kube.yaml
@@ -1211,6 +1211,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_45_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_45_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -87,6 +87,8 @@ spec:
                         type: string
                       opflexagent_log_level:
                         type: string
+                      size:
+                        type: integer
                     type: object
                   multus:
                     properties:

--- a/provision/testdata/flavor_openshift_46_baremetal.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_baremetal.kube.yaml
@@ -1211,6 +1211,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_46_baremetal_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_46_baremetal_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -87,6 +87,8 @@ spec:
                         type: string
                       opflexagent_log_level:
                         type: string
+                      size:
+                        type: integer
                     type: object
                   multus:
                     properties:

--- a/provision/testdata/flavor_openshift_46_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_esx.kube.yaml
@@ -1211,6 +1211,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -87,6 +87,8 @@ spec:
                         type: string
                       opflexagent_log_level:
                         type: string
+                      size:
+                        type: integer
                     type: object
                   multus:
                     properties:

--- a/provision/testdata/flavor_openshift_46_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_openstack.kube.yaml
@@ -1211,6 +1211,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_46_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_46_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -87,6 +87,8 @@ spec:
                         type: string
                       opflexagent_log_level:
                         type: string
+                      size:
+                        type: integer
                     type: object
                   multus:
                     properties:

--- a/provision/testdata/flavor_openshift_47_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_47_esx.kube.yaml
@@ -1211,6 +1211,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -87,6 +87,8 @@ spec:
                         type: string
                       opflexagent_log_level:
                         type: string
+                      size:
+                        type: integer
                     type: object
                   multus:
                     properties:

--- a/provision/testdata/flavor_openshift_47_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_47_openstack.kube.yaml
@@ -1211,6 +1211,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_47_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_47_openstack_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -87,6 +87,8 @@ spec:
                         type: string
                       opflexagent_log_level:
                         type: string
+                      size:
+                        type: integer
                     type: object
                   multus:
                     properties:

--- a/provision/testdata/flavor_openshift_48_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_48_esx.kube.yaml
@@ -1211,6 +1211,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_48_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
+++ b/provision/testdata/flavor_openshift_48_esx_tar/cluster-network-20-CustomResourceDefinition-accprovisioninputs.aci.ctrl.yaml
@@ -87,6 +87,8 @@ spec:
                         type: string
                       opflexagent_log_level:
                         type: string
+                      size:
+                        type: integer
                     type: object
                   multus:
                     properties:

--- a/provision/testdata/flavor_openshift_48_openstack.kube.yaml
+++ b/provision/testdata/flavor_openshift_48_openstack.kube.yaml
@@ -1211,6 +1211,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/flavor_openshift_49_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_49_esx.kube.yaml
@@ -1211,6 +1211,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/nested-elag.kube.yaml
+++ b/provision/testdata/nested-elag.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -1202,6 +1202,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_interface_mtu_headroom.kube.yaml
+++ b/provision/testdata/with_interface_mtu_headroom.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_istio_default_profile.kube.yaml
+++ b/provision/testdata/with_istio_default_profile.kube.yaml
@@ -1247,6 +1247,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_new_naming_convention.kube.yaml
+++ b/provision/testdata/with_new_naming_convention.kube.yaml
@@ -1202,6 +1202,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_new_naming_convention_dockerucp.kube.yaml
+++ b/provision/testdata/with_new_naming_convention_dockerucp.kube.yaml
@@ -1202,6 +1202,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_new_naming_convention_openshift.kube.yaml
+++ b/provision/testdata/with_new_naming_convention_openshift.kube.yaml
@@ -1202,6 +1202,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_no_drop_log.kube.yaml
+++ b/provision/testdata/with_no_drop_log.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_no_install_istio.kube.yaml
+++ b/provision/testdata/with_no_install_istio.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_no_sriov_config_kube.yaml
+++ b/provision/testdata/with_no_sriov_config_kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_pbr_non_snat.kube.yaml
+++ b/provision/testdata/with_pbr_non_snat.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_preexisting_tenant.kube.yaml
+++ b/provision/testdata/with_preexisting_tenant.kube.yaml
@@ -1202,6 +1202,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_refreshtime.kube.yaml
+++ b/provision/testdata/with_refreshtime.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_sriov_config_kube.yaml
+++ b/provision/testdata/with_sriov_config_kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_sriov_config_no_deviceinfo_kube.yaml
+++ b/provision/testdata/with_sriov_config_no_deviceinfo_kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:

--- a/provision/testdata/with_wait_for_network.kube.yaml
+++ b/provision/testdata/with_wait_for_network.kube.yaml
@@ -1201,6 +1201,8 @@ spec:
                   logging:
                     type: object
                     properties:
+                      size:
+                        type: integer
                       controller_log_level:
                         type: string
                       hostagent_log_level:


### PR DESCRIPTION
If set, we should limit the size of log file we add to the cluster report, however we should not truncate the file, but instead chop off from the beginning.

(cherry picked from commit 57d2183)