### PR TITLE
Added no_wait_for_service_ep_readiness parameter

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -215,6 +215,7 @@ def config_default():
             "host_agent_openshift_resource": False,
             "use_netpol_apigroup": "networking.k8s.io",
             "use_cluster_role": True,
+            "no_wait_for_service_ep_readiness": False,
             "image_pull_policy": "Always",
             "kubectl": "kubectl",
             "system_namespace": "aci-containers-system",

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -1362,6 +1362,9 @@ data:
         {% if config.aci_config.capic or config.flavor == "k8s-overlay" %}
         "lb-type": "None",
         {% endif %}
+        {% if config.kube_config.no_wait_for_service_ep_readiness %}
+        "no-wait-for-service-ep-readiness": {{ config.kube_config.no_wait_for_service_ep_readiness|json }},
+        {% endif %}
         {% if config.kube_config.snat_operator.disable_periodic_snat_global_info_sync %}
         "disable-periodic-snat-global-info-sync": {{ config.kube_config.snat_operator.disable_periodic_snat_global_info_sync|json }},
         {% endif %}

--- a/provision/acc_provision/templates/provision-config.yaml
+++ b/provision/acc_provision/templates/provision-config.yaml
@@ -80,6 +80,7 @@ registry:
   # image_pull_secret: secret_name      # (if needed)
 
 #kube_config:
+  # no_wait_for_service_ep_readiness: True    #override if needed, default is False
   # ovs_memory_limit: "20Gi"            # override if needed, default is "1Gi"
   # reboot_opflex_with_ovs: "false"     # override if needed, default is "true"
   # snat_operator:


### PR DESCRIPTION
Set as true when we dont want to wait for the service ep to be ready
before adding the ep to service graph. By default, we wait for service
ep to be ready

(cherry picked from commit 2ea4772f26c0d8ee753dd367b903b0f8ebe56a6d)