### PR TITLE
To generate dpu manifest config file for dpu k8s cluster

### DIFF
--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -1522,7 +1522,7 @@ data:
         "enable-nodepodif": false,
         {% endif %}
         {% if config.sriov_config.enable %}
-        {% if config.dpu_config.enable %}
+        {% if config.dpu_config.enable and config.kube_config.opflex_mode == "dpu" %}
         "dpu-ovsdb-socket": {{config.dpu_ovsdb_socket|json}},
         {% endif %}
         "enable-ovs-hw-offload": true
@@ -2926,7 +2926,7 @@ spec:
                   description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
                   type: string
 {% endif %}
-{% if config.dpu_config.enable == True %}
+{% if config.dpu_config.enable == True and config.kube_config.opflex_mode == "dpu" %}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/provision/acc_provision/templates/dpu-containers.yaml
+++ b/provision/acc_provision/templates/dpu-containers.yaml
@@ -1,0 +1,181 @@
+{% if config.dpu_config.enable %}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dpu-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: 
+  name: dpu-system-serviceaccount
+  namespace: dpu-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dpu-init
+  namespace: dpu-system
+  labels:
+    name: dpu-init-sys
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: dpu-init-sys
+  template:
+    metadata:
+      labels:
+        name: dpu-init-sys
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      nodeSelector:
+        beta.kubernetes.io/arch: arm64
+      serviceAccountName: dpu-system-serviceaccount
+      {% if config.registry.image_pull_secret %}
+      imagePullSecrets:
+        - name: {{ config.registry.image_pull_secret|yaml_quote }}
+      {% endif %}
+      restartPolicy: Always
+      containers:
+         - name: dpu-init
+           image: {{ config.registry.dpu_control_server }}/dpu:{{ config.registry.dpu_init_version }}
+           imagePullPolicy: {{ config.kube_config.image_pull_policy }}
+           args:
+             - {{config.dpuIp|json}}
+             - {{'"' ~config.net_config.infra_vlan|string~ '"'}}
+             - {{'"' ~config.net_config.kubeapi_vlan|string~ '"'}}
+           securityContext:
+             privileged: true
+             capabilities:
+               add:
+                 - NET_ADMIN
+           volumeMounts:
+             - name: dpu-fs
+               mountPath: /host
+      volumes:
+        - name: dpu-fs
+          hostPath:
+            path: /
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dpu-containers
+  namespace: dpu-system
+  labels:
+    name: dpu-systems
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: dpu-systems
+  template:
+    metadata:
+      labels:
+        name: dpu-systems
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      nodeSelector:
+        beta.kubernetes.io/arch: arm64
+      serviceAccountName: dpu-system-serviceaccount
+      {% if config.registry.image_pull_secret %}
+      imagePullSecrets:
+        - name: {{ config.registry.image_pull_secret|yaml_quote }}
+      {% endif %}
+      restartPolicy: Always
+      containers:
+         - name: dpu-opflex
+           image: {{ config.registry.dpu_control_server }}/opflex:{{ config.registry.opflex_agent_version }}
+           imagePullPolicy: {{ config.kube_config.image_pull_policy }}
+           securityContext:
+             privileged: true
+             capabilities:
+               add:
+                - SYS_ADMIN
+                - NET_ADMIN
+                - SYS_PTRACE
+                - NET_RAW
+           volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: opflex-hostconfig-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+            - name: opflex-config-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
+         - name: dpu-mcast
+           image: {{ config.registry.dpu_control_server }}/opflex:{{ config.registry.opflex_agent_version }}
+           command: ["/bin/sh"]
+           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
+           imagePullPolicy: {{ config.kube_config.image_pull_policy }}
+           securityContext:
+             privileged: true
+             capabilities:
+               add:
+                - NET_ADMIN
+           volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: opflex-hostconfig-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+            - name: opflex-config-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
+      volumes:
+        - name: dpu-fs
+          hostPath:
+            path: /
+        - name: hostvar
+          hostPath:
+            path: /var
+        - name: hostrun
+          hostPath:
+            path: /run
+        - name: opflex-hostconfig-volume
+          hostPath:
+            path: /usr/local/etc/opflex-agent-ovs/base-conf.d
+        - name: opflex-config-volume
+          configMap:
+            name: opflex-agent-config
+            items:
+              - key: opflex-agent-config
+                path: local.conf
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opflex-agent-config
+  namespace: dpu-system
+data:
+  opflex-agent-config: |-
+    {
+        "log": {
+            "level": {{config.logging.opflexagent_log_level|json}}
+        },
+        "opflex": {
+            "notif" : { "enabled" : "false" }
+          {% if not config.aci_config.client_ssl %}
+            ,"ssl": { "mode": "disabled" }
+          {% endif %}
+          {% if config.kube_config.run_gbp_container %}
+            ,"statistics" : { "mode" : "off" }
+          {% endif %}
+        },
+        "prometheus": {
+            "enabled": "false"
+        }
+    }
+---  
+{% endif %}  

--- a/provision/acc_provision/templates/provision-config.yaml
+++ b/provision/acc_provision/templates/provision-config.yaml
@@ -78,6 +78,8 @@ net_config:
 registry:
   image_prefix: noiro                   # e.g: registry.example.com/noiro
   # image_pull_secret: secret_name      # (if needed)
+  # dpu_init_version: <version>
+  # dpu_control_server: ip:port         # e.g: 192.168.20.1:5000
 
 #kube_config:
   # no_wait_for_service_ep_readiness: True    #override if needed, default is False
@@ -95,6 +97,7 @@ registry:
 
   #opflex_mode: ""                      #override if needed, supported modes are "physical", "dpu" and "overlay"
   #opflex_agent_prometheus: "true" # Set to "true" if enabling opflex-agent prometheus metrics, default is "false"
+
 #
 # Configuration for ACI CNI Operator
 #

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -1133,6 +1133,7 @@ def get_args(**overrides):
         # configuration which would otherwise be discovered from
         # the APIC
         "infra_vlan": None,
+        "dpu": None,
         "test_run": True,
     }
     argc = collections.namedtuple('argc', list(arg.keys()))

--- a/provision/testdata/help.stdout.txt
+++ b/provision/testdata/help.stdout.txt
@@ -3,6 +3,7 @@ usage: acc_provision.py [-h] [-v] [--release] [--debug] [--sample] [-c file]
                         [-p pass] [-w timeout] [--list-flavors] [-f flavor]
                         [-t token] [--test-data-out file] [--skip-kafka-certs]
                         [--upgrade] [--disable-multus disable_multus]
+                        [-s file]
 
 Provision an ACI/Kubernetes installation
 
@@ -37,3 +38,4 @@ optional arguments:
                         upgrade
   --disable-multus disable_multus
                         true/false to disable/enable multus in cluster
+  -s, --dpu file        output file for your dpu kubernetes deployment


### PR DESCRIPTION
To generate dpu manifest file for the dpu k8s cluster, I have added command like option 

"-s <output file for your dpu kubernetes deployment>"
or
"--dpu <output file for your dpu kubernetes deployment>"

example:

acc_provision -f kubernetes-1.24 -o /home/aci-containers-yaml -c provision-config.yaml -s /home/dpu_containers.yaml 

Also, please enable the following parameters in acc_provision input file to generated. the dpu manifest file

#registry:
     #dpu_init_version: <version>

#kube_config:
     # opflex_mode: "dpu"
      #run_dpu_container: True   

#sriov_config:
      # enable: True     # default is False
      # device_info:
             # isRdma: True # default is false
             # devices: ""    # default is "1014","101e"

#dpu_config:
    # enable: True                  # default is false
    # ip: ""                               # default is "192.168.200.2"
    # user: ""                           # default is "opflex"
    # ovsdb_socket_port: ""           # default is "6640"
    # masterNodeIp: ""


I will add this info to dpu design document as well