### PR TITLE
DNM: update to installer CR.

### DIFF
--- a/provision/acc_provision/templates/aci-installer-cr.yaml
+++ b/provision/acc_provision/templates/aci-installer-cr.yaml
@@ -3,6 +3,10 @@ kind: Installer
 metadata:
   name: installer-aci-cni
 spec:
+  platformConfiguration:
+    cko-gitops:
+      options:
+        "01-argo-app": <base-encoded specs>
   networkFunctions:
     networking:
       cko-cni:


### PR DESCRIPTION
suggested update to installer CR to accommodate argo-app installation once argo is available.