### PR TITLE
Add type/name for vmm nested_inside in acc-provision-config

### DIFF
--- a/provision/acc_provision/templates/acc-provision-configmap.yaml
+++ b/provision/acc_provision/templates/acc-provision-configmap.yaml
@@ -60,6 +60,12 @@ data:
                         "end": {{ config.aci_config.vmm_domain.mcast_range.end|json }},
                     }
                     "nested_inside": {
+                        {% if (config.user_config.aci_config.vmm_domain.nested_inside.type) %}
+                        "type": {{config.user_config.aci_config.vmm_domain.nested_inside.type|json|indent(width=20)}}
+                        {% endif %}
+                        {% if (config.user_config.aci_config.vmm_domain.nested_inside.name) %}
+                        "name": {{config.user_config.aci_config.vmm_domain.nested_inside.name|json|indent(width=20)}}
+                        {% endif %}
                         "installer_provisioned_lb_ip": {{config.user_config.aci_config.vmm_domain.nested_inside.installer_provisioned_lb_ip|json|indent(width=20)}}
                     }
                 },

--- a/provision/testdata/flavor_openshift_410_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_410_esx.kube.yaml
@@ -1337,6 +1337,8 @@ data:
                         "end": "225.20.255.255",
                     }
                     "nested_inside": {
+                        "type": "vmware"
+                        "name": "myvmware"
                         "installer_provisioned_lb_ip": "192.168.18.201"
                     }
                 },

--- a/provision/testdata/flavor_openshift_410_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_410_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -11,21 +11,22 @@ data:
     OpenShift\",\n                \"encap_type\": \"vlan\",\n                \"mcast_fabric\"\
     : \"225.1.2.3\",\n                \"mcast_range\": {\n                    \"start\"\
     : \"225.20.1.1\",\n                    \"end\": \"225.20.255.255\",\n        \
-    \        }\n                \"nested_inside\": {\n                    \"installer_provisioned_lb_ip\"\
-    : \"192.168.18.201\"\n                }\n            },\n            \"l3out\"\
-    : {\n                \"name\": \"l3out\",\n                \"external_networks\"\
-    : [\n                    \"default\"\n                ]\n            }\n     \
-    \   },\n        \"registry\": {\n            \"image_prefix\": \"noiro\"\n   \
-    \     },\n        \"kube_config\": {\n            \"controller\": \"1.1.1.1\"\
-    , \n            \"use_cluster_role\": true, \n            \"use_ds_rolling_update\"\
-    : true\n\n        },\n        \"logging\": {\n           \"controller_log_level\"\
-    : \"info\", \n           \"hostagent_log_level\": \"info\", \n           \"opflexagent_log_level\"\
-    : \"info\"\n        },\n        \"net_config\": {\n            \"infra_vlan\"\
-    : 4093,\n            \"service_vlan\": 4003, \n            \"kubeapi_vlan\": 4001,\n\
-    \            \"extern_static\": \"10.4.0.1/24\",\n            \"extern_dynamic\"\
-    : \"10.3.0.1/24\",\n            \"node_svc_subnet\": \"10.5.0.1/24\",\n      \
-    \      \"node_subnet\": \"10.1.0.1/16\",\n            \"pod_subnet\": \"10.2.0.1/16\"\
-    \n        }\n    }\n }"
+    \        }\n                \"nested_inside\": {\n                    \"type\"\
+    : \"vmware\"\n                    \"name\": \"myvmware\"\n                   \
+    \ \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n                }\n   \
+    \         },\n            \"l3out\": {\n                \"name\": \"l3out\",\n\
+    \                \"external_networks\": [\n                    \"default\"\n \
+    \               ]\n            }\n        },\n        \"registry\": {\n      \
+    \      \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n \
+    \           \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\": true,\
+    \ \n            \"use_ds_rolling_update\": true\n\n        },\n        \"logging\"\
+    : {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
+    : \"info\", \n           \"opflexagent_log_level\": \"info\"\n        },\n   \
+    \     \"net_config\": {\n            \"infra_vlan\": 4093,\n            \"service_vlan\"\
+    : 4003, \n            \"kubeapi_vlan\": 4001,\n            \"extern_static\":\
+    \ \"10.4.0.1/24\",\n            \"extern_dynamic\": \"10.3.0.1/24\",\n       \
+    \     \"node_svc_subnet\": \"10.5.0.1/24\",\n            \"node_subnet\": \"10.1.0.1/16\"\
+    ,\n            \"pod_subnet\": \"10.2.0.1/16\"\n        }\n    }\n }"
 kind: ConfigMap
 metadata:
   labels:

--- a/provision/testdata/flavor_openshift_44_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_44_esx.kube.yaml
@@ -1337,6 +1337,8 @@ data:
                         "end": "225.20.255.255",
                     }
                     "nested_inside": {
+                        "type": "vmware"
+                        "name": "myvmware"
                         "installer_provisioned_lb_ip": "192.168.18.201"
                     }
                 },

--- a/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_44_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -11,21 +11,22 @@ data:
     OpenShift\",\n                \"encap_type\": \"vlan\",\n                \"mcast_fabric\"\
     : \"225.1.2.3\",\n                \"mcast_range\": {\n                    \"start\"\
     : \"225.20.1.1\",\n                    \"end\": \"225.20.255.255\",\n        \
-    \        }\n                \"nested_inside\": {\n                    \"installer_provisioned_lb_ip\"\
-    : \"192.168.18.201\"\n                }\n            },\n            \"l3out\"\
-    : {\n                \"name\": \"l3out\",\n                \"external_networks\"\
-    : [\n                    \"default\"\n                ]\n            }\n     \
-    \   },\n        \"registry\": {\n            \"image_prefix\": \"noiro\"\n   \
-    \     },\n        \"kube_config\": {\n            \"controller\": \"1.1.1.1\"\
-    , \n            \"use_cluster_role\": true, \n            \"use_ds_rolling_update\"\
-    : true\n\n        },\n        \"logging\": {\n           \"controller_log_level\"\
-    : \"info\", \n           \"hostagent_log_level\": \"info\", \n           \"opflexagent_log_level\"\
-    : \"info\"\n        },\n        \"net_config\": {\n            \"infra_vlan\"\
-    : 4093,\n            \"service_vlan\": 4003, \n            \"kubeapi_vlan\": 4001,\n\
-    \            \"extern_static\": \"10.4.0.1/24\",\n            \"extern_dynamic\"\
-    : \"10.3.0.1/24\",\n            \"node_svc_subnet\": \"10.5.0.1/24\",\n      \
-    \      \"node_subnet\": \"10.1.0.10/16\",\n            \"pod_subnet\": \"10.2.0.1/16\"\
-    \n        }\n    }\n }"
+    \        }\n                \"nested_inside\": {\n                    \"type\"\
+    : \"vmware\"\n                    \"name\": \"myvmware\"\n                   \
+    \ \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n                }\n   \
+    \         },\n            \"l3out\": {\n                \"name\": \"l3out\",\n\
+    \                \"external_networks\": [\n                    \"default\"\n \
+    \               ]\n            }\n        },\n        \"registry\": {\n      \
+    \      \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n \
+    \           \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\": true,\
+    \ \n            \"use_ds_rolling_update\": true\n\n        },\n        \"logging\"\
+    : {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
+    : \"info\", \n           \"opflexagent_log_level\": \"info\"\n        },\n   \
+    \     \"net_config\": {\n            \"infra_vlan\": 4093,\n            \"service_vlan\"\
+    : 4003, \n            \"kubeapi_vlan\": 4001,\n            \"extern_static\":\
+    \ \"10.4.0.1/24\",\n            \"extern_dynamic\": \"10.3.0.1/24\",\n       \
+    \     \"node_svc_subnet\": \"10.5.0.1/24\",\n            \"node_subnet\": \"10.1.0.10/16\"\
+    ,\n            \"pod_subnet\": \"10.2.0.1/16\"\n        }\n    }\n }"
 kind: ConfigMap
 metadata:
   labels:

--- a/provision/testdata/flavor_openshift_45_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_45_esx.kube.yaml
@@ -1337,6 +1337,8 @@ data:
                         "end": "225.20.255.255",
                     }
                     "nested_inside": {
+                        "type": "vmware"
+                        "name": "myvmware"
                         "installer_provisioned_lb_ip": "192.168.18.201"
                     }
                 },

--- a/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_45_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -11,21 +11,22 @@ data:
     OpenShift\",\n                \"encap_type\": \"vlan\",\n                \"mcast_fabric\"\
     : \"225.1.2.3\",\n                \"mcast_range\": {\n                    \"start\"\
     : \"225.20.1.1\",\n                    \"end\": \"225.20.255.255\",\n        \
-    \        }\n                \"nested_inside\": {\n                    \"installer_provisioned_lb_ip\"\
-    : \"192.168.18.201\"\n                }\n            },\n            \"l3out\"\
-    : {\n                \"name\": \"l3out\",\n                \"external_networks\"\
-    : [\n                    \"default\"\n                ]\n            }\n     \
-    \   },\n        \"registry\": {\n            \"image_prefix\": \"noiro\"\n   \
-    \     },\n        \"kube_config\": {\n            \"controller\": \"1.1.1.1\"\
-    , \n            \"use_cluster_role\": true, \n            \"use_ds_rolling_update\"\
-    : true\n\n        },\n        \"logging\": {\n           \"controller_log_level\"\
-    : \"info\", \n           \"hostagent_log_level\": \"info\", \n           \"opflexagent_log_level\"\
-    : \"info\"\n        },\n        \"net_config\": {\n            \"infra_vlan\"\
-    : 4093,\n            \"service_vlan\": 4003, \n            \"kubeapi_vlan\": 4001,\n\
-    \            \"extern_static\": \"10.4.0.1/24\",\n            \"extern_dynamic\"\
-    : \"10.3.0.1/24\",\n            \"node_svc_subnet\": \"10.5.0.1/24\",\n      \
-    \      \"node_subnet\": \"10.1.0.1/16\",\n            \"pod_subnet\": \"10.2.0.1/16\"\
-    \n        }\n    }\n }"
+    \        }\n                \"nested_inside\": {\n                    \"type\"\
+    : \"vmware\"\n                    \"name\": \"myvmware\"\n                   \
+    \ \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n                }\n   \
+    \         },\n            \"l3out\": {\n                \"name\": \"l3out\",\n\
+    \                \"external_networks\": [\n                    \"default\"\n \
+    \               ]\n            }\n        },\n        \"registry\": {\n      \
+    \      \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n \
+    \           \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\": true,\
+    \ \n            \"use_ds_rolling_update\": true\n\n        },\n        \"logging\"\
+    : {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
+    : \"info\", \n           \"opflexagent_log_level\": \"info\"\n        },\n   \
+    \     \"net_config\": {\n            \"infra_vlan\": 4093,\n            \"service_vlan\"\
+    : 4003, \n            \"kubeapi_vlan\": 4001,\n            \"extern_static\":\
+    \ \"10.4.0.1/24\",\n            \"extern_dynamic\": \"10.3.0.1/24\",\n       \
+    \     \"node_svc_subnet\": \"10.5.0.1/24\",\n            \"node_subnet\": \"10.1.0.1/16\"\
+    ,\n            \"pod_subnet\": \"10.2.0.1/16\"\n        }\n    }\n }"
 kind: ConfigMap
 metadata:
   labels:

--- a/provision/testdata/flavor_openshift_46_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_46_esx.kube.yaml
@@ -1337,6 +1337,8 @@ data:
                         "end": "225.20.255.255",
                     }
                     "nested_inside": {
+                        "type": "vmware"
+                        "name": "myvmware"
                         "installer_provisioned_lb_ip": "192.168.18.201"
                     }
                 },

--- a/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_46_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -11,21 +11,22 @@ data:
     OpenShift\",\n                \"encap_type\": \"vlan\",\n                \"mcast_fabric\"\
     : \"225.1.2.3\",\n                \"mcast_range\": {\n                    \"start\"\
     : \"225.20.1.1\",\n                    \"end\": \"225.20.255.255\",\n        \
-    \        }\n                \"nested_inside\": {\n                    \"installer_provisioned_lb_ip\"\
-    : \"192.168.18.201\"\n                }\n            },\n            \"l3out\"\
-    : {\n                \"name\": \"l3out\",\n                \"external_networks\"\
-    : [\n                    \"default\"\n                ]\n            }\n     \
-    \   },\n        \"registry\": {\n            \"image_prefix\": \"noiro\"\n   \
-    \     },\n        \"kube_config\": {\n            \"controller\": \"1.1.1.1\"\
-    , \n            \"use_cluster_role\": true, \n            \"use_ds_rolling_update\"\
-    : true\n\n        },\n        \"logging\": {\n           \"controller_log_level\"\
-    : \"info\", \n           \"hostagent_log_level\": \"info\", \n           \"opflexagent_log_level\"\
-    : \"info\"\n        },\n        \"net_config\": {\n            \"infra_vlan\"\
-    : 4093,\n            \"service_vlan\": 4003, \n            \"kubeapi_vlan\": 4001,\n\
-    \            \"extern_static\": \"10.4.0.1/24\",\n            \"extern_dynamic\"\
-    : \"10.3.0.1/24\",\n            \"node_svc_subnet\": \"10.5.0.1/24\",\n      \
-    \      \"node_subnet\": \"10.1.0.1/16\",\n            \"pod_subnet\": \"10.2.0.1/16\"\
-    \n        }\n    }\n }"
+    \        }\n                \"nested_inside\": {\n                    \"type\"\
+    : \"vmware\"\n                    \"name\": \"myvmware\"\n                   \
+    \ \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n                }\n   \
+    \         },\n            \"l3out\": {\n                \"name\": \"l3out\",\n\
+    \                \"external_networks\": [\n                    \"default\"\n \
+    \               ]\n            }\n        },\n        \"registry\": {\n      \
+    \      \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n \
+    \           \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\": true,\
+    \ \n            \"use_ds_rolling_update\": true\n\n        },\n        \"logging\"\
+    : {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
+    : \"info\", \n           \"opflexagent_log_level\": \"info\"\n        },\n   \
+    \     \"net_config\": {\n            \"infra_vlan\": 4093,\n            \"service_vlan\"\
+    : 4003, \n            \"kubeapi_vlan\": 4001,\n            \"extern_static\":\
+    \ \"10.4.0.1/24\",\n            \"extern_dynamic\": \"10.3.0.1/24\",\n       \
+    \     \"node_svc_subnet\": \"10.5.0.1/24\",\n            \"node_subnet\": \"10.1.0.1/16\"\
+    ,\n            \"pod_subnet\": \"10.2.0.1/16\"\n        }\n    }\n }"
 kind: ConfigMap
 metadata:
   labels:

--- a/provision/testdata/flavor_openshift_47_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_47_esx.kube.yaml
@@ -1337,6 +1337,8 @@ data:
                         "end": "225.20.255.255",
                     }
                     "nested_inside": {
+                        "type": "vmware"
+                        "name": "myvmware"
                         "installer_provisioned_lb_ip": "192.168.18.201"
                     }
                 },

--- a/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_47_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -11,21 +11,22 @@ data:
     OpenShift\",\n                \"encap_type\": \"vlan\",\n                \"mcast_fabric\"\
     : \"225.1.2.3\",\n                \"mcast_range\": {\n                    \"start\"\
     : \"225.20.1.1\",\n                    \"end\": \"225.20.255.255\",\n        \
-    \        }\n                \"nested_inside\": {\n                    \"installer_provisioned_lb_ip\"\
-    : \"192.168.18.201\"\n                }\n            },\n            \"l3out\"\
-    : {\n                \"name\": \"l3out\",\n                \"external_networks\"\
-    : [\n                    \"default\"\n                ]\n            }\n     \
-    \   },\n        \"registry\": {\n            \"image_prefix\": \"noiro\"\n   \
-    \     },\n        \"kube_config\": {\n            \"controller\": \"1.1.1.1\"\
-    , \n            \"use_cluster_role\": true, \n            \"use_ds_rolling_update\"\
-    : true\n\n        },\n        \"logging\": {\n           \"controller_log_level\"\
-    : \"info\", \n           \"hostagent_log_level\": \"info\", \n           \"opflexagent_log_level\"\
-    : \"info\"\n        },\n        \"net_config\": {\n            \"infra_vlan\"\
-    : 4093,\n            \"service_vlan\": 4003, \n            \"kubeapi_vlan\": 4001,\n\
-    \            \"extern_static\": \"10.4.0.1/24\",\n            \"extern_dynamic\"\
-    : \"10.3.0.1/24\",\n            \"node_svc_subnet\": \"10.5.0.1/24\",\n      \
-    \      \"node_subnet\": \"10.1.0.1/16\",\n            \"pod_subnet\": \"10.2.0.1/16\"\
-    \n        }\n    }\n }"
+    \        }\n                \"nested_inside\": {\n                    \"type\"\
+    : \"vmware\"\n                    \"name\": \"myvmware\"\n                   \
+    \ \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n                }\n   \
+    \         },\n            \"l3out\": {\n                \"name\": \"l3out\",\n\
+    \                \"external_networks\": [\n                    \"default\"\n \
+    \               ]\n            }\n        },\n        \"registry\": {\n      \
+    \      \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n \
+    \           \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\": true,\
+    \ \n            \"use_ds_rolling_update\": true\n\n        },\n        \"logging\"\
+    : {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
+    : \"info\", \n           \"opflexagent_log_level\": \"info\"\n        },\n   \
+    \     \"net_config\": {\n            \"infra_vlan\": 4093,\n            \"service_vlan\"\
+    : 4003, \n            \"kubeapi_vlan\": 4001,\n            \"extern_static\":\
+    \ \"10.4.0.1/24\",\n            \"extern_dynamic\": \"10.3.0.1/24\",\n       \
+    \     \"node_svc_subnet\": \"10.5.0.1/24\",\n            \"node_subnet\": \"10.1.0.1/16\"\
+    ,\n            \"pod_subnet\": \"10.2.0.1/16\"\n        }\n    }\n }"
 kind: ConfigMap
 metadata:
   labels:

--- a/provision/testdata/flavor_openshift_48_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_48_esx.kube.yaml
@@ -1337,6 +1337,8 @@ data:
                         "end": "225.20.255.255",
                     }
                     "nested_inside": {
+                        "type": "vmware"
+                        "name": "myvmware"
                         "installer_provisioned_lb_ip": "192.168.18.201"
                     }
                 },

--- a/provision/testdata/flavor_openshift_48_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_48_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -11,21 +11,22 @@ data:
     OpenShift\",\n                \"encap_type\": \"vlan\",\n                \"mcast_fabric\"\
     : \"225.1.2.3\",\n                \"mcast_range\": {\n                    \"start\"\
     : \"225.20.1.1\",\n                    \"end\": \"225.20.255.255\",\n        \
-    \        }\n                \"nested_inside\": {\n                    \"installer_provisioned_lb_ip\"\
-    : \"192.168.18.201\"\n                }\n            },\n            \"l3out\"\
-    : {\n                \"name\": \"l3out\",\n                \"external_networks\"\
-    : [\n                    \"default\"\n                ]\n            }\n     \
-    \   },\n        \"registry\": {\n            \"image_prefix\": \"noiro\"\n   \
-    \     },\n        \"kube_config\": {\n            \"controller\": \"1.1.1.1\"\
-    , \n            \"use_cluster_role\": true, \n            \"use_ds_rolling_update\"\
-    : true\n\n        },\n        \"logging\": {\n           \"controller_log_level\"\
-    : \"info\", \n           \"hostagent_log_level\": \"info\", \n           \"opflexagent_log_level\"\
-    : \"info\"\n        },\n        \"net_config\": {\n            \"infra_vlan\"\
-    : 4093,\n            \"service_vlan\": 4003, \n            \"kubeapi_vlan\": 4001,\n\
-    \            \"extern_static\": \"10.4.0.1/24\",\n            \"extern_dynamic\"\
-    : \"10.3.0.1/24\",\n            \"node_svc_subnet\": \"10.5.0.1/24\",\n      \
-    \      \"node_subnet\": \"10.1.0.1/16\",\n            \"pod_subnet\": \"10.2.0.1/16\"\
-    \n        }\n    }\n }"
+    \        }\n                \"nested_inside\": {\n                    \"type\"\
+    : \"vmware\"\n                    \"name\": \"myvmware\"\n                   \
+    \ \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n                }\n   \
+    \         },\n            \"l3out\": {\n                \"name\": \"l3out\",\n\
+    \                \"external_networks\": [\n                    \"default\"\n \
+    \               ]\n            }\n        },\n        \"registry\": {\n      \
+    \      \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n \
+    \           \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\": true,\
+    \ \n            \"use_ds_rolling_update\": true\n\n        },\n        \"logging\"\
+    : {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
+    : \"info\", \n           \"opflexagent_log_level\": \"info\"\n        },\n   \
+    \     \"net_config\": {\n            \"infra_vlan\": 4093,\n            \"service_vlan\"\
+    : 4003, \n            \"kubeapi_vlan\": 4001,\n            \"extern_static\":\
+    \ \"10.4.0.1/24\",\n            \"extern_dynamic\": \"10.3.0.1/24\",\n       \
+    \     \"node_svc_subnet\": \"10.5.0.1/24\",\n            \"node_subnet\": \"10.1.0.1/16\"\
+    ,\n            \"pod_subnet\": \"10.2.0.1/16\"\n        }\n    }\n }"
 kind: ConfigMap
 metadata:
   labels:

--- a/provision/testdata/flavor_openshift_49_esx.kube.yaml
+++ b/provision/testdata/flavor_openshift_49_esx.kube.yaml
@@ -1337,6 +1337,8 @@ data:
                         "end": "225.20.255.255",
                     }
                     "nested_inside": {
+                        "type": "vmware"
+                        "name": "myvmware"
                         "installer_provisioned_lb_ip": "192.168.18.201"
                     }
                 },

--- a/provision/testdata/flavor_openshift_49_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
+++ b/provision/testdata/flavor_openshift_49_esx_tar/cluster-network-22-ConfigMap-acc-provision-config.yaml
@@ -11,21 +11,22 @@ data:
     OpenShift\",\n                \"encap_type\": \"vlan\",\n                \"mcast_fabric\"\
     : \"225.1.2.3\",\n                \"mcast_range\": {\n                    \"start\"\
     : \"225.20.1.1\",\n                    \"end\": \"225.20.255.255\",\n        \
-    \        }\n                \"nested_inside\": {\n                    \"installer_provisioned_lb_ip\"\
-    : \"192.168.18.201\"\n                }\n            },\n            \"l3out\"\
-    : {\n                \"name\": \"l3out\",\n                \"external_networks\"\
-    : [\n                    \"default\"\n                ]\n            }\n     \
-    \   },\n        \"registry\": {\n            \"image_prefix\": \"noiro\"\n   \
-    \     },\n        \"kube_config\": {\n            \"controller\": \"1.1.1.1\"\
-    , \n            \"use_cluster_role\": true, \n            \"use_ds_rolling_update\"\
-    : true\n\n        },\n        \"logging\": {\n           \"controller_log_level\"\
-    : \"info\", \n           \"hostagent_log_level\": \"info\", \n           \"opflexagent_log_level\"\
-    : \"info\"\n        },\n        \"net_config\": {\n            \"infra_vlan\"\
-    : 4093,\n            \"service_vlan\": 4003, \n            \"kubeapi_vlan\": 4001,\n\
-    \            \"extern_static\": \"10.4.0.1/24\",\n            \"extern_dynamic\"\
-    : \"10.3.0.1/24\",\n            \"node_svc_subnet\": \"10.5.0.1/24\",\n      \
-    \      \"node_subnet\": \"10.1.0.1/16\",\n            \"pod_subnet\": \"10.2.0.1/16\"\
-    \n        }\n    }\n }"
+    \        }\n                \"nested_inside\": {\n                    \"type\"\
+    : \"vmware\"\n                    \"name\": \"myvmware\"\n                   \
+    \ \"installer_provisioned_lb_ip\": \"192.168.18.201\"\n                }\n   \
+    \         },\n            \"l3out\": {\n                \"name\": \"l3out\",\n\
+    \                \"external_networks\": [\n                    \"default\"\n \
+    \               ]\n            }\n        },\n        \"registry\": {\n      \
+    \      \"image_prefix\": \"noiro\"\n        },\n        \"kube_config\": {\n \
+    \           \"controller\": \"1.1.1.1\", \n            \"use_cluster_role\": true,\
+    \ \n            \"use_ds_rolling_update\": true\n\n        },\n        \"logging\"\
+    : {\n           \"controller_log_level\": \"info\", \n           \"hostagent_log_level\"\
+    : \"info\", \n           \"opflexagent_log_level\": \"info\"\n        },\n   \
+    \     \"net_config\": {\n            \"infra_vlan\": 4093,\n            \"service_vlan\"\
+    : 4003, \n            \"kubeapi_vlan\": 4001,\n            \"extern_static\":\
+    \ \"10.4.0.1/24\",\n            \"extern_dynamic\": \"10.3.0.1/24\",\n       \
+    \     \"node_svc_subnet\": \"10.5.0.1/24\",\n            \"node_subnet\": \"10.1.0.1/16\"\
+    ,\n            \"pod_subnet\": \"10.2.0.1/16\"\n        }\n    }\n }"
 kind: ConfigMap
 metadata:
   labels:


### PR DESCRIPTION
ESX flavor requires these for provisioning in CKO unmanaged mode

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>