### PR TITLE
#2217 added imagePullSecret to Tigera installation CR

### DIFF
--- a/provision/acc_provision/templates/custom-resources-aci-calico.yaml
+++ b/provision/acc_provision/templates/custom-resources-aci-calico.yaml
@@ -13,6 +13,10 @@ metadata:
   name: default
 spec:
   # Configures Calico networking.
+  {% if config.registry.image_pull_secret %}
+  imagePullSecrets:
+    - name: {{ config.registry.image_pull_secret|yaml_quote }}
+  {% endif %}
   calicoNetwork:
     # Note: The ipPools section cannot be modified post-install.
     ipPools:


### PR DESCRIPTION
added imagePullSecrets to Tigera installation CR from input file (.registry.image_pull_secret). The main reason for this change is to introduce authentication for docker hub where calico images are hosted, to overcome rate limit. 
The placeholder for registry in the input file was for maintaining aci cni images, however calico and aci cni are mutually exclusive. 