### PR TITLE
unset loopback in rtr_id for Calico L3out

### DIFF
--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -5861,6 +5861,7 @@ class ApicKubeConfig(object):
                                     [
                                         ("rtrId", router_id),
                                         ("tDn", node_dn),
+                                        ("rtrIdLoopBack", "no"),
                                     ]
                                 ),
                             ),
@@ -5889,6 +5890,7 @@ class ApicKubeConfig(object):
                                     [
                                         ("rtrId", router_id),
                                         ("tDn", node_dn),
+                                        ("rtrIdLoopBack", "no"),
                                     ]
                                 ),
                             ),

--- a/provision/testdata/flavor_calico-3.23.2.apic.txt
+++ b/provision/testdata/flavor_calico-3.23.2.apic.txt
@@ -336,7 +336,7 @@
     "l3extRsNodeL3OutAtt": {
         "attributes": {
             "rtrId": "2.2.2.2",
-            "rtrIdLoopBack": "no"
+            "rtrIdLoopBack": "no",
             "tDn": "topology/pod-1/node-102",
             "annotation": "orchestrator:aci-containers-controller"
         }
@@ -347,7 +347,7 @@
     "l3extRsNodeL3OutAtt": {
         "attributes": {
             "rtrId": "1.1.4.103",
-            "rtrIdLoopBack": "no"
+            "rtrIdLoopBack": "no",
             "tDn": "topology/pod-1/node-103",
             "annotation": "orchestrator:aci-containers-controller"
         }

--- a/provision/testdata/flavor_calico-3.23.2.apic.txt
+++ b/provision/testdata/flavor_calico-3.23.2.apic.txt
@@ -336,6 +336,7 @@
     "l3extRsNodeL3OutAtt": {
         "attributes": {
             "rtrId": "2.2.2.2",
+            "rtrIdLoopBack": "no"
             "tDn": "topology/pod-1/node-102",
             "annotation": "orchestrator:aci-containers-controller"
         }
@@ -346,6 +347,7 @@
     "l3extRsNodeL3OutAtt": {
         "attributes": {
             "rtrId": "1.1.4.103",
+            "rtrIdLoopBack": "no"
             "tDn": "topology/pod-1/node-103",
             "annotation": "orchestrator:aci-containers-controller"
         }

--- a/provision/testdata/flavor_calico-3.23.2.apic.txt
+++ b/provision/testdata/flavor_calico-3.23.2.apic.txt
@@ -336,8 +336,8 @@
     "l3extRsNodeL3OutAtt": {
         "attributes": {
             "rtrId": "2.2.2.2",
-            "rtrIdLoopBack": "no",
             "tDn": "topology/pod-1/node-102",
+            "rtrIdLoopBack": "no",
             "annotation": "orchestrator:aci-containers-controller"
         }
     }
@@ -347,8 +347,8 @@
     "l3extRsNodeL3OutAtt": {
         "attributes": {
             "rtrId": "1.1.4.103",
-            "rtrIdLoopBack": "no",
             "tDn": "topology/pod-1/node-103",
+            "rtrIdLoopBack": "no",
             "annotation": "orchestrator:aci-containers-controller"
         }
     }

--- a/provision/testdata/flavor_calico-3.23.2_base_case.apic.txt
+++ b/provision/testdata/flavor_calico-3.23.2_base_case.apic.txt
@@ -336,6 +336,7 @@
     "l3extRsNodeL3OutAtt": {
         "attributes": {
             "rtrId": "2.2.2.2",
+            "rtrIdLoopBack": "no"
             "tDn": "topology/pod-1/node-102",
             "annotation": "orchestrator:aci-containers-controller"
         }
@@ -346,6 +347,7 @@
     "l3extRsNodeL3OutAtt": {
         "attributes": {
             "rtrId": "1.1.4.103",
+            "rtrIdLoopBack": "no"
             "tDn": "topology/pod-1/node-103",
             "annotation": "orchestrator:aci-containers-controller"
         }


### PR DESCRIPTION
Override default when creating router_id in node profile to not set it as loopback.