### PR TITLE
Propagate canary configuration

### DIFF
--- a/provision/acc_provision/templates/cko/0.7.0/netop-manifest-openshift.yaml
+++ b/provision/acc_provision/templates/cko/0.7.0/netop-manifest-openshift.yaml
@@ -1509,6 +1509,8 @@ spec:
               key: email
               name: cko-config
               optional: true
+        - name: DISABLE_CANARY_INSTALLER
+          value: "false"
         image: quay.io/ckodev/netop-manager:0.7.0
         imagePullPolicy: Always
         livenessProbe:

--- a/provision/acc_provision/templates/cko/0.7.0/netop-manifest.yaml
+++ b/provision/acc_provision/templates/cko/0.7.0/netop-manifest.yaml
@@ -1506,6 +1506,8 @@ spec:
               key: email
               name: cko-config
               optional: true
+        - name: DISABLE_CANARY_INSTALLER
+          value: "false"
         image: quay.io/ckodev/netop-manager:0.7.0
         imagePullPolicy: Always
         livenessProbe:

--- a/provision/acc_provision/templates/cko/0.8.0/netop-manifest-openshift.yaml
+++ b/provision/acc_provision/templates/cko/0.8.0/netop-manifest-openshift.yaml
@@ -1509,6 +1509,8 @@ spec:
               key: email
               name: cko-config
               optional: true
+        - name: DISABLE_CANARY_INSTALLER
+          value: "false"
         image: quay.io/ckodev/netop-manager:0.8.0
         imagePullPolicy: Always
         livenessProbe:

--- a/provision/acc_provision/templates/cko/0.8.0/netop-manifest.yaml
+++ b/provision/acc_provision/templates/cko/0.8.0/netop-manifest.yaml
@@ -1506,6 +1506,8 @@ spec:
               key: email
               name: cko-config
               optional: true
+        - name: DISABLE_CANARY_INSTALLER
+          value: "false"
         image: quay.io/ckodev/netop-manager:0.8.0
         imagePullPolicy: Always
         livenessProbe:

--- a/provision/acc_provision/templates/cko/0.9.0/netop-manifest-openshift.yaml
+++ b/provision/acc_provision/templates/cko/0.9.0/netop-manifest-openshift.yaml
@@ -1509,6 +1509,8 @@ spec:
               key: email
               name: cko-config
               optional: true
+        - name: DISABLE_CANARY_INSTALLER
+          value: "false"
         image: quay.io/ckodev/netop-manager:0.9.0.d04f56f
         imagePullPolicy: Always
         livenessProbe:

--- a/provision/acc_provision/templates/cko/0.9.0/netop-manifest.yaml
+++ b/provision/acc_provision/templates/cko/0.9.0/netop-manifest.yaml
@@ -1506,6 +1506,8 @@ spec:
               key: email
               name: cko-config
               optional: true
+        - name: DISABLE_CANARY_INSTALLER
+          value: "false"
         image: quay.io/ckodev/netop-manager:0.9.0.d04f56f
         imagePullPolicy: Always
         livenessProbe:

--- a/provision/testdata/cko_aci.kube.yaml
+++ b/provision/testdata/cko_aci.kube.yaml
@@ -1506,6 +1506,8 @@ spec:
               key: email
               name: cko-config
               optional: true
+        - name: DISABLE_CANARY_INSTALLER
+          value: "false"
         image: quay.io/ckodev/netop-manager:0.9.0.d04f56f
         imagePullPolicy: Always
         livenessProbe:
@@ -1590,6 +1592,7 @@ data:
       cko-cni-awsvpc:
       - "10-aws.conflist"
       - "10-aws.conf"
+
 ---
 apiVersion: controller.netop-manager.io/v1alpha1
 kind: Installer

--- a/provision/testdata/cko_aci_openshift_410_esx.kube.yaml
+++ b/provision/testdata/cko_aci_openshift_410_esx.kube.yaml
@@ -1509,6 +1509,8 @@ spec:
               key: email
               name: cko-config
               optional: true
+        - name: DISABLE_CANARY_INSTALLER
+          value: "false"
         image: quay.io/ckodev/netop-manager:0.9.0.d04f56f
         imagePullPolicy: Always
         livenessProbe:
@@ -1602,6 +1604,7 @@ metadata:
 value: 1000000000
 globalDefault: false
 description: "This priority class is used for netop-manager resources"
+
 ---
 apiVersion: controller.netop-manager.io/v1alpha1
 kind: Installer

--- a/provision/testdata/cko_aci_unmanaged.kube.yaml
+++ b/provision/testdata/cko_aci_unmanaged.kube.yaml
@@ -1506,6 +1506,8 @@ spec:
               key: email
               name: cko-config
               optional: true
+        - name: DISABLE_CANARY_INSTALLER
+          value: "false"
         image: quay.io/ckodev/netop-manager:0.9.0.d04f56f
         imagePullPolicy: Always
         livenessProbe:
@@ -1590,6 +1592,7 @@ data:
       cko-cni-awsvpc:
       - "10-aws.conflist"
       - "10-aws.conf"
+
 ---
 apiVersion: controller.netop-manager.io/v1alpha1
 kind: Installer

--- a/provision/testdata/cko_calico.kube.yaml
+++ b/provision/testdata/cko_calico.kube.yaml
@@ -1506,6 +1506,8 @@ spec:
               key: email
               name: cko-config
               optional: true
+        - name: DISABLE_CANARY_INSTALLER
+          value: "false"
         image: quay.io/ckodev/netop-manager:0.9.0.d04f56f
         imagePullPolicy: Always
         livenessProbe:
@@ -1590,6 +1592,7 @@ data:
       cko-cni-awsvpc:
       - "10-aws.conflist"
       - "10-aws.conf"
+
 ---
 apiVersion: controller.netop-manager.io/v1alpha1
 kind: Installer


### PR DESCRIPTION
 Set knob DISABLE_CANARY_INSTALLER to true to have netop-manager
 disable canary installer creation.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>