### PR TITLE
Fix acc-provision-config map for calico

### DIFF
--- a/provision/acc_provision/templates/acc-provision-configmap.yaml
+++ b/provision/acc_provision/templates/acc-provision-configmap.yaml
@@ -48,37 +48,7 @@ data:
                     "tenant": {{config.aci_config.vrf.tenant|json}}
                 },
                 {% if config.user_config.aci_config.cluster_l3out %}
-                "cluster_l3out": {
-                    {% if config.user_config.aci_config.cluster_l3out.name %}
-                    "name": {{config.user_config.aci_config.cluster_l3out.name|json}},
-                    {% endif %}
-                    "aep": {{config.user_config.aci_config.cluster_l3out.aep|json}},
-                    "svi": {
-                        "type": "floating",
-                        "floating_ip": {{config.user_config.aci_config.cluster_l3out.svi.floating_ip|json}},
-                        "secondary_ip": {{config.user_config.aci_config.cluster_l3out.svi.secondary_ip|json}},
-                        {% if not config.user_config.aci_config.cluster_l3out.svi.mtu %}
-                        "vlan_id": {{config.user_config.aci_config.cluster_l3out.svi.vlan_id|json}}
-                        {% else %}
-                        "vlan_id": {{config.user_config.aci_config.cluster_l3out.svi.vlan_id|json}},
-                        "mtu": {{config.user_config.aci_config.cluster_l3out.svi.mtu|json}}
-                        {% endif %}
-                    },
-                    "bgp": {
-                        {% if config.user_config.aci_config.cluster_l3out.bgp.secret %}
-                        "secret": {{config.user_config.aci_config.cluster_l3out.bgp.secret|json}},
-                        {% endif %}
-                        "peering": {
-                        {% if config.user_config.aci_config.cluster_l3out.bgp.peering.prefixes %}
-                            "prefixes": {{config.user_config.aci_config.cluster_l3out.bgp.peering.prefixes|json}},
-                        {% endif %}
-                        {% if config.user_config.aci_config.cluster_l3out.bgp.peering.remote_as_number %}
-                            "remote_as_number": {{config.user_config.aci_config.cluster_l3out.bgp.peering.remote_as_number|json}},
-                        {% endif %}
-                            "aci_as_number": {{config.user_config.aci_config.cluster_l3out.bgp.peering.aci_as_number|json}}
-                        }
-                    }
-                },
+                "cluster_l3out": {{config.user_config.aci_config.cluster_l3out|json|indent(width=16)}},
                 {% endif %}
                 {% if config.user_config.aci_config.sync_login %}
                 "sync_login": {

--- a/provision/testdata/flavor_calico-3.23.2_tar/custom_resources_aci_calico.yaml
+++ b/provision/testdata/flavor_calico-3.23.2_tar/custom_resources_aci_calico.yaml
@@ -205,22 +205,22 @@ data:
                     "tenant": "test"
                 },
                 "cluster_l3out": {
-                    "name": "calico-l3out-fsvi-vlan-13",
                     "aep": "kube-cluster",
-                    "svi": {
-                        "type": "floating",
-                        "floating_ip": "2.100.101.100/24",
-                        "secondary_ip": "2.100.101.254/24",
-                        "vlan_id": 13,
-                        "mtu": 9000
-                    },
                     "bgp": {
-                        "secret": "test",
                         "peering": {
+                            "aci_as_number": 2,
                             "prefixes": 500,
-                            "remote_as_number": 64512,
-                            "aci_as_number": 2
-                        }
+                            "remote_as_number": 64512
+                        },
+                        "secret": "test"
+                    },
+                    "name": "calico-l3out-fsvi-vlan-13",
+                    "svi": {
+                        "floating_ip": "2.100.101.100/24",
+                        "mtu": 9000,
+                        "secondary_ip": "2.100.101.254/24",
+                        "type": "floating",
+                        "vlan_id": 13
                     }
                 },
                 "l3out": {


### PR DESCRIPTION
Some config like cluster_l3out was generated even for aci cni input with empty arguments, this caused an issue while regenerating the output on control-cluster, so simplifying rendering of that part. this applies to most of this file, we don't need so many checks on individual knobs

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>
(cherry picked from commit fb2f4eb1ba345c96fe6019caae6a34862ed8073b)