### PR TITLE
CKO: control-cluster - Remove type field from svi

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -152,7 +152,6 @@ def config_default():
             "cluster_l3out": {
                 "name": None,
                 "svi": {
-                    "type": "floating",
                     "mtu": 9000
                 },
                 "bgp": {

--- a/provision/acc_provision/templates/calico-provision-config.yaml
+++ b/provision/acc_provision/templates/calico-provision-config.yaml
@@ -12,7 +12,6 @@ aci_config:
     name: calico_l3out          # This is the l3out created by acc-provision
     aep: kube-cluster             # Required field. The AEP for ports/VPCs used by this cluster
     svi:
-      type: floating                          # This is the interface type. Only "floating" is supported
       floating_ip: 2.100.101.100/24           # Required field. Should be an IP in the node subnet
       secondary_ip: 2.100.101.254/24          # Required field
       vlan_id: 13                             # Required field. Valid vlan-id for the whole cluster

--- a/provision/testdata/cko_calico.inp.yaml
+++ b/provision/testdata/cko_calico.inp.yaml
@@ -8,7 +8,6 @@ aci_config:
   cluster_l3out:
     aep: kube-cluster 
     svi:
-      type: floating
       floating_ip: 2.100.101.100/24
       secondary_ip: 2.100.101.254/24
       vlan_id: 13

--- a/provision/testdata/flavor_calico-3.23.2_base_case.inp.yaml
+++ b/provision/testdata/flavor_calico-3.23.2_base_case.inp.yaml
@@ -8,7 +8,6 @@ aci_config:
     name: calico-l3out-fsvi-vlan-13
     aep: kube-cluster 
     svi:
-      type: floating
       floating_ip: 2.100.101.100/24
       secondary_ip: 2.100.101.254/24
       vlan_id: 13

--- a/provision/testdata/flavor_calico-3.23.2_base_case_tar/custom_resources_aci_calico.yaml
+++ b/provision/testdata/flavor_calico-3.23.2_base_case_tar/custom_resources_aci_calico.yaml
@@ -219,7 +219,6 @@ data:
                         "floating_ip": "2.100.101.100/24",
                         "mtu": 9000,
                         "secondary_ip": "2.100.101.254/24",
-                        "type": "floating",
                         "vlan_id": 13
                     }
                 },

--- a/provision/testdata/flavor_calico-3.23.2_overrides.inp.yaml
+++ b/provision/testdata/flavor_calico-3.23.2_overrides.inp.yaml
@@ -9,7 +9,6 @@ aci_config:
     name: test-l3out
     aep: kube-cluster 
     svi:
-      type: floating
       floating_ip: 2.100.101.100/24
       secondary_ip: 2.100.101.254/24
       vlan_id: 13

--- a/provision/testdata/flavor_calico-3.23.2_overrides_tar/custom_resources_aci_calico.yaml
+++ b/provision/testdata/flavor_calico-3.23.2_overrides_tar/custom_resources_aci_calico.yaml
@@ -219,7 +219,6 @@ data:
                         "floating_ip": "2.100.101.100/24",
                         "mtu": 9000,
                         "secondary_ip": "2.100.101.254/24",
-                        "type": "floating",
                         "vlan_id": 13
                     }
                 },

--- a/provision/testdata/flavor_calico-3.23.2_tar/custom_resources_aci_calico.yaml
+++ b/provision/testdata/flavor_calico-3.23.2_tar/custom_resources_aci_calico.yaml
@@ -219,7 +219,6 @@ data:
                         "floating_ip": "2.100.101.100/24",
                         "mtu": 9000,
                         "secondary_ip": "2.100.101.254/24",
-                        "type": "floating",
                         "vlan_id": 13
                     }
                 },


### PR DESCRIPTION
The confi.yaml has type field but the code svi struct doesnot have the type field . This field while looking over acc-provision code is not doing anything with it. So removed from acc-provision and control cluster logic