### PR TITLE
Fix calico node labeling

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -1398,8 +1398,8 @@ def generate_calico_deployment_files(config, network_operator_output):
         calico_bgp_config_output = calico_bgp_config_template.render(config=config)
 
         tigera_operator_yaml = calico_crds_output
-        custom_resources_aci_calico_yaml = calico_crs_output + "\n---\n" + calicoctl_output
-        custom_resources_calicoctl_yaml = calico_bgp_config_output + bgp_peer + bgp_node
+        custom_resources_aci_calico_yaml = calico_crs_output + "\n---\n" + calicoctl_output + bgp_node
+        custom_resources_calicoctl_yaml = calico_bgp_config_output + bgp_peer
         acc_provision_yaml = get_jinja_template('acc-provision-configmap.yaml').render(config=config)
         custom_resources_aci_calico_yaml += "\n---\n" + acc_provision_yaml
         with open("custom_resources_aci_calico.yaml", "w") as fh:

--- a/provision/acc_provision/templates/calico-node.yaml
+++ b/provision/acc_provision/templates/calico-node.yaml
@@ -1,4 +1,4 @@
-apiVersion: projectcalico.org/v3
+apiVersion: v1
 kind: Node
 metadata:
   name: {{config.node_name}}

--- a/provision/testdata/flavor_calico-3.23.2_tar/custom_resources_aci_calico.yaml
+++ b/provision/testdata/flavor_calico-3.23.2_tar/custom_resources_aci_calico.yaml
@@ -175,6 +175,38 @@ subjects:
   namespace: kube-system
 ---
 apiVersion: v1
+kind: Node
+metadata:
+  name: k8s-node1
+  labels:
+    rack_id: "1"
+
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k8s-node2
+  labels:
+    rack_id: "1"
+
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k8s-node3
+  labels:
+    rack_id: "2"
+
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k8s-node4
+  labels:
+    rack_id: "2"
+
+---
+apiVersion: v1
 kind: Namespace
 metadata:
   name: aci-containers-system

--- a/provision/testdata/flavor_calico-3.23.2_tar/custom_resources_calicoctl.yaml
+++ b/provision/testdata/flavor_calico-3.23.2_tar/custom_resources_calicoctl.yaml
@@ -54,32 +54,3 @@ spec:
     secretKeyRef:
       name: bgp-secrets
       key: rr-password
-
----
-apiVersion: projectcalico.org/v3
-kind: Node
-metadata:
-  name: k8s-node1
-  labels:
-    rack_id: "1"
----
-apiVersion: projectcalico.org/v3
-kind: Node
-metadata:
-  name: k8s-node2
-  labels:
-    rack_id: "1"
----
-apiVersion: projectcalico.org/v3
-kind: Node
-metadata:
-  name: k8s-node3
-  labels:
-    rack_id: "2"
----
-apiVersion: projectcalico.org/v3
-kind: Node
-metadata:
-  name: k8s-node4
-  labels:
-    rack_id: "2"


### PR DESCRIPTION
Use kubectl instead of calicoctl. Note that a doc change is needed.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>
(cherry picked from commit 38440a8c6c5b50516b183e0cca512fe6f67e74ce)