### PR TITLE
Fix error with CKO greenfield

### DIFF
--- a/provision/acc_provision/templates/acc-provision-configmap.yaml
+++ b/provision/acc_provision/templates/acc-provision-configmap.yaml
@@ -1,9 +1,11 @@
 {% if config.user_config.aci_config.cluster_l3out %}
+{% if config.user_config.aci_config.cluster_l3out.aep %}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ config.kube_config.system_namespace }}
 ---
+{% endif %}
 {% endif %}
 
 apiVersion: v1


### PR DESCRIPTION
With an empty cluster_l3out section in the input supplied to acc-provision for ACI CNI deployment, namespace section was also being generated for ACI CNI.This section in acc-provision-config is only required for 3rd party CNI. Add additional check for a required field AEP to have cluster_l3out section not affect ACI CNI.