### PR TITLE
Fixing templates path in MANIFEST.in for cko and cni subfolders

### DIFF
--- a/provision/MANIFEST.in
+++ b/provision/MANIFEST.in
@@ -1,13 +1,7 @@
 include README.md
-include acc_provision/templates/*.yaml
-include acc_provision/templates/cko/0.7.0/*.yaml
-include acc_provision/templates/cko/0.8.0/*.yaml
-include acc_provision/templates/cko/0.9.0/*.yaml
-include acc_provision/templates/cko/0.7.0/nettools/*.yaml
-include acc_provision/templates/cko/0.8.0/nettools/*.yaml
-include acc_provision/templates/cko/0.9.0/nettools/*.yaml
-include acc_provision/templates/cni/*/*.yaml
-include acc_provision/templates/*.json
+include acc_provision/templates/cni/*
+include acc_provision/templates/legacy/*
+include acc_provision/templates/cko/*
 include acc_provision/*.yaml
 include bin/acikubectl
 include debian/*

--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -1535,7 +1535,7 @@ def generate_kube_yaml(args, config, operator_output, operator_tar, operator_cr_
         kube_objects.extend(["clusterrolebinding", "clusterrole"])
 
     if operator_output and operator_output != "/dev/null":
-        template = get_jinja_template(config["aci_cni_versions_path"] + '/aci-containers.yaml')
+        template = get_jinja_template(config["aci_cni_versions_path"] + 'aci-containers.yaml')
         outname = operator_output
         tar_path = operator_tar
 


### PR DESCRIPTION
The fix covers the template not found error when running acc-provision inside the pod. To cater with handelling multiple versions for both cko and cni version, we will be taking in consideration all artifacts inside those folders.