### PR TITLE
Fix for the MANIFEST.in including directories and subdirectories.

### DIFF
--- a/provision/MANIFEST.in
+++ b/provision/MANIFEST.in
@@ -1,7 +1,7 @@
 include README.md
-include acc_provision/templates/cni/*
+recursive-include acc_provision/templates/cni *
 include acc_provision/templates/legacy/*
-include acc_provision/templates/cko/*
+recursive-include acc_provision/templates/cko *
 include acc_provision/*.yaml
 include bin/acikubectl
 include debian/*


### PR DESCRIPTION
Last change to MANIFEST.in didnt reflected the changes properly for including all files with directories and subdirectories. The use of recursive-include helped in achieving intended goal