### PR TITLE
use scripts option to copy acikubectl to bin dir,

### DIFF
--- a/provision/setup.py
+++ b/provision/setup.py
@@ -1,9 +1,25 @@
+import os
+import sys
+import tokenize
+from gitversion.gitversion import get_git_version
 from setuptools import setup, find_packages
-import os, sys
+
 file_dir = os.path.dirname(__file__)
 sys.path.append(file_dir)
-from gitversion.gitversion import get_git_version
 os.chdir(os.path.abspath(file_dir))
+
+try:
+    _detect_encoding = tokenize.detect_encoding
+except AttributeError:
+    pass
+else:
+    def detect_encoding(readline):
+        try:
+            return _detect_encoding(readline)
+        except SyntaxError:
+            return 'latin-1', []
+
+    tokenize.detect_encoding = detect_encoding
 
 setup(
     name='acc_provision',
@@ -16,7 +32,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    data_files = [('bin', ['bin/acikubectl'])],
+    scripts=['bin/acikubectl'],
     entry_points={
         'console_scripts': [
             'acc-provision=acc_provision.acc_provision:main',


### PR DESCRIPTION
also added code to handle python 3 choking on non-text scripts.

(cherry picked from commit 142c252e03cef04542db6a126a0d1c5ad46bec64)