### PR TITLE
Backport: Added RKE2 flavor for kubernetes version 1.24 in cko branch

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -297,6 +297,10 @@ def config_default():
         "lb_config": {
             "lb_type": "metallb",
         },
+        "rke2_config": {
+            "logging_namespace": "cattle-logging",
+            "monitoring_namespace": "cattle-prometheus",
+        },
     }
     return default_config
 
@@ -617,6 +621,13 @@ def config_adjust(args, config, prov_apic, no_random):
         adj_config["aci_config"]["vmm_domain"]["injected_cluster_type"] = ""
     if not config["aci_config"]["vmm_domain"].get("injected_cluster_provider"):
         adj_config["aci_config"]["vmm_domain"]["injected_cluster_provider"] = ""
+
+    if config["aci_config"]["vmm_domain"].get("injected_cluster_type") == "RKE2":
+        ns_list = ["cattle-system"]
+        ns_list.append(config["rke2_config"]["logging_namespace"])
+        ns_list.append(config["rke2_config"]["monitoring_namespace"])
+        for ns in ns_list:
+            adj_config["kube_config"]["namespace_default_endpoint_group"][ns] = ns_value
 
     if config["sriov_config"].get("enable"):
         adj_config["vendors"] = "15b3"

--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -5783,13 +5783,7 @@ class ApicKubeConfig(object):
                                                    kube_api_entries, api_filter_prefix, dns_entries, filter_prefix)
             elif flavor == "docker-ucp-3.0":
                 dockerucp_flavor_specific_handling(data, items, api_filter_prefix)
-            elif flavor == "RKE-1.2.3":
-                rke_flavor_specific_handling(aci_prefix, data, items, api_filter_prefix, self.config["rke_config"])
-            elif flavor == "RKE-1.3.13":
-                rke_flavor_specific_handling(aci_prefix, data, items, api_filter_prefix, self.config["rke_config"])
-            elif flavor == "RKE-1.3.17":
-                rke_flavor_specific_handling(aci_prefix, data, items, api_filter_prefix, self.config["rke_config"])
-            elif flavor == "RKE-1.3.18":
+            elif flavor.startswith("RKE"):
                 rke_flavor_specific_handling(aci_prefix, data, items, api_filter_prefix, self.config["rke_config"])
 
         # Adding prometheus opflex-agent contract for all flavors

--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -3741,6 +3741,60 @@ flavors:
             prot: tcp
             stateful: "no"
     order: 30
+  RKE2-kubernetes-1.24:
+    desc: Rancher Kubernetes Engine Government kubernetes version 1.24
+    default_version: 5.2.3.4 
+    config:
+      rke_config:
+        contracts:
+          - name: prometheus-monitoring
+            provided: ["aci-containers-system"]
+            consumed: ["aci-containers-istio"]
+            filter: "access-prometheus"
+        filters:
+          - name: access-prometheus
+            items:
+              - name: http
+                range: [8080, 8080]
+                etherT: ip
+                prot: tcp
+                stateful: "no"
+      kube_config:
+        allow_kube_api_default_epg: True
+        use_host_netns_volume: True
+        allow_pods_external_access: True
+        use_cnideploy_initcontainer: True
+      aci_config:
+        items:
+          - name: metrics-kubelet
+            range: [10250, 10250]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+          - name: monitoring-node
+            range: [9796, 9796]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+          - name: monitoring-ingress
+            range: [10254, 10254]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+          - name: rancher-ui
+            range: [443, 443]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+        vmm_domain:
+          type: Kubernetes
+          injected_cluster_type: RKE2
+          injected_cluster_provider: Rancher
+      istio_config:
+        install_istio: False
+    status: null
+    hidden: false
+    order: 47
   RKE-1.3.18:
     desc: Rancher Kubernetes Engine min version 1.3.18
     default_version: 5.2.3.4
@@ -3796,7 +3850,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 47
+    order: 48
   RKE-1.3.17:
     desc: Rancher Kubernetes Engine min version 1.3.17
     default_version: 5.2.3.4
@@ -3852,7 +3906,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 48
+    order: 49
   RKE-1.3.13:
     desc: Rancher Kubernetes Engine min version 1.3.13
     default_version: 5.2.3.4
@@ -3908,7 +3962,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 49
+    order: 50
   RKE-1.2.3:
     desc: Rancher Kubernetes Engine min version 1.2.3
     default_version: 5.2.3.4
@@ -3964,7 +4018,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 50
+    order: 51
   k8s-overlay:
     desc: Kubernetes basic overlay
     default_version: 5.2.3.4
@@ -4010,7 +4064,7 @@ flavors:
         enable: true
     status: Experimental
     hidden: true
-    order: 51
+    order: 52
   aks:
     desc: Azure Kubernetes Service
     default_version: 5.2.3.4
@@ -4069,7 +4123,7 @@ flavors:
                   prot: tcp
     status: Experimental
     hidden: true
-    order: 52
+    order: 53
   cloud:
     desc: Openshift IPI/AWS
     default_version: 5.2.3.4
@@ -4197,7 +4251,7 @@ flavors:
             
     status: Experimental
     hidden: true
-    order: 53
+    order: 54
   eks:
     desc: Elastic Kubernetes Service (aws)
     default_version: 5.2.3.4
@@ -4323,7 +4377,7 @@ flavors:
             
     status: Experimental
     hidden: true
-    order: 54
+    order: 55
   calico-3.23.2:
     desc: calico-3.23.2
     default_version: 3.23
@@ -4332,4 +4386,4 @@ flavors:
       template_generator: generate_calico_deployment_files
     status: Experimental
     hidden: False
-    order: 55
+    order: 56

--- a/provision/acc_provision/templates/cni/aci/5.2.3.3/provision-config.yaml
+++ b/provision/acc_provision/templates/cni/aci/5.2.3.3/provision-config.yaml
@@ -124,3 +124,9 @@ registry:
 
 #nodepodif_config:
   # enable: True     # default is False, set to True to enable ERSPAN feature
+
+# Configuration for RKE2 cluster
+
+#rke2_config:
+  # logging_namespace: "cattle-logging" #override if needed, default is "cattle-logging"
+  # monitoring_namespace: "cattle-prometheus" #override if needed, default is "cattle-prometheus"

--- a/provision/acc_provision/templates/cni/aci/5.2.3.4/provision-config.yaml
+++ b/provision/acc_provision/templates/cni/aci/5.2.3.4/provision-config.yaml
@@ -124,3 +124,9 @@ registry:
 
 #nodepodif_config:
   # enable: True     # default is False, set to True to enable ERSPAN feature
+
+# Configuration for RKE2 cluster
+
+#rke2_config:
+  # logging_namespace: "cattle-logging" #override if needed, default is "cattle-logging"
+  # monitoring_namespace: "cattle-prometheus" #override if needed, default is "cattle-prometheus"

--- a/provision/acc_provision/templates/cni/aci/5.2.3.5/provision-config.yaml
+++ b/provision/acc_provision/templates/cni/aci/5.2.3.5/provision-config.yaml
@@ -124,3 +124,9 @@ registry:
 
 #nodepodif_config:
   # enable: True     # default is False, set to True to enable ERSPAN feature
+
+# Configuration for RKE2 cluster
+
+#rke2_config:
+  # logging_namespace: "cattle-logging" #override if needed, default is "cattle-logging"
+  # monitoring_namespace: "cattle-prometheus" #override if needed, default is "cattle-prometheus"

--- a/provision/acc_provision/templates/cni/aci/5.2.3.6/provision-config.yaml
+++ b/provision/acc_provision/templates/cni/aci/5.2.3.6/provision-config.yaml
@@ -124,3 +124,9 @@ registry:
 
 #nodepodif_config:
   # enable: True     # default is False, set to True to enable ERSPAN feature
+
+# Configuration for RKE2 cluster
+
+#rke2_config:
+  # logging_namespace: "cattle-logging" #override if needed, default is "cattle-logging"
+  # monitoring_namespace: "cattle-prometheus" #override if needed, default is "cattle-prometheus"

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -916,6 +916,18 @@ def test_sriov_with_no_deviceinfo():
 
 
 @in_testdir
+def test_flavor_RKE2_kubernetes_1_24_base():
+    run_provision(
+        "flavor_RKE2_kubernetes_1_24.inp.yaml",
+        "flavor_RKE2_kubernetes_1_24.kube.yaml",
+        None,
+        None,
+        "flavor_RKE2_kubernetes_1_24.apic.txt",
+        overrides={"flavor": "RKE2-kubernetes-1.24"}
+    )
+
+
+@in_testdir
 def test_flavor_RKE_1_2_3_base():
     run_provision(
         "flavor_RKE_1_2_3.inp.yaml",

--- a/provision/testdata/flavor_RKE2_kubernetes_1_24.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_24.apic.txt
@@ -1,0 +1,1353 @@
+/api/mo/uni/infra/vlanns-[rke2-pool]-static.json
+{
+    "fvnsVlanInstP": {
+        "attributes": {
+            "name": "rke2-pool",
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvnsEncapBlk": {
+                    "attributes": {
+                        "allocMode": "static",
+                        "from": "vlan-4001",
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "fvnsEncapBlk": {
+                    "attributes": {
+                        "allocMode": "static",
+                        "from": "vlan-4003",
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra/maddrns-rke2-mpool.json
+{
+    "fvnsMcastAddrInstP": {
+        "attributes": {
+            "name": "rke2-mpool",
+            "dn": "uni/infra/maddrns-rke2-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvnsMcastAddrBlk": {
+                    "attributes": {
+                        "from": "225.2.1.1",
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke2-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke2-pdom",
+            "name": "rke2-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke2-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/vmmp-Kubernetes/dom-rke2.json
+{
+    "vmmDomP": {
+        "attributes": {
+            "name": "rke2",
+            "mode": "rancher",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "vmmCtrlrP": {
+                    "attributes": {
+                        "name": "rke2",
+                        "mode": "rancher",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "vmmRsDomMcastAddrNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/maddrns-rke2-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra.json
+{
+    "infraAttEntityP": {
+        "attributes": {
+            "name": "rke2-aep",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsDomP": {
+                    "attributes": {
+                        "tDn": "uni/vmmp-Kubernetes/dom-rke2",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "infraRsDomP": {
+                    "attributes": {
+                        "tDn": "uni/phys-rke2-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "infraProvAcc": {
+                    "attributes": {
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "infraRsFuncToEpg": {
+                                "attributes": {
+                                    "encap": "vlan-4093",
+                                    "mode": "regular",
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "dhcpInfraProvP": {
+                                "attributes": {
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "infraGeneric": {
+                    "attributes": {
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "infraRsFuncToEpg": {
+                                "attributes": {
+                                    "tDn": "uni/tn-rke2/ap-aci-containers-rke2/epg-aci-containers-nodes",
+                                    "encap": "vlan-4001",
+                                    "mode": "regular",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra/attentp-rke2-aep/rsdomP-[uni/vmmp-Kubernetes/dom-rke2].json
+None
+/api/mo/uni/infra/attentp-rke2-aep/rsdomP-[uni/phys-rke2-pdom].json
+None
+/api/mo/uni/infra/attentp-rke2-aep/gen-default/rsfuncToEpg-[uni/tn-rke2/ap-aci-containers-rke2/epg-aci-containers-nodes].json
+None
+/api/mo/uni/infra.json
+{
+    "infraSetPol": {
+        "attributes": {
+            "opflexpAuthenticateClients": "no",
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/node/mo/comp/prov-Kubernetes/ctrlr-[rke2]-rke2/injcont/info.json
+{
+    "vmmInjectedClusterInfo": {
+        "attributes": {
+            "name": "rke2",
+            "accountName": "rke2",
+            "type": "RKE2",
+            "provider": "Rancher"
+        },
+        "children": [
+            {
+                "vmmInjectedClusterDetails": {
+                    "attributes": {
+                        "accProvisionInput": "aci_config:\n  system_id: rke2\n  use_legacy_kube_naming_convention: False\n  apic_hosts:\n    - 10.30.120.100\n    - 10.30.120.101\n    - 10.30.120.102\n  apic_login:\n    username: admin\n    \n  apic_version: \"5.1\"\n  aep: rke2-aep\n  vrf:\n    name: rke2\n    tenant: common\n  l3out:\n    name: l3out\n    external_networks:\n    - default\n    - test_ext_net\n  sync_login:\n    certfile: user.crt\n    keyfile: user.key\n  vmm_domain:\n    encap_type: vxlan\n    mcast_range:\n        start: 225.2.1.1\n        end: 225.2.255.255\n\nnet_config:\n  node_subnet: 10.1.0.1/16\n  pod_subnet: 10.2.0.1/16\n  extern_dynamic: 10.3.0.1/24\n  extern_static: 10.4.0.1/24\n  node_svc_subnet: 10.5.0.1/24\n  pod_subnet_chunk_size: 256\n  kubeapi_vlan: 4001\n  service_vlan: 4003\n  infra_vlan: 4093\n\nlogging:\n  controller_log_level: info\n  hostagent_log_level: info\n  opflexagent_log_level: info\n\nrke2_config:\n  logging_namespace: \"cattle-logging-system\"\n  monitoring_namespace: \"cattle-monitoring-system\"\n",
+                        "userKey": "-----BEGIN PRIVATE KEY-----\nMIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBANr+A+gOKbAVVrJs\nb3+ZWbcnVXo/gduxITkvm09keiFCn+Up/SGdqv6Ah+jlJfF7uv+FgCJtCxD87qYw\n0q5DcGVLIcfF4ZUb9B8rJWKBI6wJfxtMfFuUNY24cgwQpJqrMUqADz/MW+wrZehs\nSnFsyewXR388eR7EKjDWegdJyPcXAgMBAAECgYB9AXb1ZfBCBUxB+UgETGM7+4X9\njHbyE0BlxlkfjrlwdvmS9M77+2Z6dKAgP33TRM/PwEMOY7RndBo+X6xDsVdcTJIy\n5Vw8xUZlr+auEOls2ZnZx11e5zh7sU3Nj5K35BWR9GTXJ6PMdpT49lB9bllMjDrL\n7+5bCsdu63O8KaN9YQJBAPGMbpHpFstC1cWGpRQx3iwF+ZLYArAUbCKbWQfbiZTp\nCS8DgOmyU7uKTRKiC+2RYTS3prLV57GvffFxJjTwGykCQQDoGBwf5iOsyuMQNz7K\nRirbD0J7R6YeQkJZ+pCeKwy+NyIqxh0LBDmBymSKvX0WEKCitOgpi32FWBoqHjf3\nMQg/AkBLBLRqeJvtsOo3mKO4a+x2e7yRUKk1CoKzFNBH0nUeXGnPwiTNb+b1ffSF\n7vIJbHdmKguJy0lUNA7HZ77X/iJRAkAjnbeLKZzl4kiP73piPfxLm37fPjJ+yDo4\nZpwUuZR+CCXlHHvOefp9MVrWc5ejcC/GaC6MWYyMjuWM+xApjcuvAkEAzY+p140C\nxwpr95linnvWcC7N708AJFim3/FU10GDo77yIOI5h+537JbYdm555hOeH/KjSekh\nEF4MmxRPmit99w==\n-----END PRIVATE KEY-----\n",
+                        "userCert": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common.json
+{
+    "fvTenant": {
+        "attributes": {
+            "name": "common",
+            "dn": "uni/tn-common"
+        },
+        "children": [
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "rke2-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "rke2-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "rke2-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common/flt-rke2-allow-all-filter.json
+None
+/api/mo/uni/tn-common/brc-rke2-l3out-allow-all.json
+None
+/api/mo/uni/tn-rke2.json
+{
+    "fvTenant": {
+        "attributes": {
+            "name": "rke2",
+            "dn": "uni/tn-rke2",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvAp": {
+                    "attributes": {
+                        "name": "aci-containers-rke2",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke2",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-istio",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke2-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "rke2-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-prometheus-opflex-agent",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "rke2-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke2",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke2-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-prometheus-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-prometheus-opflex-agent",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "rke2-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke2",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke2-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "encap": "vlan-4001",
+                                                "tDn": "uni/phys-rke2-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-prometheus-opflex-agent",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-istio",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-istio",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke2",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke2-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-prometheus-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "fvBD": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-node-bd",
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "10.1.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsCtx": {
+                                "attributes": {
+                                    "tnFvCtxName": "rke2",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsBDToOut": {
+                                "attributes": {
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "fvBD": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "10.2.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsCtx": {
+                                "attributes": {
+                                    "tnFvCtxName": "rke2",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsBDToOut": {
+                                "attributes": {
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "icmp",
+                                    "etherT": "ipv4",
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "icmp6",
+                                    "etherT": "ipv6",
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "health-check",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "health-check",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "stateful": "no",
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "dns-udp",
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "6443",
+                                    "dToPort": "6443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "8443",
+                                    "dToPort": "8443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "metrics-kubelet",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "10250",
+                                    "dToPort": "10250",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "monitoring-node",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9796",
+                                    "dToPort": "9796",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "monitoring-ingress",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "10254",
+                                    "dToPort": "10254",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "rancher-ui",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "443",
+                                    "dToPort": "443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-istio-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-9080",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "sFromPort": "9080",
+                                    "sToPort": "9080",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-mixer-9090:91",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9090",
+                                    "dToPort": "9091",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-prometheus-15090",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "sFromPort": "15090",
+                                    "sToPort": "15090",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot-15010:12",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-api",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "aci-containers-api-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke2-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "health-check-subj",
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzOutTerm": {
+                                            "attributes": {
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            },
+                                            "children": [
+                                                {
+                                                    "vzRsFiltAtt": {
+                                                        "attributes": {
+                                                            "tnVzFilterName": "aci-containers-rke2-health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "vzInTerm": {
+                                            "attributes": {
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            },
+                                            "children": [
+                                                {
+                                                    "vzRsFiltAtt": {
+                                                        "attributes": {
+                                                            "tnVzFilterName": "aci-containers-rke2-health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-dns",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke2-dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke2-icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-istio",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "istio-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke2-istio-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-prometheus-monitoring",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "aci-containers-rke2-prometheus-monitoring-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke2-access-prometheus",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-access-prometheus",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "http",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "8080",
+                                    "dToPort": "8080",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-prometheus-opflex-agent-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "prometheus-opflex-agent",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9612",
+                                    "dToPort": "9612",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-prometheus-opflex-agent",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "prometheus-opflex-agent-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke2-prometheus-opflex-agent-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-default.json
+{
+    "fvRsProv": {
+        "attributes": {
+            "matchT": "AtleastOne",
+            "tnVzBrCPName": "rke2-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-rke2-l3out-allow-all.json
+None
+/api/mo/uni/tn-common/out-l3out/instP-test_ext_net.json
+{
+    "fvRsProv": {
+        "attributes": {
+            "matchT": "AtleastOne",
+            "tnVzBrCPName": "rke2-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-test_ext_net/rsprov-rke2-l3out-allow-all.json
+None
+/api/node/mo/uni/userext/user-rke2.json
+{
+    "aaaUser": {
+        "attributes": {
+            "name": "rke2",
+            "accountStatus": "active",
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "aaaUserDomain": {
+                    "attributes": {
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "aaaUserRole": {
+                                "attributes": {
+                                    "name": "admin",
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/node/mo/uni/userext/user-rke2.json
+{
+    "aaaUser": {
+        "attributes": {
+            "name": "rke2",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "aaaUserCert": {
+                    "attributes": {
+                        "name": "rke2.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/provision/testdata/flavor_RKE2_kubernetes_1_24.inp.yaml
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_24.inp.yaml
@@ -1,0 +1,48 @@
+aci_config:
+  system_id: rke2
+  use_legacy_kube_naming_convention: False
+  apic_hosts:
+    - 10.30.120.100
+    - 10.30.120.101
+    - 10.30.120.102
+  apic_login:
+    username: admin
+    password: dummy
+  apic_version: "5.1"
+  aep: rke2-aep
+  vrf:
+    name: rke2
+    tenant: common
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+    - test_ext_net
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+
+net_config:
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  pod_subnet_chunk_size: 256
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info
+
+rke2_config:
+  logging_namespace: "cattle-logging-system"
+  monitoring_namespace: "cattle-monitoring-system"

--- a/provision/testdata/flavor_RKE2_kubernetes_1_24.kube.yaml
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_24.kube.yaml
@@ -1,0 +1,2481 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: acicontainersoperators.aci.ctrl
+spec:
+  group: aci.ctrl
+  names:
+    kind: AciContainersOperator
+    listKind: AciContainersOperatorList
+    plural: acicontainersoperators
+    singular: acicontainersoperator
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: acicontainersoperator owns the lifecycle of ACI objects in the cluster
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AciContainersOperatorSpec defines the desired spec for ACI Objects
+            properties:
+              flavor:
+                type: string
+              config:
+                type: string
+            type: object
+          status:
+            description: AciContainersOperatorStatus defines the successful completion of AciContainersOperator
+            properties:
+              status:
+                type: boolean
+            type: object
+        required:
+        - spec
+        type: object
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  annotations:
+    openshift.io/node-selector: ''
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nodepodifs.aci.aw
+spec:
+  group: aci.aw
+  names:
+    kind: NodePodIF
+    listKind: NodePodIFList
+    plural: nodepodifs
+    singular: nodepodif
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            properties:
+              podifs:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    containerID:
+                      type: string
+                    epg:
+                      type: string
+                    ifname:
+                      type: string
+                    ipaddr:
+                      type: string
+                    macaddr:
+                      type: string
+                    podname:
+                      type: string
+                    podns:
+                      type: string
+                    vtep:
+                      type: string
+        required:
+        - spec
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatglobalinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatGlobalInfo
+    listKind: SnatGlobalInfoList
+    plural: snatglobalinfos
+    singular: snatglobalinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: SnatGlobalInfo is the Schema for the snatglobalinfos API
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              globalInfos:
+                additionalProperties:
+                  items:
+                    properties:
+                      macAddress:
+                        type: string
+                      portRanges:
+                        items:
+                          properties:
+                            end:
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            start:
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          type: object
+                        type: array
+                      snatIp:
+                        type: string
+                      snatIpUid:
+                        type: string
+                      snatPolicyName:
+                        type: string
+                    required:
+                    - macAddress
+                    - portRanges
+                    - snatIp
+                    - snatIpUid
+                    - snatPolicyName
+                    type: object
+                  type: array
+                type: object
+            required:
+            - globalInfos
+            type: object
+          status:
+            description: SnatGlobalInfoStatus defines the observed state of SnatGlobalInfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatlocalinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatLocalInfo
+    listKind: SnatLocalInfoList
+    plural: snatlocalinfos
+    singular: snatlocalinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SnatLocalInfoSpec defines the desired state of SnatLocalInfo
+            properties:
+              localInfos:
+                items:
+                  properties:
+                    podName:
+                      type: string
+                    podNamespace:
+                      type: string
+                    podUid:
+                      type: string
+                    snatPolicies:
+                      items:
+                        properties:
+                          destIp:
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            type: string
+                          snatIp:
+                            type: string
+                        required:
+                        - destIp
+                        - name
+                        - snatIp
+                        type: object
+                      type: array
+                  required:
+                  - podName
+                  - podNamespace
+                  - podUid
+                  - snatPolicies
+                  type: object
+                type: array
+            required:
+            - localInfos
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatpolicies.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatPolicy
+    listKind: SnatPolicyList
+    plural: snatpolicies
+    singular: snatpolicy
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            properties:
+              selector:
+                type: object
+                properties:
+                  labels:
+                    type: object
+                    description: 'Selection of Pods'
+                    properties:
+                    additionalProperties:
+                      type: string
+                  namespace:
+                    type: string
+                type: object
+              snatIp:
+                type: array
+                items:
+                  type: string
+              destIp:
+                type: array
+                items:
+                  type: string
+            type: object
+          status:
+            type: object
+            properties:
+            additionalProperties:
+              type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nodeinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: NodeInfo
+    listKind: NodeInfoList
+    plural: nodeinfos
+    singular: nodeinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              macaddress:
+                type: string
+              snatpolicynames:
+                additionalProperties:
+                  type: boolean
+                type: object
+            type: object
+          status:
+            description: NodeinfoStatus defines the observed state of Nodeinfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rdconfigs.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: RdConfig
+    listKind: RdConfigList
+    plural: rdconfigs
+    singular: rdconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              discoveredsubnets:
+                items:
+                  type: string
+                type: array
+              usersubnets:
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: NodeinfoStatus defines the observed state of Nodeinfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.aci.netpol
+spec:
+  group: aci.netpol
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Network Policy describes traffic flow at IP address or port level
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              appliedTo:
+                properties:
+                  namespaceSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  podSelector:
+                    description: allow ingress from the same namespace
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+              egress:
+                description: Set of egress rules evaluated based on the order in which they are set.
+                items:
+                  properties:
+                    action:
+                      description: Action specifies the action to be applied on the rule.
+                      type: string
+                    enableLogging:
+                      description: EnableLogging is used to indicate if agent should generate logs default to false.
+                      type: boolean
+                    ports:
+                      description: Set of port and protocol allowed/denied by the rule. If this field is unset or empty, this rule matches all ports.
+                      items:
+                        description: NetworkPolicyPort describes the port and protocol to match in a rule.
+                        properties:
+                          endPort:
+                            description: EndPort defines the end of the port range, being the end included within the range. It can only be specified when a numerical `port` is specified.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can be either a numerical or named port on a Pod. If this field is not provided, this matches all port names and numbers.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            default: TCP
+                            description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      description: Rule is matched if traffic is intended for workloads selected by this field. If this field is empty or missing, this rule matches all destinations.
+                      items:
+                        properties:
+                          ipBlock:
+                            description: IPBlock describes the IPAddresses/IPBlocks that is matched in to/from. IPBlock cannot be set as part of the AppliedTo field. Cannot be set with any other selector.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            description: Select all Pods from Namespaces matched by this selector, as workloads in To/From fields. If set with PodSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except PodSelector or ExternalEntitySelector.
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          podSelector:
+                            description: Select Pods from NetworkPolicy's Namespace as workloads in AppliedTo/To/From fields. If set with NamespaceSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    toFqDn:
+                      properties:
+                        matchNames:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - matchNames
+                      type: object
+                  required:
+                  - enableLogging
+                  - toFqDn
+                  type: object
+                type: array
+              ingress:
+                description: Set of ingress rules evaluated based on the order in which they are set.
+                items:
+                  properties:
+                    action:
+                      description: Action specifies the action to be applied on the rule.
+                      type: string
+                    enableLogging:
+                      description: EnableLogging is used to indicate if agent should generate logs when rules are matched. Should be default to false.
+                      type: boolean
+                    from:
+                      description: Rule is matched if traffic originates from workloads selected by this field. If this field is empty, this rule matches all sources.
+                      items:
+                        properties:
+                          ipBlock:
+                            description: IPBlock describes the IPAddresses/IPBlocks that is matched in to/from. IPBlock cannot be set as part of the AppliedTo field. Cannot be set with any other selector.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          podSelector:
+                            description: Select Pods from NetworkPolicy's Namespace as workloads in AppliedTo/To/From fields. If set with NamespaceSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    ports:
+                      description: Set of port and protocol allowed/denied by the rule. If this field is unset or empty, this rule matches all ports.
+                      items:
+                        description: NetworkPolicyPort describes the port and protocol to match in a rule.
+                        properties:
+                          endPort:
+                            description: EndPort defines the end of the port range, being the end included within the range. It can only be specified when a numerical `port` is specified.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can be either a numerical or named port on a Pod. If this field is not provided, this matches all port names and numbers.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            default: TCP
+                            description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              policyTypes:
+                items:
+                  description: Policy Type string describes the NetworkPolicy type This type is beta-level in 1.8
+                  type: string
+                type: array
+              priority:
+                description: Priority specfies the order of the NetworkPolicy relative to other NetworkPolicies.
+                type: integer
+              type:
+                description: type of the policy.
+                type: string
+            required:
+            - type
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dnsnetworkpolicies.aci.dnsnetpol
+spec:
+  group: aci.dnsnetpol
+  names:
+    kind: DnsNetworkPolicy
+    listKind: DnsNetworkPolicyList
+    plural: dnsnetworkpolicies
+    singular: dnsnetworkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1beta
+    schema:
+      openAPIV3Schema:
+        description: dns network Policy
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              appliedTo:
+                properties:
+                  namespaceSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  podSelector:
+                    description: allow ingress from the same namespace
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+              egress:
+                description: Set of egress rules evaluated based on the order in which they are set.
+                properties:
+                  toFqdn:
+                    properties:
+                      matchNames:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - matchNames
+                    type: object
+                required:
+                - toFqdn
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: qospolicies.aci.qos
+spec:
+  group: aci.qos
+  names:
+    kind: QosPolicy
+    listKind: QosPolicyList
+    plural: qospolicies
+    singular: qospolicy
+  scope: Namespaced
+  preserveUnknownFields: false
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              podSelector:
+                description: 'Selection of Pods'
+                type: object
+                properties:
+                  matchLabels:
+                    type: object
+                    description:
+              ingress:
+                type: object
+                properties:
+                  policing_rate:
+                    type: integer
+                    minimum: 0
+                  policing_burst:
+                    type: integer
+                    minimum: 0
+              egress:
+                type: object
+                properties:
+                  policing_rate:
+                    type: integer
+                    minimum: 0
+                  policing_burst:
+                    type: integer
+                    minimum: 0
+              dscpmark:
+                type: integer
+                default: 0
+                minimum: 0
+                maximum: 63
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: netflowpolicies.aci.netflow
+spec:
+  group: aci.netflow
+  names:
+    kind: NetflowPolicy
+    listKind: NetflowPolicyList
+    plural: netflowpolicies
+    singular: netflowpolicy
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+  - name: v1alpha
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              flowSamplingPolicy:
+                type: object
+                properties:
+                  destIp:
+                    type: string
+                  destPort:
+                    type: integer
+                    minimum: 0
+                    maximum: 65535
+                    default: 2055
+                  flowType:
+                    type: string
+                    enum:
+                      - netflow
+                      - ipfix
+                    default: netflow
+                  activeFlowTimeOut:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                    default: 60
+                  idleFlowTimeOut:
+                    type: integer
+                    minimum: 0
+                    maximum: 600
+                    default: 15
+                  samplingRate:
+                    type: integer
+                    minimum: 0
+                    maximum: 1000
+                    default: 0
+                required:
+                - destIp
+                type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: erspanpolicies.aci.erspan
+spec:
+  group: aci.erspan
+  names:
+    kind: ErspanPolicy
+    listKind: ErspanPolicyList
+    plural: erspanpolicies
+    singular: erspanpolicy
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+  - name: v1alpha
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              selector:
+                type: object
+                description: 'Selection of Pods'
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+                  namespace:
+                    type: string
+              source:
+                type: object
+                properties:
+                  adminState:
+                    description: Administrative state.
+                    default: start
+                    type: string
+                    enum:
+                      - start
+                      - stop
+                  direction:
+                    description: Direction of the packets to monitor.
+                    default: both
+                    type: string
+                    enum:
+                      - in
+                      - out
+                      - both
+              destination:
+                type: object
+                properties:
+                  destIP:
+                    description: Destination IP of the ERSPAN packet.
+                    type: string
+                  flowID:
+                    description: Unique flow ID of the ERSPAN packet.
+                    default: 1
+                    type: integer
+                    minimum: 1
+                    maximum: 1023
+                required:
+                - destIP
+                type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: enabledroplogs.aci.droplog
+spec:
+  group: aci.droplog
+  names:
+    kind: EnableDropLog
+    listKind: EnableDropLogList
+    plural: enabledroplogs
+    singular: enabledroplog
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            description: Defines the desired state of EnableDropLog
+            type: object
+            properties:
+              disableDefaultDropLog:
+                description: Disables the default droplog enabled by acc-provision.
+                default: false
+                type: boolean
+              nodeSelector:
+                type: object
+                description: Drop logging is enabled on nodes selected based on labels
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: prunedroplogs.aci.droplog
+spec:
+  group: aci.droplog
+  names:
+    kind: PruneDropLog
+    listKind: PruneDropLogList
+    plural: prunedroplogs
+    singular: prunedroplog
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            description: Defines the desired state of PruneDropLog
+            type: object
+            properties:
+              nodeSelector:
+                type: object
+                description: Drop logging filters are applied to nodes selected based on labels
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+              dropLogFilters:
+                type: object
+                properties:
+                  srcIP:
+                    type: string
+                  destIP:
+                    type: string
+                  srcMAC:
+                    type: string
+                  destMAC:
+                    type: string
+                  srcPort:
+                    type: integer
+                  destPort:
+                    type: integer
+                  ipProto:
+                    type: integer
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: accprovisioninputs.aci.ctrl
+spec:
+  group: aci.ctrl
+  names:
+    kind: AccProvisionInput
+    listKind: AccProvisionInputList
+    plural: accprovisioninputs
+    singular: accprovisioninput
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: accprovisioninput defines the input configuration for ACI CNI
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AccProvisionInputSpec defines the desired spec for accprovisioninput object
+            properties:
+              acc_provision_input:
+                type: object
+                properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
+                  aci_config:
+                    type: object
+                    properties:
+                      sync_login:
+                        type: object
+                        properties:
+                          certfile:
+                            type: string
+                          keyfile:
+                            type: string
+                      client_ssl:
+                        type: boolean
+                  net_config:
+                    type: object
+                    properties:
+                      interface_mtu:
+                        type: integer
+                      service_monitor_interval:
+                        type: integer
+                      pbr_tracking_non_snat:
+                        type: boolean
+                      pod_subnet_chunk_size:
+                        type: integer
+                      disable_wait_for_network:
+                        type: boolean
+                      duration_wait_for_network:
+                        type: integer
+                  registry:
+                    type: object
+                    properties:
+                      image_prefix:
+                        type: string
+                      image_pull_secret:
+                        type: string
+                      aci_containers_operator_version:
+                        type: string
+                      aci_containers_controller_version:
+                        type: string
+                      aci_containers_host_version:
+                        type: string
+                      acc_provision_operator_version:
+                        type: string
+                      aci_cni_operator_version:
+                        type: string
+                      cnideploy_version:
+                        type: string
+                      opflex_agent_version:
+                        type: string
+                      openvswitch_version:
+                        type: string
+                      gbp_version:
+                        type: string
+                  logging:
+                    type: object
+                    properties:
+                      size:
+                        type: integer
+                      controller_log_level:
+                        type: string
+                      hostagent_log_level:
+                        type: string
+                      opflexagent_log_level:
+                        type: string
+                  istio_config:
+                    type: object
+                    properties:
+                      install_istio:
+                        type: boolean
+                      install_profile:
+                        type: string
+                  multus:
+                    type: object
+                    properties:
+                      disable:
+                        type: boolean
+                  drop_log_config:
+                    type: object
+                    properties:
+                      enable:
+                        type: boolean
+                  nodepodif_config:
+                    type: object
+                    properties:
+                      enable:
+                        type: boolean
+                  sriov_config:
+                    type: object
+                    properties:
+                      enable:
+                        type: boolean
+                  kube_config:
+                    type: object
+                    properties:
+                      ovs_memory_limit:
+                        type: string
+                      use_privileged_containers:
+                        type: boolean
+                      image_pull_policy:
+                        type: string
+                      reboot_opflex_with_ovs:
+                        type: string
+                      snat_operator:
+                        type: object
+                        properties:
+                          port_range:
+                            type: object
+                            properties:
+                              start:
+                                type: integer
+                              end:
+                                type: integer
+                              ports_per_node:
+                                type: integer
+                          contract_scope:
+                            type: string
+                          disable_periodic_snat_global_info_sync:
+                            type: boolean
+            type: object
+          status:
+            description: AccProvisionInputStatus defines the successful completion of AccProvisionInput
+            properties:
+              status:
+                type: boolean
+            type: object
+        required:
+        - spec
+        type: object
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aci-operator-config
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  spec: |-
+    {
+        "flavor": "RKE2-kubernetes-1.24",
+        "config": "CmFwaVZlcnNpb246IHYxCmtpbmQ6IE5hbWVzcGFjZQptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVycy1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgYW5ub3RhdGlvbnM6CiAgICBvcGVuc2hpZnQuaW8vbm9kZS1zZWxlY3RvcjogJycKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBub2RlcG9kaWZzLmFjaS5hdwpzcGVjOgogIGdyb3VwOiBhY2kuYXcKICBuYW1lczoKICAgIGtpbmQ6IE5vZGVQb2RJRgogICAgbGlzdEtpbmQ6IE5vZGVQb2RJRkxpc3QKICAgIHBsdXJhbDogbm9kZXBvZGlmcwogICAgc2luZ3VsYXI6IG5vZGVwb2RpZgogIHNjb3BlOiBOYW1lc3BhY2VkCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIHBvZGlmczoKICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgY29udGFpbmVySUQ6CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICBlcGc6CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICBpZm5hbWU6CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICBpcGFkZHI6CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICBtYWNhZGRyOgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgcG9kbmFtZToKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIHBvZG5zOgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgdnRlcDoKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgIHJlcXVpcmVkOgogICAgICAgIC0gc3BlYwogICAgICAgIHR5cGU6IG9iamVjdAotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IHNuYXRnbG9iYWxpbmZvcy5hY2kuc25hdApzcGVjOgogIGdyb3VwOiBhY2kuc25hdAogIG5hbWVzOgogICAga2luZDogU25hdEdsb2JhbEluZm8KICAgIGxpc3RLaW5kOiBTbmF0R2xvYmFsSW5mb0xpc3QKICAgIHBsdXJhbDogc25hdGdsb2JhbGluZm9zCiAgICBzaW5ndWxhcjogc25hdGdsb2JhbGluZm8KICBzY29wZTogTmFtZXNwYWNlZAogIHZlcnNpb25zOgogIC0gbmFtZTogdjEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgZGVzY3JpcHRpb246IFNuYXRHbG9iYWxJbmZvIGlzIHRoZSBTY2hlbWEgZm9yIHRoZSBzbmF0Z2xvYmFsaW5mb3MgQVBJCiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIGdsb2JhbEluZm9zOgogICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICBtYWNBZGRyZXNzOgogICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgIHBvcnRSYW5nZXM6CiAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBlbmQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIG1heGltdW06IDY1NTM1CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIG1pbmltdW06IDEKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgICAgICAgICAgICAgICAgc3RhcnQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIG1heGltdW06IDY1NTM1CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIG1pbmltdW06IDEKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgc25hdElwOgogICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgIHNuYXRJcFVpZDoKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICBzbmF0UG9saWN5TmFtZToKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgLSBtYWNBZGRyZXNzCiAgICAgICAgICAgICAgICAgICAgLSBwb3J0UmFuZ2VzCiAgICAgICAgICAgICAgICAgICAgLSBzbmF0SXAKICAgICAgICAgICAgICAgICAgICAtIHNuYXRJcFVpZAogICAgICAgICAgICAgICAgICAgIC0gc25hdFBvbGljeU5hbWUKICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgLSBnbG9iYWxJbmZvcwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHN0YXR1czoKICAgICAgICAgICAgZGVzY3JpcHRpb246IFNuYXRHbG9iYWxJbmZvU3RhdHVzIGRlZmluZXMgdGhlIG9ic2VydmVkIHN0YXRlIG9mIFNuYXRHbG9iYWxJbmZvCiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHR5cGU6IG9iamVjdAotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IHNuYXRsb2NhbGluZm9zLmFjaS5zbmF0CnNwZWM6CiAgZ3JvdXA6IGFjaS5zbmF0CiAgbmFtZXM6CiAgICBraW5kOiBTbmF0TG9jYWxJbmZvCiAgICBsaXN0S2luZDogU25hdExvY2FsSW5mb0xpc3QKICAgIHBsdXJhbDogc25hdGxvY2FsaW5mb3MKICAgIHNpbmd1bGFyOiBzbmF0bG9jYWxpbmZvCiAgc2NvcGU6IE5hbWVzcGFjZWQKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgbWV0YWRhdGE6CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgZGVzY3JpcHRpb246IFNuYXRMb2NhbEluZm9TcGVjIGRlZmluZXMgdGhlIGRlc2lyZWQgc3RhdGUgb2YgU25hdExvY2FsSW5mbwogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIGxvY2FsSW5mb3M6CiAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICBwb2ROYW1lOgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgcG9kTmFtZXNwYWNlOgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgcG9kVWlkOgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgc25hdFBvbGljaWVzOgogICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzdElwOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICBuYW1lOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgc25hdElwOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgICAgICAtIGRlc3RJcAogICAgICAgICAgICAgICAgICAgICAgICAtIG5hbWUKICAgICAgICAgICAgICAgICAgICAgICAgLSBzbmF0SXAKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgLSBwb2ROYW1lCiAgICAgICAgICAgICAgICAgIC0gcG9kTmFtZXNwYWNlCiAgICAgICAgICAgICAgICAgIC0gcG9kVWlkCiAgICAgICAgICAgICAgICAgIC0gc25hdFBvbGljaWVzCiAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgIC0gbG9jYWxJbmZvcwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBzbmF0cG9saWNpZXMuYWNpLnNuYXQKc3BlYzoKICBncm91cDogYWNpLnNuYXQKICBuYW1lczoKICAgIGtpbmQ6IFNuYXRQb2xpY3kKICAgIGxpc3RLaW5kOiBTbmF0UG9saWN5TGlzdAogICAgcGx1cmFsOiBzbmF0cG9saWNpZXMKICAgIHNpbmd1bGFyOiBzbmF0cG9saWN5CiAgc2NvcGU6IENsdXN0ZXIKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHN1YnJlc291cmNlczoKICAgICAgc3RhdHVzOiB7fQogICAgc2NoZW1hOgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBtZXRhZGF0YToKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzcGVjOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBzZWxlY3RvcjoKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgbGFiZWxzOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiAnU2VsZWN0aW9uIG9mIFBvZHMnCiAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICBuYW1lc3BhY2U6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICBzbmF0SXA6CiAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgIGRlc3RJcDoKICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3RhdHVzOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCi0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogbm9kZWluZm9zLmFjaS5zbmF0CnNwZWM6CiAgZ3JvdXA6IGFjaS5zbmF0CiAgbmFtZXM6CiAgICBraW5kOiBOb2RlSW5mbwogICAgbGlzdEtpbmQ6IE5vZGVJbmZvTGlzdAogICAgcGx1cmFsOiBub2RlaW5mb3MKICAgIHNpbmd1bGFyOiBub2RlaW5mbwogIHNjb3BlOiBOYW1lc3BhY2VkCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgbWFjYWRkcmVzczoKICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgIHNuYXRwb2xpY3luYW1lczoKICAgICAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICB0eXBlOiBib29sZWFuCiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICBzdGF0dXM6CiAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBOb2RlaW5mb1N0YXR1cyBkZWZpbmVzIHRoZSBvYnNlcnZlZCBzdGF0ZSBvZiBOb2RlaW5mbwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICB0eXBlOiBvYmplY3QKLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiByZGNvbmZpZ3MuYWNpLnNuYXQKc3BlYzoKICBncm91cDogYWNpLnNuYXQKICBuYW1lczoKICAgIGtpbmQ6IFJkQ29uZmlnCiAgICBsaXN0S2luZDogUmRDb25maWdMaXN0CiAgICBwbHVyYWw6IHJkY29uZmlncwogICAgc2luZ3VsYXI6IHJkY29uZmlnCiAgc2NvcGU6IE5hbWVzcGFjZWQKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxCiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKICAgIHNjaGVtYToKICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgbWV0YWRhdGE6CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBkaXNjb3ZlcmVkc3VibmV0czoKICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgdXNlcnN1Ym5ldHM6CiAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHN0YXR1czoKICAgICAgICAgICAgZGVzY3JpcHRpb246IE5vZGVpbmZvU3RhdHVzIGRlZmluZXMgdGhlIG9ic2VydmVkIHN0YXRlIG9mIE5vZGVpbmZvCiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHR5cGU6IG9iamVjdAotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IG5ldHdvcmtwb2xpY2llcy5hY2kubmV0cG9sCnNwZWM6CiAgZ3JvdXA6IGFjaS5uZXRwb2wKICBuYW1lczoKICAgIGtpbmQ6IE5ldHdvcmtQb2xpY3kKICAgIGxpc3RLaW5kOiBOZXR3b3JrUG9saWN5TGlzdAogICAgcGx1cmFsOiBuZXR3b3JrcG9saWNpZXMKICAgIHNpbmd1bGFyOiBuZXR3b3JrcG9saWN5CiAgc2NvcGU6IE5hbWVzcGFjZWQKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxCiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICBkZXNjcmlwdGlvbjogTmV0d29yayBQb2xpY3kgZGVzY3JpYmVzIHRyYWZmaWMgZmxvdyBhdCBJUCBhZGRyZXNzIG9yIHBvcnQgbGV2ZWwKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgYXBwbGllZFRvOgogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgbmFtZXNwYWNlU2VsZWN0b3I6CiAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgIG1hdGNoRXhwcmVzc2lvbnM6CiAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBrZXk6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgb3BlcmF0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFsdWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgICAtIGtleQogICAgICAgICAgICAgICAgICAgICAgICAgIC0gb3BlcmF0b3IKICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgIG1hdGNoTGFiZWxzOgogICAgICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgIHBvZFNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBhbGxvdyBpbmdyZXNzIGZyb20gdGhlIHNhbWUgbmFtZXNwYWNlCiAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgIG1hdGNoRXhwcmVzc2lvbnM6CiAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBrZXk6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgb3BlcmF0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFsdWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgICAtIGtleQogICAgICAgICAgICAgICAgICAgICAgICAgIC0gb3BlcmF0b3IKICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgIG1hdGNoTGFiZWxzOgogICAgICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICBlZ3Jlc3M6CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogU2V0IG9mIGVncmVzcyBydWxlcyBldmFsdWF0ZWQgYmFzZWQgb24gdGhlIG9yZGVyIGluIHdoaWNoIHRoZXkgYXJlIHNldC4KICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgIGFjdGlvbjoKICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBBY3Rpb24gc3BlY2lmaWVzIHRoZSBhY3Rpb24gdG8gYmUgYXBwbGllZCBvbiB0aGUgcnVsZS4KICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIGVuYWJsZUxvZ2dpbmc6CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRW5hYmxlTG9nZ2luZyBpcyB1c2VkIHRvIGluZGljYXRlIGlmIGFnZW50IHNob3VsZCBnZW5lcmF0ZSBsb2dzIGRlZmF1bHQgdG8gZmFsc2UuCiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBib29sZWFuCiAgICAgICAgICAgICAgICAgICAgcG9ydHM6CiAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogU2V0IG9mIHBvcnQgYW5kIHByb3RvY29sIGFsbG93ZWQvZGVuaWVkIGJ5IHRoZSBydWxlLiBJZiB0aGlzIGZpZWxkIGlzIHVuc2V0IG9yIGVtcHR5LCB0aGlzIHJ1bGUgbWF0Y2hlcyBhbGwgcG9ydHMuCiAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IE5ldHdvcmtQb2xpY3lQb3J0IGRlc2NyaWJlcyB0aGUgcG9ydCBhbmQgcHJvdG9jb2wgdG8gbWF0Y2ggaW4gYSBydWxlLgogICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGVuZFBvcnQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRW5kUG9ydCBkZWZpbmVzIHRoZSBlbmQgb2YgdGhlIHBvcnQgcmFuZ2UsIGJlaW5nIHRoZSBlbmQgaW5jbHVkZWQgd2l0aGluIHRoZSByYW5nZS4gSXQgY2FuIG9ubHkgYmUgc3BlY2lmaWVkIHdoZW4gYSBudW1lcmljYWwgYHBvcnRgIGlzIHNwZWNpZmllZC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIGZvcm1hdDogaW50MzIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICBwb3J0OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgYW55T2Y6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0gdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogVGhlIHBvcnQgb24gdGhlIGdpdmVuIHByb3RvY29sLiBUaGlzIGNhbiBiZSBlaXRoZXIgYSBudW1lcmljYWwgb3IgbmFtZWQgcG9ydCBvbiBhIFBvZC4gSWYgdGhpcyBmaWVsZCBpcyBub3QgcHJvdmlkZWQsIHRoaXMgbWF0Y2hlcyBhbGwgcG9ydCBuYW1lcyBhbmQgbnVtYmVycy4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIHgta3ViZXJuZXRlcy1pbnQtb3Itc3RyaW5nOiB0cnVlCiAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvdG9jb2w6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZWZhdWx0OiBUQ1AKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBUaGUgcHJvdG9jb2wgKFRDUCwgVURQLCBvciBTQ1RQKSB3aGljaCB0cmFmZmljIG11c3QgbWF0Y2guIElmIG5vdCBzcGVjaWZpZWQsIHRoaXMgZmllbGQgZGVmYXVsdHMgdG8gVENQLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICB0bzoKICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBSdWxlIGlzIG1hdGNoZWQgaWYgdHJhZmZpYyBpcyBpbnRlbmRlZCBmb3Igd29ya2xvYWRzIHNlbGVjdGVkIGJ5IHRoaXMgZmllbGQuIElmIHRoaXMgZmllbGQgaXMgZW1wdHkgb3IgbWlzc2luZywgdGhpcyBydWxlIG1hdGNoZXMgYWxsIGRlc3RpbmF0aW9ucy4KICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgIGlwQmxvY2s6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogSVBCbG9jayBkZXNjcmliZXMgdGhlIElQQWRkcmVzc2VzL0lQQmxvY2tzIHRoYXQgaXMgbWF0Y2hlZCBpbiB0by9mcm9tLiBJUEJsb2NrIGNhbm5vdCBiZSBzZXQgYXMgcGFydCBvZiB0aGUgQXBwbGllZFRvIGZpZWxkLiBDYW5ub3QgYmUgc2V0IHdpdGggYW55IG90aGVyIHNlbGVjdG9yLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgY2lkcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogQ0lEUiBpcyBhIHN0cmluZyByZXByZXNlbnRpbmcgdGhlIElQIEJsb2NrIFZhbGlkIGV4YW1wbGVzIGFyZSAiMTkyLjE2OC4xLjEvMjQiIG9yICIyMDAxOmRiOTo6LzY0IgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBleGNlcHQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEV4Y2VwdCBpcyBhIHNsaWNlIG9mIENJRFJzIHRoYXQgc2hvdWxkIG5vdCBiZSBpbmNsdWRlZCB3aXRoaW4gYW4gSVAgQmxvY2sgVmFsaWQgZXhhbXBsZXMgYXJlICIxOTIuMTY4LjEuMS8yNCIgb3IgIjIwMDE6ZGI5OjovNjQiIEV4Y2VwdCB2YWx1ZXMgd2lsbCBiZSByZWplY3RlZCBpZiB0aGV5IGFyZSBvdXRzaWRlIHRoZSBDSURSIHJhbmdlCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIGNpZHIKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgIG5hbWVzcGFjZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNlbGVjdCBhbGwgUG9kcyBmcm9tIE5hbWVzcGFjZXMgbWF0Y2hlZCBieSB0aGlzIHNlbGVjdG9yLCBhcyB3b3JrbG9hZHMgaW4gVG8vRnJvbSBmaWVsZHMuIElmIHNldCB3aXRoIFBvZFNlbGVjdG9yLCBQb2RzIGFyZSBtYXRjaGVkIGZyb20gTmFtZXNwYWNlcyBtYXRjaGVkIGJ5IHRoZSBOYW1lc3BhY2VTZWxlY3Rvci4gQ2Fubm90IGJlIHNldCB3aXRoIGFueSBvdGhlciBzZWxlY3RvciBleGNlcHQgUG9kU2VsZWN0b3Igb3IgRXh0ZXJuYWxFbnRpdHlTZWxlY3Rvci4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIG1hdGNoRXhwcmVzc2lvbnM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBrZXk6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBvcGVyYXRvciByZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy4gVmFsaWQgb3BlcmF0b3JzIGFyZSBJbiwgTm90SW4sIEV4aXN0cyBhbmQgRG9lc05vdEV4aXN0LgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YWx1ZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IHZhbHVlcyBpcyBhbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sIHRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljIG1lcmdlIHBhdGNoLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0gb3BlcmF0b3IKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIG1hdGNoTGFiZWxzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICBwb2RTZWxlY3RvcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTZWxlY3QgUG9kcyBmcm9tIE5ldHdvcmtQb2xpY3kncyBOYW1lc3BhY2UgYXMgd29ya2xvYWRzIGluIEFwcGxpZWRUby9Uby9Gcm9tIGZpZWxkcy4gSWYgc2V0IHdpdGggTmFtZXNwYWNlU2VsZWN0b3IsIFBvZHMgYXJlIG1hdGNoZWQgZnJvbSBOYW1lc3BhY2VzIG1hdGNoZWQgYnkgdGhlIE5hbWVzcGFjZVNlbGVjdG9yLiBDYW5ub3QgYmUgc2V0IHdpdGggYW55IG90aGVyIHNlbGVjdG9yIGV4Y2VwdCBOYW1lc3BhY2VTZWxlY3Rvci4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIG1hdGNoRXhwcmVzc2lvbnM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBrZXk6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIG9wZXJhdG9yOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBvcGVyYXRvciByZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy4gVmFsaWQgb3BlcmF0b3JzIGFyZSBJbiwgTm90SW4sIEV4aXN0cyBhbmQgRG9lc05vdEV4aXN0LgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YWx1ZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IHZhbHVlcyBpcyBhbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sIHRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljIG1lcmdlIHBhdGNoLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgLSBrZXkKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0gb3BlcmF0b3IKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIG1hdGNoTGFiZWxzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgIHRvRnFEbjoKICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgIG1hdGNoTmFtZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgICAtIG1hdGNoTmFtZXMKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgLSBlbmFibGVMb2dnaW5nCiAgICAgICAgICAgICAgICAgIC0gdG9GcURuCiAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICBpbmdyZXNzOgogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFNldCBvZiBpbmdyZXNzIHJ1bGVzIGV2YWx1YXRlZCBiYXNlZCBvbiB0aGUgb3JkZXIgaW4gd2hpY2ggdGhleSBhcmUgc2V0LgogICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgYWN0aW9uOgogICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IEFjdGlvbiBzcGVjaWZpZXMgdGhlIGFjdGlvbiB0byBiZSBhcHBsaWVkIG9uIHRoZSBydWxlLgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgZW5hYmxlTG9nZ2luZzoKICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBFbmFibGVMb2dnaW5nIGlzIHVzZWQgdG8gaW5kaWNhdGUgaWYgYWdlbnQgc2hvdWxkIGdlbmVyYXRlIGxvZ3Mgd2hlbiBydWxlcyBhcmUgbWF0Y2hlZC4gU2hvdWxkIGJlIGRlZmF1bHQgdG8gZmFsc2UuCiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBib29sZWFuCiAgICAgICAgICAgICAgICAgICAgZnJvbToKICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBSdWxlIGlzIG1hdGNoZWQgaWYgdHJhZmZpYyBvcmlnaW5hdGVzIGZyb20gd29ya2xvYWRzIHNlbGVjdGVkIGJ5IHRoaXMgZmllbGQuIElmIHRoaXMgZmllbGQgaXMgZW1wdHksIHRoaXMgcnVsZSBtYXRjaGVzIGFsbCBzb3VyY2VzLgogICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgaXBCbG9jazoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBJUEJsb2NrIGRlc2NyaWJlcyB0aGUgSVBBZGRyZXNzZXMvSVBCbG9ja3MgdGhhdCBpcyBtYXRjaGVkIGluIHRvL2Zyb20uIElQQmxvY2sgY2Fubm90IGJlIHNldCBhcyBwYXJ0IG9mIHRoZSBBcHBsaWVkVG8gZmllbGQuIENhbm5vdCBiZSBzZXQgd2l0aCBhbnkgb3RoZXIgc2VsZWN0b3IuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBjaWRyOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBDSURSIGlzIGEgc3RyaW5nIHJlcHJlc2VudGluZyB0aGUgSVAgQmxvY2sgVmFsaWQgZXhhbXBsZXMgYXJlICIxOTIuMTY4LjEuMS8yNCIgb3IgIjIwMDE6ZGI5OjovNjQiCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGV4Y2VwdDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRXhjZXB0IGlzIGEgc2xpY2Ugb2YgQ0lEUnMgdGhhdCBzaG91bGQgbm90IGJlIGluY2x1ZGVkIHdpdGhpbiBhbiBJUCBCbG9jayBWYWxpZCBleGFtcGxlcyBhcmUgIjE5Mi4xNjguMS4xLzI0IiBvciAiMjAwMTpkYjk6Oi82NCIgRXhjZXB0IHZhbHVlcyB3aWxsIGJlIHJlamVjdGVkIGlmIHRoZXkgYXJlIG91dHNpZGUgdGhlIENJRFIgcmFuZ2UKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0gY2lkcgogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgICAgbmFtZXNwYWNlU2VsZWN0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBvcGVyYXRvcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogb3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuIFZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFsdWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiB2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0ga2V5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgICAgcG9kU2VsZWN0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogU2VsZWN0IFBvZHMgZnJvbSBOZXR3b3JrUG9saWN5J3MgTmFtZXNwYWNlIGFzIHdvcmtsb2FkcyBpbiBBcHBsaWVkVG8vVG8vRnJvbSBmaWVsZHMuIElmIHNldCB3aXRoIE5hbWVzcGFjZVNlbGVjdG9yLCBQb2RzIGFyZSBtYXRjaGVkIGZyb20gTmFtZXNwYWNlcyBtYXRjaGVkIGJ5IHRoZSBOYW1lc3BhY2VTZWxlY3Rvci4gQ2Fubm90IGJlIHNldCB3aXRoIGFueSBvdGhlciBzZWxlY3RvciBleGNlcHQgTmFtZXNwYWNlU2VsZWN0b3IuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaEV4cHJlc3Npb25zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBtYXRjaEV4cHJlc3Npb25zIGlzIGEgbGlzdCBvZiBsYWJlbCBzZWxlY3RvciByZXF1aXJlbWVudHMuIFRoZSByZXF1aXJlbWVudHMgYXJlIEFORGVkLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAga2V5OgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBvcGVyYXRvcjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogb3BlcmF0b3IgcmVwcmVzZW50cyBhIGtleSdzIHJlbGF0aW9uc2hpcCB0byBhIHNldCBvZiB2YWx1ZXMuIFZhbGlkIG9wZXJhdG9ycyBhcmUgSW4sIE5vdEluLCBFeGlzdHMgYW5kIERvZXNOb3RFeGlzdC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFsdWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiB2YWx1ZXMgaXMgYW4gYXJyYXkgb2Ygc3RyaW5nIHZhbHVlcy4gSWYgdGhlIG9wZXJhdG9yIGlzIEluIG9yIE5vdEluLCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgbm9uLWVtcHR5LiBJZiB0aGUgb3BlcmF0b3IgaXMgRXhpc3RzIG9yIERvZXNOb3RFeGlzdCwgdGhlIHZhbHVlcyBhcnJheSBtdXN0IGJlIGVtcHR5LiBUaGlzIGFycmF5IGlzIHJlcGxhY2VkIGR1cmluZyBhIHN0cmF0ZWdpYyBtZXJnZSBwYXRjaC4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0ga2V5CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAtIG9wZXJhdG9yCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICBwb3J0czoKICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBTZXQgb2YgcG9ydCBhbmQgcHJvdG9jb2wgYWxsb3dlZC9kZW5pZWQgYnkgdGhlIHJ1bGUuIElmIHRoaXMgZmllbGQgaXMgdW5zZXQgb3IgZW1wdHksIHRoaXMgcnVsZSBtYXRjaGVzIGFsbCBwb3J0cy4KICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogTmV0d29ya1BvbGljeVBvcnQgZGVzY3JpYmVzIHRoZSBwb3J0IGFuZCBwcm90b2NvbCB0byBtYXRjaCBpbiBhIHJ1bGUuCiAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgZW5kUG9ydDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBFbmRQb3J0IGRlZmluZXMgdGhlIGVuZCBvZiB0aGUgcG9ydCByYW5nZSwgYmVpbmcgdGhlIGVuZCBpbmNsdWRlZCB3aXRoaW4gdGhlIHJhbmdlLiBJdCBjYW4gb25seSBiZSBzcGVjaWZpZWQgd2hlbiBhIG51bWVyaWNhbCBgcG9ydGAgaXMgc3BlY2lmaWVkLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgZm9ybWF0OiBpbnQzMgogICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgICAgICAgICAgICAgIHBvcnQ6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBhbnlPZjoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIC0gdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgICAgICAgICAgICAgICAgLSB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBUaGUgcG9ydCBvbiB0aGUgZ2l2ZW4gcHJvdG9jb2wuIFRoaXMgY2FuIGJlIGVpdGhlciBhIG51bWVyaWNhbCBvciBuYW1lZCBwb3J0IG9uIGEgUG9kLiBJZiB0aGlzIGZpZWxkIGlzIG5vdCBwcm92aWRlZCwgdGhpcyBtYXRjaGVzIGFsbCBwb3J0IG5hbWVzIGFuZCBudW1iZXJzLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgeC1rdWJlcm5ldGVzLWludC1vci1zdHJpbmc6IHRydWUKICAgICAgICAgICAgICAgICAgICAgICAgICBwcm90b2NvbDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IFRDUAogICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFRoZSBwcm90b2NvbCAoVENQLCBVRFAsIG9yIFNDVFApIHdoaWNoIHRyYWZmaWMgbXVzdCBtYXRjaC4gSWYgbm90IHNwZWNpZmllZCwgdGhpcyBmaWVsZCBkZWZhdWx0cyB0byBUQ1AuCiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgcG9saWN5VHlwZXM6CiAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFBvbGljeSBUeXBlIHN0cmluZyBkZXNjcmliZXMgdGhlIE5ldHdvcmtQb2xpY3kgdHlwZSBUaGlzIHR5cGUgaXMgYmV0YS1sZXZlbCBpbiAxLjgKICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICB0eXBlOiBhcnJheQogICAgICAgICAgICAgIHByaW9yaXR5OgogICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IFByaW9yaXR5IHNwZWNmaWVzIHRoZSBvcmRlciBvZiB0aGUgTmV0d29ya1BvbGljeSByZWxhdGl2ZSB0byBvdGhlciBOZXR3b3JrUG9saWNpZXMuCiAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgdHlwZToKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiB0eXBlIG9mIHRoZSBwb2xpY3kuCiAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgIC0gdHlwZQogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICByZXF1aXJlZDoKICAgICAgICAtIHNwZWMKICAgICAgICB0eXBlOiBvYmplY3QKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQpzdGF0dXM6CiAgYWNjZXB0ZWROYW1lczoKICAgIGtpbmQ6ICIiCiAgICBwbHVyYWw6ICIiCiAgY29uZGl0aW9uczogW10KICBzdG9yZWRWZXJzaW9uczogW10KLS0tCmFwaVZlcnNpb246IGFwaWV4dGVuc2lvbnMuazhzLmlvL3YxCmtpbmQ6IEN1c3RvbVJlc291cmNlRGVmaW5pdGlvbgptZXRhZGF0YToKICBuYW1lOiBkbnNuZXR3b3JrcG9saWNpZXMuYWNpLmRuc25ldHBvbApzcGVjOgogIGdyb3VwOiBhY2kuZG5zbmV0cG9sCiAgbmFtZXM6CiAgICBraW5kOiBEbnNOZXR3b3JrUG9saWN5CiAgICBsaXN0S2luZDogRG5zTmV0d29ya1BvbGljeUxpc3QKICAgIHBsdXJhbDogZG5zbmV0d29ya3BvbGljaWVzCiAgICBzaW5ndWxhcjogZG5zbmV0d29ya3BvbGljeQogIHNjb3BlOiBOYW1lc3BhY2VkCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MWJldGEKICAgIHNjaGVtYToKICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIGRlc2NyaXB0aW9uOiBkbnMgbmV0d29yayBQb2xpY3kKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgYXBwbGllZFRvOgogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgbmFtZXNwYWNlU2VsZWN0b3I6CiAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgIG1hdGNoRXhwcmVzc2lvbnM6CiAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBrZXk6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgb3BlcmF0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFsdWVzOgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgICAtIGtleQogICAgICAgICAgICAgICAgICAgICAgICAgIC0gb3BlcmF0b3IKICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgIG1hdGNoTGFiZWxzOgogICAgICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgIHBvZFNlbGVjdG9yOgogICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBhbGxvdyBpbmdyZXNzIGZyb20gdGhlIHNhbWUgbmFtZXNwYWNlCiAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgIG1hdGNoRXhwcmVzc2lvbnM6CiAgICAgICAgICAgICAgICAgICAgICAgIGl0ZW1zOgogICAgICAgICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBrZXk6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgICAgICAgICAgb3BlcmF0b3I6CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBvcGVyYXRvciByZXByZXNlbnRzIGEga2V5J3MgcmVsYXRpb25zaGlwIHRvIGEgc2V0IG9mIHZhbHVlcy4gVmFsaWQgb3BlcmF0b3JzIGFyZSBJbiwgTm90SW4sIEV4aXN0cyBhbmQgRG9lc05vdEV4aXN0LgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhbHVlczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZGVzY3JpcHRpb246IHZhbHVlcyBpcyBhbiBhcnJheSBvZiBzdHJpbmcgdmFsdWVzLiBJZiB0aGUgb3BlcmF0b3IgaXMgSW4gb3IgTm90SW4sIHRoZSB2YWx1ZXMgYXJyYXkgbXVzdCBiZSBub24tZW1wdHkuIElmIHRoZSBvcGVyYXRvciBpcyBFeGlzdHMgb3IgRG9lc05vdEV4aXN0LCB0aGUgdmFsdWVzIGFycmF5IG11c3QgYmUgZW1wdHkuIFRoaXMgYXJyYXkgaXMgcmVwbGFjZWQgZHVyaW5nIGEgc3RyYXRlZ2ljIG1lcmdlIHBhdGNoLgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpdGVtczoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgICAgICAgICAgICAtIGtleQogICAgICAgICAgICAgICAgICAgICAgICAgIC0gb3BlcmF0b3IKICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogYXJyYXkKICAgICAgICAgICAgICAgICAgICAgIG1hdGNoTGFiZWxzOgogICAgICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICBlZ3Jlc3M6CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogU2V0IG9mIGVncmVzcyBydWxlcyBldmFsdWF0ZWQgYmFzZWQgb24gdGhlIG9yZGVyIGluIHdoaWNoIHRoZXkgYXJlIHNldC4KICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIHRvRnFkbjoKICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgbWF0Y2hOYW1lczoKICAgICAgICAgICAgICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IGFycmF5CiAgICAgICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAgICAgLSBtYXRjaE5hbWVzCiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICByZXF1aXJlZDoKICAgICAgICAgICAgICAgIC0gdG9GcWRuCiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgLSBzcGVjCiAgICAgICAgdHlwZTogb2JqZWN0CiAgICBzZXJ2ZWQ6IHRydWUKICAgIHN0b3JhZ2U6IHRydWUKc3RhdHVzOgogIGFjY2VwdGVkTmFtZXM6CiAgICBraW5kOiAiIgogICAgcGx1cmFsOiAiIgogIGNvbmRpdGlvbnM6IFtdCiAgc3RvcmVkVmVyc2lvbnM6IFtdCi0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogcW9zcG9saWNpZXMuYWNpLnFvcwpzcGVjOgogIGdyb3VwOiBhY2kucW9zCiAgbmFtZXM6CiAgICBraW5kOiBRb3NQb2xpY3kKICAgIGxpc3RLaW5kOiBRb3NQb2xpY3lMaXN0CiAgICBwbHVyYWw6IHFvc3BvbGljaWVzCiAgICBzaW5ndWxhcjogcW9zcG9saWN5CiAgc2NvcGU6IE5hbWVzcGFjZWQKICBwcmVzZXJ2ZVVua25vd25GaWVsZHM6IGZhbHNlCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzdWJyZXNvdXJjZXM6CiAgICAgIHN0YXR1czoge30KICAgIHNjaGVtYToKICAgICAgb3BlbkFQSVYzU2NoZW1hOgogICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICBhcGlWZXJzaW9uOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIGtpbmQ6CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgc3BlYzoKICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgcG9kU2VsZWN0b3I6CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogJ1NlbGVjdGlvbiBvZiBQb2RzJwogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBtYXRjaExhYmVsczoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjoKICAgICAgICAgICAgICBpbmdyZXNzOgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBwb2xpY2luZ19yYXRlOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAwCiAgICAgICAgICAgICAgICAgIHBvbGljaW5nX2J1cnN0OgogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAwCiAgICAgICAgICAgICAgZWdyZXNzOgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBwb2xpY2luZ19yYXRlOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAwCiAgICAgICAgICAgICAgICAgIHBvbGljaW5nX2J1cnN0OgogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAwCiAgICAgICAgICAgICAgZHNjcG1hcms6CiAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICBkZWZhdWx0OiAwCiAgICAgICAgICAgICAgICBtaW5pbXVtOiAwCiAgICAgICAgICAgICAgICBtYXhpbXVtOiA2MwotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IG5ldGZsb3dwb2xpY2llcy5hY2kubmV0ZmxvdwpzcGVjOgogIGdyb3VwOiBhY2kubmV0ZmxvdwogIG5hbWVzOgogICAga2luZDogTmV0Zmxvd1BvbGljeQogICAgbGlzdEtpbmQ6IE5ldGZsb3dQb2xpY3lMaXN0CiAgICBwbHVyYWw6IG5ldGZsb3dwb2xpY2llcwogICAgc2luZ3VsYXI6IG5ldGZsb3dwb2xpY3kKICBzY29wZTogQ2x1c3RlcgogIHByZXNlcnZlVW5rbm93bkZpZWxkczogZmFsc2UKICB2ZXJzaW9uczoKICAtIG5hbWU6IHYxYWxwaGEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAjIG9wZW5BUElWM1NjaGVtYSBpcyB0aGUgc2NoZW1hIGZvciB2YWxpZGF0aW5nIGN1c3RvbSBvYmplY3RzLgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBzcGVjOgogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBmbG93U2FtcGxpbmdQb2xpY3k6CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIGRlc3RJcDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgZGVzdFBvcnQ6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgICAgICAgIG1pbmltdW06IDAKICAgICAgICAgICAgICAgICAgICBtYXhpbXVtOiA2NTUzNQogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IDIwNTUKICAgICAgICAgICAgICAgICAgZmxvd1R5cGU6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgICAgZW51bToKICAgICAgICAgICAgICAgICAgICAgIC0gbmV0ZmxvdwogICAgICAgICAgICAgICAgICAgICAgLSBpcGZpeAogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IG5ldGZsb3cKICAgICAgICAgICAgICAgICAgYWN0aXZlRmxvd1RpbWVPdXQ6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogaW50ZWdlcgogICAgICAgICAgICAgICAgICAgIG1pbmltdW06IDAKICAgICAgICAgICAgICAgICAgICBtYXhpbXVtOiAzNjAwCiAgICAgICAgICAgICAgICAgICAgZGVmYXVsdDogNjAKICAgICAgICAgICAgICAgICAgaWRsZUZsb3dUaW1lT3V0OgogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAwCiAgICAgICAgICAgICAgICAgICAgbWF4aW11bTogNjAwCiAgICAgICAgICAgICAgICAgICAgZGVmYXVsdDogMTUKICAgICAgICAgICAgICAgICAgc2FtcGxpbmdSYXRlOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAwCiAgICAgICAgICAgICAgICAgICAgbWF4aW11bTogMTAwMAogICAgICAgICAgICAgICAgICAgIGRlZmF1bHQ6IDAKICAgICAgICAgICAgICAgIHJlcXVpcmVkOgogICAgICAgICAgICAgICAgLSBkZXN0SXAKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IGVyc3BhbnBvbGljaWVzLmFjaS5lcnNwYW4Kc3BlYzoKICBncm91cDogYWNpLmVyc3BhbgogIG5hbWVzOgogICAga2luZDogRXJzcGFuUG9saWN5CiAgICBsaXN0S2luZDogRXJzcGFuUG9saWN5TGlzdAogICAgcGx1cmFsOiBlcnNwYW5wb2xpY2llcwogICAgc2luZ3VsYXI6IGVyc3BhbnBvbGljeQogIHNjb3BlOiBDbHVzdGVyCiAgcHJlc2VydmVVbmtub3duRmllbGRzOiBmYWxzZQogIHZlcnNpb25zOgogIC0gbmFtZTogdjFhbHBoYQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzY2hlbWE6CiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIHNlbGVjdG9yOgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogJ1NlbGVjdGlvbiBvZiBQb2RzJwogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgbGFiZWxzOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgYWRkaXRpb25hbFByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgbmFtZXNwYWNlOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgIHNvdXJjZToKICAgICAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgYWRtaW5TdGF0ZToKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogQWRtaW5pc3RyYXRpdmUgc3RhdGUuCiAgICAgICAgICAgICAgICAgICAgZGVmYXVsdDogc3RhcnQKICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgICBlbnVtOgogICAgICAgICAgICAgICAgICAgICAgLSBzdGFydAogICAgICAgICAgICAgICAgICAgICAgLSBzdG9wCiAgICAgICAgICAgICAgICAgIGRpcmVjdGlvbjoKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRGlyZWN0aW9uIG9mIHRoZSBwYWNrZXRzIHRvIG1vbml0b3IuCiAgICAgICAgICAgICAgICAgICAgZGVmYXVsdDogYm90aAogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICAgIGVudW06CiAgICAgICAgICAgICAgICAgICAgICAtIGluCiAgICAgICAgICAgICAgICAgICAgICAtIG91dAogICAgICAgICAgICAgICAgICAgICAgLSBib3RoCiAgICAgICAgICAgICAgZGVzdGluYXRpb246CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIGRlc3RJUDoKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRGVzdGluYXRpb24gSVAgb2YgdGhlIEVSU1BBTiBwYWNrZXQuCiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIGZsb3dJRDoKICAgICAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogVW5pcXVlIGZsb3cgSUQgb2YgdGhlIEVSU1BBTiBwYWNrZXQuCiAgICAgICAgICAgICAgICAgICAgZGVmYXVsdDogMQogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgICBtaW5pbXVtOiAxCiAgICAgICAgICAgICAgICAgICAgbWF4aW11bTogMTAyMwogICAgICAgICAgICAgICAgcmVxdWlyZWQ6CiAgICAgICAgICAgICAgICAtIGRlc3RJUAogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0Ci0tLQphcGlWZXJzaW9uOiBhcGlleHRlbnNpb25zLms4cy5pby92MQpraW5kOiBDdXN0b21SZXNvdXJjZURlZmluaXRpb24KbWV0YWRhdGE6CiAgbmFtZTogZW5hYmxlZHJvcGxvZ3MuYWNpLmRyb3Bsb2cKc3BlYzoKICBncm91cDogYWNpLmRyb3Bsb2cKICBuYW1lczoKICAgIGtpbmQ6IEVuYWJsZURyb3BMb2cKICAgIGxpc3RLaW5kOiBFbmFibGVEcm9wTG9nTGlzdAogICAgcGx1cmFsOiBlbmFibGVkcm9wbG9ncwogICAgc2luZ3VsYXI6IGVuYWJsZWRyb3Bsb2cKICBzY29wZTogQ2x1c3RlcgogIHZlcnNpb25zOgogIC0gbmFtZTogdjFhbHBoYTEKICAgIHNlcnZlZDogdHJ1ZQogICAgc3RvcmFnZTogdHJ1ZQogICAgc2NoZW1hOgogICAjIG9wZW5BUElWM1NjaGVtYSBpcyB0aGUgc2NoZW1hIGZvciB2YWxpZGF0aW5nIGN1c3RvbSBvYmplY3RzLgogICAgICBvcGVuQVBJVjNTY2hlbWE6CiAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgIGFwaVZlcnNpb246CiAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAga2luZDoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBzcGVjOgogICAgICAgICAgICBkZXNjcmlwdGlvbjogRGVmaW5lcyB0aGUgZGVzaXJlZCBzdGF0ZSBvZiBFbmFibGVEcm9wTG9nCiAgICAgICAgICAgIHR5cGU6IG9iamVjdAogICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgIGRpc2FibGVEZWZhdWx0RHJvcExvZzoKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBEaXNhYmxlcyB0aGUgZGVmYXVsdCBkcm9wbG9nIGVuYWJsZWQgYnkgYWNjLXByb3Zpc2lvbi4KICAgICAgICAgICAgICAgIGRlZmF1bHQ6IGZhbHNlCiAgICAgICAgICAgICAgICB0eXBlOiBib29sZWFuCiAgICAgICAgICAgICAgbm9kZVNlbGVjdG9yOgogICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICBkZXNjcmlwdGlvbjogRHJvcCBsb2dnaW5nIGlzIGVuYWJsZWQgb24gbm9kZXMgc2VsZWN0ZWQgYmFzZWQgb24gbGFiZWxzCiAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICBsYWJlbHM6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogb2JqZWN0CiAgICAgICAgICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICBhZGRpdGlvbmFsUHJvcGVydGllczoKICAgICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwotLS0KYXBpVmVyc2lvbjogYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEKa2luZDogQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uCm1ldGFkYXRhOgogIG5hbWU6IHBydW5lZHJvcGxvZ3MuYWNpLmRyb3Bsb2cKc3BlYzoKICBncm91cDogYWNpLmRyb3Bsb2cKICBuYW1lczoKICAgIGtpbmQ6IFBydW5lRHJvcExvZwogICAgbGlzdEtpbmQ6IFBydW5lRHJvcExvZ0xpc3QKICAgIHBsdXJhbDogcHJ1bmVkcm9wbG9ncwogICAgc2luZ3VsYXI6IHBydW5lZHJvcGxvZwogIHNjb3BlOiBDbHVzdGVyCiAgdmVyc2lvbnM6CiAgLSBuYW1lOiB2MWFscGhhMQogICAgc2VydmVkOiB0cnVlCiAgICBzdG9yYWdlOiB0cnVlCiAgICBzY2hlbWE6CiAgICMgb3BlbkFQSVYzU2NoZW1hIGlzIHRoZSBzY2hlbWEgZm9yIHZhbGlkYXRpbmcgY3VzdG9tIG9iamVjdHMuCiAgICAgIG9wZW5BUElWM1NjaGVtYToKICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgYXBpVmVyc2lvbjoKICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICBraW5kOgogICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgIHNwZWM6CiAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBEZWZpbmVzIHRoZSBkZXNpcmVkIHN0YXRlIG9mIFBydW5lRHJvcExvZwogICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgcHJvcGVydGllczoKICAgICAgICAgICAgICBub2RlU2VsZWN0b3I6CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIGRlc2NyaXB0aW9uOiBEcm9wIGxvZ2dpbmcgZmlsdGVycyBhcmUgYXBwbGllZCB0byBub2RlcyBzZWxlY3RlZCBiYXNlZCBvbiBsYWJlbHMKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIGxhYmVsczoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgICAgICBwcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgIGFkZGl0aW9uYWxQcm9wZXJ0aWVzOgogICAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgZHJvcExvZ0ZpbHRlcnM6CiAgICAgICAgICAgICAgICB0eXBlOiBvYmplY3QKICAgICAgICAgICAgICAgIHByb3BlcnRpZXM6CiAgICAgICAgICAgICAgICAgIHNyY0lQOgogICAgICAgICAgICAgICAgICAgIHR5cGU6IHN0cmluZwogICAgICAgICAgICAgICAgICBkZXN0SVA6CiAgICAgICAgICAgICAgICAgICAgdHlwZTogc3RyaW5nCiAgICAgICAgICAgICAgICAgIHNyY01BQzoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgZGVzdE1BQzoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICAgICAgICAgICAgc3JjUG9ydDoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCiAgICAgICAgICAgICAgICAgIGRlc3RQb3J0OgogICAgICAgICAgICAgICAgICAgIHR5cGU6IGludGVnZXIKICAgICAgICAgICAgICAgICAgaXBQcm90bzoKICAgICAgICAgICAgICAgICAgICB0eXBlOiBpbnRlZ2VyCi0tLQphcGlWZXJzaW9uOiB2MQpraW5kOiBDb25maWdNYXAKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29uZmlnCiAgbmFtZXNwYWNlOiBhY2ktY29udGFpbmVycy1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCmRhdGE6CiAgY29udHJvbGxlci1jb25maWc6IHwtCiAgICB7CiAgICAgICAgImZsYXZvciI6ICJSS0UyLWt1YmVybmV0ZXMtMS4yNCIsCiAgICAgICAgImxvZy1sZXZlbCI6ICJpbmZvIiwKICAgICAgICAiYXBpYy1ob3N0cyI6IFsKICAgICAgICAgICAgIjEwLjMwLjEyMC4xMDAiLAogICAgICAgICAgICAiMTAuMzAuMTIwLjEwMSIsCiAgICAgICAgICAgICIxMC4zMC4xMjAuMTAyIgogICAgICAgIF0sCiAgICAgICAgImFwaWMtdXNlcm5hbWUiOiAicmtlMiIsCiAgICAgICAgImFwaWMtcHJpdmF0ZS1rZXktcGF0aCI6ICIvdXNyL2xvY2FsL2V0Yy9hY2ktY2VydC91c2VyLmtleSIsCiAgICAgICAgImFjaS1wcmVmaXgiOiAicmtlMiIsCiAgICAgICAgImFjaS12bW0tdHlwZSI6ICJLdWJlcm5ldGVzIiwKICAgICAgICAiYWNpLXZtbS1kb21haW4iOiAicmtlMiIsCiAgICAgICAgImFjaS12bW0tY29udHJvbGxlciI6ICJya2UyIiwKICAgICAgICAiYWNpLXBvbGljeS10ZW5hbnQiOiAicmtlMiIsCiAgICAgICAgImFjaS1wb2RiZC1kbiI6ICJ1bmkvdG4tcmtlMi9CRC1hY2ktY29udGFpbmVycy1ya2UyLXBvZC1iZCIsCiAgICAgICAgImFjaS1ub2RlYmQtZG4iOiAidW5pL3RuLXJrZTIvQkQtYWNpLWNvbnRhaW5lcnMtcmtlMi1ub2RlLWJkIiwKICAgICAgICAiYWNpLXNlcnZpY2UtcGh5cy1kb20iOiAicmtlMi1wZG9tIiwKICAgICAgICAiYWNpLXNlcnZpY2UtZW5jYXAiOiAidmxhbi00MDAzIiwKICAgICAgICAiYWNpLXNlcnZpY2UtbW9uaXRvci1pbnRlcnZhbCI6IDUsCiAgICAgICAgImFjaS1wYnItdHJhY2tpbmctbm9uLXNuYXQiOiBmYWxzZSwKICAgICAgICAiYWNpLXZyZi10ZW5hbnQiOiAiY29tbW9uIiwKICAgICAgICAiYWNpLXZyZi1kbiI6ICJ1bmkvdG4tY29tbW9uL2N0eC1ya2UyIiwKICAgICAgICAiYWNpLWwzb3V0IjogImwzb3V0IiwKICAgICAgICAiYWNpLWV4dC1uZXR3b3JrcyI6IFsKICAgICAgICAgICAgImRlZmF1bHQiLAogICAgICAgICAgICAidGVzdF9leHRfbmV0IgogICAgICAgIF0sCiAgICAgICAgImFjaS12cmYiOiAicmtlMiIsCiAgICAgICAgImRlZmF1bHQtZW5kcG9pbnQtZ3JvdXAiOiB7CiAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAicmtlMiIsCiAgICAgICAgICAgICJuYW1lIjogImFjaS1jb250YWluZXJzLXJrZTJ8YWNpLWNvbnRhaW5lcnMtZGVmYXVsdCIKICAgICAgICB9LAogICAgICAgICJtYXgtbm9kZXMtc3ZjLWdyYXBoIjogMzIsCiAgICAgICAgIm5hbWVzcGFjZS1kZWZhdWx0LWVuZHBvaW50LWdyb3VwIjogewogICAgICAgICAgICAiYWNpLWNvbnRhaW5lcnMtc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJya2UyIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImFjaS1jb250YWluZXJzLXJrZTJ8YWNpLWNvbnRhaW5lcnMtc3lzdGVtIgogICAgICAgICAgICB9LAogICAgICAgICAgICAiY2F0dGxlLWxvZ2dpbmctc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJya2UyIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImFjaS1jb250YWluZXJzLXJrZTJ8YWNpLWNvbnRhaW5lcnMtc3lzdGVtIgogICAgICAgICAgICB9LAogICAgICAgICAgICAiY2F0dGxlLW1vbml0b3Jpbmctc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJya2UyIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImFjaS1jb250YWluZXJzLXJrZTJ8YWNpLWNvbnRhaW5lcnMtc3lzdGVtIgogICAgICAgICAgICB9LAogICAgICAgICAgICAiY2F0dGxlLXN5c3RlbSI6IHsKICAgICAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAicmtlMiIsCiAgICAgICAgICAgICAgICAibmFtZSI6ICJhY2ktY29udGFpbmVycy1ya2UyfGFjaS1jb250YWluZXJzLXN5c3RlbSIKICAgICAgICAgICAgfSwKICAgICAgICAgICAgImlzdGlvLW9wZXJhdG9yIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJya2UyIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImFjaS1jb250YWluZXJzLXJrZTJ8YWNpLWNvbnRhaW5lcnMtaXN0aW8iCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgICJpc3Rpby1zeXN0ZW0iOiB7CiAgICAgICAgICAgICAgICAicG9saWN5LXNwYWNlIjogInJrZTIiLAogICAgICAgICAgICAgICAgIm5hbWUiOiAiYWNpLWNvbnRhaW5lcnMtcmtlMnxhY2ktY29udGFpbmVycy1pc3RpbyIKICAgICAgICAgICAgfSwKICAgICAgICAgICAgImt1YmUtc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJya2UyIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImFjaS1jb250YWluZXJzLXJrZTJ8YWNpLWNvbnRhaW5lcnMtc3lzdGVtIgogICAgICAgICAgICB9ICAgICAgICB9LAogICAgICAgICJzZXJ2aWNlLWlwLXBvb2wiOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJlbmQiOiAiMTAuMy4wLjI1NCIsCiAgICAgICAgICAgICAgICAic3RhcnQiOiAiMTAuMy4wLjIiCiAgICAgICAgICAgIH0KICAgICAgICBdLAogICAgICAgICJleHRlcm4tc3RhdGljIjogIjEwLjQuMC4xLzI0IiwKICAgICAgICAiZXh0ZXJuLWR5bmFtaWMiOiAiMTAuMy4wLjEvMjQiLAogICAgICAgICJzbmF0LWNvbnRyYWN0LXNjb3BlIjogImdsb2JhbCIsCiAgICAgICAgInN0YXRpYy1zZXJ2aWNlLWlwLXBvb2wiOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJlbmQiOiAiMTAuNC4wLjI1NCIsCiAgICAgICAgICAgICAgICAic3RhcnQiOiAiMTAuNC4wLjIiCiAgICAgICAgICAgIH0KICAgICAgICBdLAogICAgICAgICJwb2QtaXAtcG9vbCI6IFsKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgImVuZCI6ICIxMC4yLjI1NS4yNTQiLAogICAgICAgICAgICAgICAgInN0YXJ0IjogIjEwLjIuMC4yIgogICAgICAgICAgICB9CiAgICAgICAgXSwKICAgICAgICAicG9kLXN1Ym5ldC1jaHVuay1zaXplIjogMjU2LAogICAgICAgICJub2RlLXNlcnZpY2UtaXAtcG9vbCI6IFsKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgImVuZCI6ICIxMC41LjAuMjU0IiwKICAgICAgICAgICAgICAgICJzdGFydCI6ICIxMC41LjAuMiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgIm5vZGUtc2VydmljZS1zdWJuZXRzIjogWwogICAgICAgICAgICAiMTAuNS4wLjEvMjQiCiAgICAgICAgXQogICAgfQogIGhvc3QtYWdlbnQtY29uZmlnOiB8LQogICAgewogICAgICAgICJmbGF2b3IiOiAiUktFMi1rdWJlcm5ldGVzLTEuMjQiLAogICAgICAgICJhcHAtcHJvZmlsZSI6ICJhY2ktY29udGFpbmVycy1ya2UyIiwKICAgICAgICAib3BmbGV4LW1vZGUiOiBudWxsLAogICAgICAgICJsb2ctbGV2ZWwiOiAiaW5mbyIsCiAgICAgICAgImFjaS1zbmF0LW5hbWVzcGFjZSI6ICJhY2ktY29udGFpbmVycy1zeXN0ZW0iLAogICAgICAgICJhY2ktdm1tLXR5cGUiOiAiS3ViZXJuZXRlcyIsCiAgICAgICAgImFjaS12bW0tZG9tYWluIjogInJrZTIiLAogICAgICAgICJhY2ktdm1tLWNvbnRyb2xsZXIiOiAicmtlMiIsCiAgICAgICAgImFjaS1wcmVmaXgiOiAicmtlMiIsCiAgICAgICAgImFjaS12cmYiOiAicmtlMiIsCiAgICAgICAgImFjaS12cmYtdGVuYW50IjogImNvbW1vbiIsCiAgICAgICAgInNlcnZpY2UtdmxhbiI6IDQwMDMsCiAgICAgICAgImt1YmVhcGktdmxhbiI6IDQwMDEsCiAgICAgICAgInBvZC1zdWJuZXQiOiAiMTAuMi4wLjEvMTYiLAogICAgICAgICJub2RlLXN1Ym5ldCI6ICIxMC4xLjAuMS8xNiIsCiAgICAgICAgImVuY2FwLXR5cGUiOiAidnhsYW4iLAogICAgICAgICJhY2ktaW5mcmEtdmxhbiI6IDQwOTMsCiAgICAgICAgImNuaS1uZXRjb25maWciOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJnYXRld2F5IjogIjEwLjIuMC4xIiwKICAgICAgICAgICAgICAgICJyb3V0ZXMiOiBbCiAgICAgICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgICAgICAiZHN0IjogIjAuMC4wLjAvMCIsCiAgICAgICAgICAgICAgICAgICAgICAgICJndyI6ICIxMC4yLjAuMSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBdLAogICAgICAgICAgICAgICAgInN1Ym5ldCI6ICIxMC4yLjAuMC8xNiIKICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgImRlZmF1bHQtZW5kcG9pbnQtZ3JvdXAiOiB7CiAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAicmtlMiIsCiAgICAgICAgICAgICJuYW1lIjogImFjaS1jb250YWluZXJzLXJrZTJ8YWNpLWNvbnRhaW5lcnMtZGVmYXVsdCIKICAgICAgICB9LAogICAgICAgICJuYW1lc3BhY2UtZGVmYXVsdC1lbmRwb2ludC1ncm91cCI6IHsKICAgICAgICAgICAgImFjaS1jb250YWluZXJzLXN5c3RlbSI6IHsKICAgICAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAicmtlMiIsCiAgICAgICAgICAgICAgICAibmFtZSI6ICJhY2ktY29udGFpbmVycy1ya2UyfGFjaS1jb250YWluZXJzLXN5c3RlbSIKICAgICAgICAgICAgfSwKICAgICAgICAgICAgImNhdHRsZS1sb2dnaW5nLXN5c3RlbSI6IHsKICAgICAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAicmtlMiIsCiAgICAgICAgICAgICAgICAibmFtZSI6ICJhY2ktY29udGFpbmVycy1ya2UyfGFjaS1jb250YWluZXJzLXN5c3RlbSIKICAgICAgICAgICAgfSwKICAgICAgICAgICAgImNhdHRsZS1tb25pdG9yaW5nLXN5c3RlbSI6IHsKICAgICAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAicmtlMiIsCiAgICAgICAgICAgICAgICAibmFtZSI6ICJhY2ktY29udGFpbmVycy1ya2UyfGFjaS1jb250YWluZXJzLXN5c3RlbSIKICAgICAgICAgICAgfSwKICAgICAgICAgICAgImNhdHRsZS1zeXN0ZW0iOiB7CiAgICAgICAgICAgICAgICAicG9saWN5LXNwYWNlIjogInJrZTIiLAogICAgICAgICAgICAgICAgIm5hbWUiOiAiYWNpLWNvbnRhaW5lcnMtcmtlMnxhY2ktY29udGFpbmVycy1zeXN0ZW0iCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgICJpc3Rpby1vcGVyYXRvciI6IHsKICAgICAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAicmtlMiIsCiAgICAgICAgICAgICAgICAibmFtZSI6ICJhY2ktY29udGFpbmVycy1ya2UyfGFjaS1jb250YWluZXJzLWlzdGlvIgogICAgICAgICAgICB9LAogICAgICAgICAgICAiaXN0aW8tc3lzdGVtIjogewogICAgICAgICAgICAgICAgInBvbGljeS1zcGFjZSI6ICJya2UyIiwKICAgICAgICAgICAgICAgICJuYW1lIjogImFjaS1jb250YWluZXJzLXJrZTJ8YWNpLWNvbnRhaW5lcnMtaXN0aW8iCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgICJrdWJlLXN5c3RlbSI6IHsKICAgICAgICAgICAgICAgICJwb2xpY3ktc3BhY2UiOiAicmtlMiIsCiAgICAgICAgICAgICAgICAibmFtZSI6ICJhY2ktY29udGFpbmVycy1ya2UyfGFjaS1jb250YWluZXJzLXN5c3RlbSIKICAgICAgICAgICAgfSAgICAgICAgfSwKICAgICAgICAiZW5hYmxlLWRyb3AtbG9nIjogdHJ1ZSwKICAgICAgICAiZW5hYmxlLW5vZGVwb2RpZiI6IGZhbHNlLAogICAgICAgICJlbmFibGUtb3ZzLWh3LW9mZmxvYWQiOiBmYWxzZQogICAgfQogIG9wZmxleC1hZ2VudC1jb25maWc6IHwtCiAgICB7CiAgICAgICAgImxvZyI6IHsKICAgICAgICAgICAgImxldmVsIjogImluZm8iCiAgICAgICAgfSwKICAgICAgICAib3BmbGV4IjogewogICAgICAgICAgICAibm90aWYiIDogeyAiZW5hYmxlZCIgOiAiZmFsc2UiIH0sCiAgICAgICAgICAgICJhc3luY2pzb24iOiB7ICJlbmFibGVkIiA6ICJmYWxzZSIgfQogICAgICAgIH0sCiAgICAgICAgIm92cyI6IHsKICAgICAgICAgICAgImFzeW5janNvbiI6IHsgImVuYWJsZWQiIDogImZhbHNlIiB9CiAgICAgICAgfSwKICAgICAgICAicHJvbWV0aGV1cyI6IHsKICAgICAgICAgICAgImVuYWJsZWQiOiAiZmFsc2UiCiAgICAgICAgfQogICAgfQotLS0KYXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnTWFwCm1ldGFkYXRhOgogIG5hbWU6IHNuYXQtb3BlcmF0b3ItY29uZmlnCiAgbmFtZXNwYWNlOiBhY2ktY29udGFpbmVycy1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgogICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCmRhdGE6CiAgICAic3RhcnQiOiAiNTAwMCIKICAgICJlbmQiOiAiNjUwMDAiCiAgICAicG9ydHMtcGVyLW5vZGUiOiAiMzAwMCIKLS0tCmFwaVZlcnNpb246IHYxCmtpbmQ6IFNlY3JldAptZXRhZGF0YToKICBuYW1lOiBhY2ktdXNlci1jZXJ0CiAgbmFtZXNwYWNlOiBhY2ktY29udGFpbmVycy1zeXN0ZW0KICBsYWJlbHM6CiAgICBhY2ktY29udGFpbmVycy1jb25maWctdmVyc2lvbjogImR1bW15IgpkYXRhOgogIHVzZXIua2V5OiBMUzB0TFMxQ1JVZEpUaUJRVWtsV1FWUkZJRXRGV1MwdExTMHRDazFKU1VOa1owbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJSVVpCUVZORFFXMUJkMmRuU21OQlowVkJRVzlIUWtGT2NpdEJLMmRQUzJKQlZsWnlTbk1LWWpNcldsZGlZMjVXV0c4dloyUjFlRWxVYTNadE1EbHJaV2xHUTI0clZYQXZVMGRrY1hZMlFXZ3JhbXhLWmtZM2RYWXJSbWREU25SRGVFUTROM0ZaZHdvd2NUVkVZMGRXVEVsalprWTBXbFZpT1VJNGNrcFhTMEpKTm5kS1puaDBUV1pHZFZWT1dUSTBZMmQzVVhCS2NYSk5WWEZCUkhvdlRWY3JkM0phWldoekNsTnVSbk41WlhkWVVqTTRPR1ZTTjBWTGFrUlhaV2RrU25sUVkxaEJaMDFDUVVGRlEyZFpRamxCV0dJeFdtWkNRMEpWZUVJclZXZEZWRWROTnlzMFdEa0tha2hpZVVVd1FteDRiR3RtYW5Kc2QyUjJiVk01VFRjM0t6SmFObVJMUVdkUU16TlVVazB2VUhkRlRVOVpOMUp1WkVKdksxZzJlRVJ6Vm1SalZFcEplUW8xVm5jNGVGVmFiSElyWVhWRlQyeHpNbHB1V25neE1XVTFlbWczYzFVelRtbzFTek0xUWxkU09VZFVXRW8yVUUxa2NGUTBPV3hDT1dKc2JFMXFSSEpNQ2pjck5XSkRjMlIxTmpOUE9FdGhUamxaVVVwQ1FWQkhUV0p3U0hCR2MzUkRNV05YUjNCU1VYZ3phWGRHSzFwTVdVRnlRVlZpUTB0aVYxRm1ZbWxhVkhBS1ExTTRSR2RQYlhsVk4zVkxWRkpMYVVNck1sSlpWRk16Y0hKTVZqVTNSM1ptWmtaNFNtcFVkMGQ1YTBOUlVVUnZSMEozWmpWcFQzTjVkVTFSVG5vM1N3cFNhWEppUkRCS04xSTJXV1ZSYTBwYUszQkRaVXQzZVN0T2VVbHhlR2d3VEVKRWJVSjViVk5MZGxnd1YwVkxRMmwwVDJkd2FUTXlSbGRDYjNGSWFtWXpDazFSWnk5QmEwSk1Ra3hTY1dWS2RuUnpUMjh6YlV0UE5HRXJlREpsTjNsU1ZVdHJNVU52UzNwR1RrSklNRzVWWlZoSGJsQjNhVlJPWWl0aU1XWm1VMFlLTjNaSlNtSklaRzFMWjNWS2VUQnNWVTVCTjBoYU56ZFlMMmxLVWtGclFXcHVZbVZNUzFwNmJEUnJhVkEzTTNCcFVHWjRURzB6TjJaUWFrb3JlVVJ2TkFwYWNIZFZkVnBTSzBORFdHeElTSFpQWldad09VMVdjbGRqTldWcVkwTXZSMkZETmsxWFdYbE5hblZYVFN0NFFYQnFZM1YyUVd0RlFYcFpLM0F4TkRCRENuaDNjSEk1Tld4cGJtNTJWMk5ETjA0M01EaEJTa1pwYlRNdlJsVXhNRWRFYnpjM2VVbFBTVFZvS3pVek4wcGlXV1J0TlRVMWFFOWxTQzlMYWxObGEyZ0tSVVkwVFcxNFVsQnRhWFE1T1hjOVBRb3RMUzB0TFVWT1JDQlFVa2xXUVZSRklFdEZXUzB0TFMwdENnPT0KICB1c2VyLmNydDogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSTJSRU5EUVZaRlEwRm5VRzlOUVRCSFExTnhSMU5KWWpORVVVVkNRbEZWUVUxRWQzaERla0ZLUW1kT1ZrSkJXVlJCYkZaVVRWSlpkMFpCV1VRS1ZsRlJTMFJCTVVSaFdFNXFZbmxDVkdWWVRqQmFWekY2VFZKVmQwVjNXVVJXVVZGRVJFRjRWbU15Vm5sSlJ6Rm9ZbTFTYkZwWVFYZElhR05PVFZSamR3cE9WRVV5VFdwRmVVOVVUWGRYYUdOT1RXcGpkMDVVUlRCTmFrVjVUMVJOZDFkcVFUaE5VWE4zUTFGWlJGWlJVVWRGZDBwV1ZYcEZWMDFDVVVkQk1WVkZDa05uZDA1Uk1teDZXVEk0WjFVemJIcGtSMVowWTNwRlZrMUNUVWRCTVZWRlFYZDNUVlpZVG14amFVSjBXVmMxYTFwWFZuZE5TVWRtVFVFd1IwTlRjVWNLVTBsaU0wUlJSVUpCVVZWQlFUUkhUa0ZFUTBKcFVVdENaMUZFWVM5blVHOUVhVzEzUmxaaGVXSkhPUzl0Vm0welNqRldObEEwU0dKelUwVTFURFYwVUFwYVNHOW9VWEF2YkV0bU1HaHVZWElyWjBsbWJ6VlRXSGhsTjNJdmFGbEJhV0pSYzFFdlR6WnRUVTVMZFZFelFteFRlVWhJZUdWSFZrY3ZVV1pMZVZacENtZFRUM05EV0RoaVZFaDRZbXhFVjA1MVNFbE5SVXRUWVhGNlJrdG5RVGd2ZWtaMmMwc3lXRzlpUlhCNFlrMXVjMFl3WkM5UVNHdGxlRU52ZHpGdWIwZ0tVMk5xTTBaM1NVUkJVVUZDVFVFd1IwTlRjVWRUU1dJelJGRkZRa0pSVlVGQk5FZENRVWhZSzJ0TVZHVTJURU5CUW1WM2JVTlVkazF6YW5WelNHUndXZ3ByYVRBeEsyNVJOMHRvYmtWU1lrSnRMM1JhTlhOaldrVTBZM1JKY1dOb00yNTVNVVZKVkVoT2RGbFhTMEpPTkVOa1ZVdGphblpFVnpKb01uWnJTR1ZuQ25KMFdXSldLMEZoUlhOeE1HMDBka2RHT1VWdGRuUXhZM0E1V1RReFNYbE5RbHBaY1hjNFl5OVdNVUYwYlZKUlkxSlVXVkZCT0VnelQwWkVZMmg1UWpJS01FcElVMFJ1UW05VE4yWm1VMkpDZUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQotLS0KYXBpVmVyc2lvbjogdjEKa2luZDogU2VydmljZUFjY291bnQKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgogIG5hbWVzcGFjZTogYWNpLWNvbnRhaW5lcnMtc3lzdGVtCiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKLS0tCmFwaVZlcnNpb246IHYxCmtpbmQ6IFNlcnZpY2VBY2NvdW50Cm1ldGFkYXRhOgogIG5hbWU6IGFjaS1jb250YWluZXJzLWhvc3QtYWdlbnQKICBuYW1lc3BhY2U6IGFjaS1jb250YWluZXJzLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCi0tLQphcGlWZXJzaW9uOiByYmFjLmF1dGhvcml6YXRpb24uazhzLmlvL3YxCmtpbmQ6IENsdXN0ZXJSb2xlCm1ldGFkYXRhOgogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCiAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKICBuYW1lOiBhY2ktY29udGFpbmVyczpjb250cm9sbGVyCnJ1bGVzOgotIGFwaUdyb3VwczoKICAtICIiCiAgcmVzb3VyY2VzOgogIC0gbm9kZXMKICAtIG5hbWVzcGFjZXMKICAtIHBvZHMKICAtIGVuZHBvaW50cwogIC0gc2VydmljZXMKICAtIGV2ZW50cwogIC0gcmVwbGljYXRpb25jb250cm9sbGVycwogIC0gc2VydmljZWFjY291bnRzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0CiAgLSBwYXRjaAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICIiCiAgcmVzb3VyY2VzOgogIC0gY29uZmlnbWFwcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICJhcGlleHRlbnNpb25zLms4cy5pbyIKICByZXNvdXJjZXM6CiAgLSBjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zCiAgdmVyYnM6CiAgLSAnKicKLSBhcGlHcm91cHM6CiAgLSAicmJhYy5hdXRob3JpemF0aW9uLms4cy5pbyIKICByZXNvdXJjZXM6CiAgLSBjbHVzdGVycm9sZXMKICAtIGNsdXN0ZXJyb2xlYmluZGluZ3MKICB2ZXJiczoKICAtICcqJwotIGFwaUdyb3VwczoKICAtICJuZXR3b3JraW5nLms4cy5pbyIKICByZXNvdXJjZXM6CiAgLSBuZXR3b3JrcG9saWNpZXMKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAiYXBwcyIKICByZXNvdXJjZXM6CiAgLSBkZXBsb3ltZW50cwogIC0gcmVwbGljYXNldHMKICAtIGRhZW1vbnNldHMKICAtIHN0YXRlZnVsc2V0cwogIHZlcmJzOgogIC0gJyonCi0gYXBpR3JvdXBzOgogIC0gIiIKICByZXNvdXJjZXM6CiAgLSBub2RlcwogIC0gc2VydmljZXMvc3RhdHVzCiAgdmVyYnM6CiAgLSB1cGRhdGUKLSBhcGlHcm91cHM6CiAgLSAibW9uaXRvcmluZy5jb3Jlb3MuY29tIgogIHJlc291cmNlczoKICAtIHNlcnZpY2Vtb25pdG9ycwogIHZlcmJzOgogIC0gZ2V0CiAgLSBjcmVhdGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnNuYXQiCiAgcmVzb3VyY2VzOgogIC0gc25hdHBvbGljaWVzL2ZpbmFsaXplcnMKICAtIHNuYXRwb2xpY2llcy9zdGF0dXMKICAtIG5vZGVpbmZvcwogIHZlcmJzOgogIC0gdXBkYXRlCiAgLSBjcmVhdGUKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtICJhY2kuc25hdCIKICByZXNvdXJjZXM6CiAgLSBzbmF0Z2xvYmFsaW5mb3MKICAtIHNuYXRwb2xpY2llcwogIC0gbm9kZWluZm9zCiAgLSByZGNvbmZpZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGNyZWF0ZQogIC0gdXBkYXRlCiAgLSBkZWxldGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnFvcyIKICByZXNvdXJjZXM6CiAgLSBxb3Nwb2xpY2llcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQogIC0gcGF0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYWNpLm5ldGZsb3ciCiAgcmVzb3VyY2VzOgogIC0gbmV0Zmxvd3BvbGljaWVzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0CiAgLSB1cGRhdGUKLSBhcGlHcm91cHM6CiAgLSAiYWNpLmVyc3BhbiIKICByZXNvdXJjZXM6CiAgLSBlcnNwYW5wb2xpY2llcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gdXBkYXRlCi0gYXBpR3JvdXBzOgogIC0gImFjaS5hdyIKICByZXNvdXJjZXM6CiAgLSBub2RlcG9kaWZzCiAgdmVyYnM6CiAgLSAnKicKLSBhcGlHcm91cHM6CiAgLSBhcHBzLm9wZW5zaGlmdC5pbwogIHJlc291cmNlczoKICAtIGRlcGxveW1lbnRjb25maWdzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0Ci0gYXBpR3JvdXBzOgogIC0gZGlzY292ZXJ5Lms4cy5pbwogIHJlc291cmNlczoKICAtIGVuZHBvaW50c2xpY2VzCiAgdmVyYnM6CiAgLSBnZXQKICAtIGxpc3QKICAtIHdhdGNoCi0gYXBpR3JvdXBzOgogIC0gImFjaS5uZXRwb2wiCiAgcmVzb3VyY2VzOgogIC0gbmV0d29ya3BvbGljaWVzCiAgdmVyYnM6CiAgLSBnZXQKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBjcmVhdGUKICAtIHVwZGF0ZQogIC0gZGVsZXRlCi0gYXBpR3JvdXBzOgogIC0gImFjaS5kbnNuZXRwb2wiCiAgcmVzb3VyY2VzOgogIC0gZG5zbmV0d29ya3BvbGljaWVzCiAgdmVyYnM6CiAgLSBnZXQKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBjcmVhdGUKICAtIHVwZGF0ZQogIC0gZGVsZXRlCi0tLQphcGlWZXJzaW9uOiByYmFjLmF1dGhvcml6YXRpb24uazhzLmlvL3YxCmtpbmQ6IENsdXN0ZXJSb2xlCm1ldGFkYXRhOgogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCiAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKICBuYW1lOiBhY2ktY29udGFpbmVyczpob3N0LWFnZW50CnJ1bGVzOgotIGFwaUdyb3VwczoKICAtICIiCiAgcmVzb3VyY2VzOgogIC0gbm9kZXMKICAtIG5hbWVzcGFjZXMKICAtIHBvZHMKICAtIGVuZHBvaW50cwogIC0gc2VydmljZXMKICAtIHJlcGxpY2F0aW9uY29udHJvbGxlcnMKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIHVwZGF0ZQotIGFwaUdyb3VwczoKICAtICIiCiAgcmVzb3VyY2VzOgogIC0gZXZlbnRzCiAgdmVyYnM6CiAgLSBjcmVhdGUKICAtIHBhdGNoCi0gYXBpR3JvdXBzOgogIC0gImFwaWV4dGVuc2lvbnMuazhzLmlvIgogIHJlc291cmNlczoKICAtIGN1c3RvbXJlc291cmNlZGVmaW5pdGlvbnMKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAibmV0d29ya2luZy5rOHMuaW8iCiAgcmVzb3VyY2VzOgogIC0gbmV0d29ya3BvbGljaWVzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0Ci0gYXBpR3JvdXBzOgogIC0gImFwcHMiCiAgcmVzb3VyY2VzOgogIC0gZGVwbG95bWVudHMKICAtIHJlcGxpY2FzZXRzCiAgdmVyYnM6CiAgLSBsaXN0CiAgLSB3YXRjaAogIC0gZ2V0Ci0gYXBpR3JvdXBzOgogIC0gImFjaS5zbmF0IgogIHJlc291cmNlczoKICAtIHNuYXRwb2xpY2llcwogIC0gc25hdGdsb2JhbGluZm9zCiAgLSByZGNvbmZpZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnFvcyIKICByZXNvdXJjZXM6CiAgLSBxb3Nwb2xpY2llcwogIHZlcmJzOgogIC0gbGlzdAogIC0gd2F0Y2gKICAtIGdldAogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGRlbGV0ZQogIC0gcGF0Y2gKLSBhcGlHcm91cHM6CiAgLSAiYWNpLmRyb3Bsb2ciCiAgcmVzb3VyY2VzOgogIC0gZW5hYmxlZHJvcGxvZ3MKICAtIHBydW5lZHJvcGxvZ3MKICB2ZXJiczoKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKLSBhcGlHcm91cHM6CiAgLSAiYWNpLnNuYXQiCiAgcmVzb3VyY2VzOgogIC0gbm9kZWluZm9zCiAgLSBzbmF0bG9jYWxpbmZvcwogIHZlcmJzOgogIC0gY3JlYXRlCiAgLSB1cGRhdGUKICAtIGxpc3QKICAtIHdhdGNoCiAgLSBnZXQKICAtIGRlbGV0ZQotIGFwaUdyb3VwczoKICAtIGRpc2NvdmVyeS5rOHMuaW8KICByZXNvdXJjZXM6CiAgLSBlbmRwb2ludHNsaWNlcwogIHZlcmJzOgogIC0gZ2V0CiAgLSBsaXN0CiAgLSB3YXRjaAotIGFwaUdyb3VwczoKICAtICJhY2kubmV0cG9sIgogIHJlc291cmNlczoKICAtIG5ldHdvcmtwb2xpY2llcwogIHZlcmJzOgogIC0gZ2V0CiAgLSBsaXN0CiAgLSB3YXRjaAotIGFwaUdyb3VwczoKICAtICJhY2kuYXciCiAgcmVzb3VyY2VzOgogIC0gbm9kZXBvZGlmcwogIHZlcmJzOgogIC0gIioiCi0tLQphcGlWZXJzaW9uOiByYmFjLmF1dGhvcml6YXRpb24uazhzLmlvL3YxCmtpbmQ6IENsdXN0ZXJSb2xlQmluZGluZwptZXRhZGF0YToKICBuYW1lOiBhY2ktY29udGFpbmVyczpjb250cm9sbGVyCiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKcm9sZVJlZjoKICBhcGlHcm91cDogcmJhYy5hdXRob3JpemF0aW9uLms4cy5pbwogIGtpbmQ6IENsdXN0ZXJSb2xlCiAgbmFtZTogYWNpLWNvbnRhaW5lcnM6Y29udHJvbGxlcgpzdWJqZWN0czoKLSBraW5kOiBTZXJ2aWNlQWNjb3VudAogIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICBuYW1lc3BhY2U6IGFjaS1jb250YWluZXJzLXN5c3RlbQotLS0KYXBpVmVyc2lvbjogcmJhYy5hdXRob3JpemF0aW9uLms4cy5pby92MQpraW5kOiBDbHVzdGVyUm9sZUJpbmRpbmcKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnM6aG9zdC1hZ2VudAogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCnJvbGVSZWY6CiAgYXBpR3JvdXA6IHJiYWMuYXV0aG9yaXphdGlvbi5rOHMuaW8KICBraW5kOiBDbHVzdGVyUm9sZQogIG5hbWU6IGFjaS1jb250YWluZXJzOmhvc3QtYWdlbnQKc3ViamVjdHM6Ci0ga2luZDogU2VydmljZUFjY291bnQKICBuYW1lOiBhY2ktY29udGFpbmVycy1ob3N0LWFnZW50CiAgbmFtZXNwYWNlOiBhY2ktY29udGFpbmVycy1zeXN0ZW0KLS0tCmFwaVZlcnNpb246IGFwcHMvdjEKa2luZDogRGFlbW9uU2V0Cm1ldGFkYXRhOgogIG5hbWU6IGFjaS1jb250YWluZXJzLWhvc3QKICBuYW1lc3BhY2U6IGFjaS1jb250YWluZXJzLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCiAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKc3BlYzoKICB1cGRhdGVTdHJhdGVneToKICAgIHR5cGU6IFJvbGxpbmdVcGRhdGUKICBzZWxlY3RvcjoKICAgIG1hdGNoTGFiZWxzOgogICAgICBuYW1lOiBhY2ktY29udGFpbmVycy1ob3N0CiAgICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogIHRlbXBsYXRlOgogICAgbWV0YWRhdGE6CiAgICAgIGxhYmVsczoKICAgICAgICBuYW1lOiBhY2ktY29udGFpbmVycy1ob3N0CiAgICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgICAgIGFubm90YXRpb25zOgogICAgICAgIHNjaGVkdWxlci5hbHBoYS5rdWJlcm5ldGVzLmlvL2NyaXRpY2FsLXBvZDogJycKICAgIHNwZWM6CiAgICAgIGhvc3ROZXR3b3JrOiB0cnVlCiAgICAgIGhvc3RQSUQ6IHRydWUKICAgICAgaG9zdElQQzogdHJ1ZQogICAgICBzZXJ2aWNlQWNjb3VudE5hbWU6IGFjaS1jb250YWluZXJzLWhvc3QtYWdlbnQKICAgICAgdG9sZXJhdGlvbnM6CiAgICAgICAgLSBvcGVyYXRvcjogRXhpc3RzCiAgICAgIGluaXRDb250YWluZXJzOgogICAgICAgIC0gbmFtZTogY25pZGVwbG95CiAgICAgICAgICBpbWFnZTogbm9pcm8vY25pZGVwbG95OjUuMi4zLjQuMWQxNTBkYQogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIHNlY3VyaXR5Q29udGV4dDoKICAgICAgICAgICAgY2FwYWJpbGl0aWVzOgogICAgICAgICAgICAgIGFkZDoKICAgICAgICAgICAgICAgIC0gU1lTX0FETUlOCiAgICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgICAgIC0gbmFtZTogY25pLWJpbgogICAgICAgICAgICAgIG1vdW50UGF0aDogL21udC9jbmktYmluCiAgICAgIHByaW9yaXR5Q2xhc3NOYW1lOiBzeXN0ZW0tY2x1c3Rlci1jcml0aWNhbAogICAgICBjb250YWluZXJzOgogICAgICAgIC0gbmFtZTogYWNpLWNvbnRhaW5lcnMtaG9zdAogICAgICAgICAgaW1hZ2U6IG5vaXJvL2FjaS1jb250YWluZXJzLWhvc3Q6NS4yLjMuNC4xZDE1MGRhCiAgICAgICAgICBpbWFnZVB1bGxQb2xpY3k6IEFsd2F5cwogICAgICAgICAgc2VjdXJpdHlDb250ZXh0OgogICAgICAgICAgICBjYXBhYmlsaXRpZXM6CiAgICAgICAgICAgICAgYWRkOgogICAgICAgICAgICAgICAgLSBTWVNfQURNSU4KICAgICAgICAgICAgICAgIC0gTkVUX0FETUlOCiAgICAgICAgICAgICAgICAtIFNZU19QVFJBQ0UKICAgICAgICAgICAgICAgIC0gTkVUX1JBVwogICAgICAgICAgZW52OgogICAgICAgICAgICAtIG5hbWU6IEdPVFJBQ0VCQUNLCiAgICAgICAgICAgICAgdmFsdWU6ICIyIgogICAgICAgICAgICAtIG5hbWU6IEtVQkVSTkVURVNfTk9ERV9OQU1FCiAgICAgICAgICAgICAgdmFsdWVGcm9tOgogICAgICAgICAgICAgICAgZmllbGRSZWY6CiAgICAgICAgICAgICAgICAgIGZpZWxkUGF0aDogc3BlYy5ub2RlTmFtZQogICAgICAgICAgICAtIG5hbWU6IFRFTkFOVAogICAgICAgICAgICAgIHZhbHVlOiAicmtlMiIKICAgICAgICAgICAgLSBuYW1lOiBOT0RFX0VQRwogICAgICAgICAgICAgIHZhbHVlOiAiYWNpLWNvbnRhaW5lcnMtcmtlMnxhY2ktY29udGFpbmVycy1ub2RlcyIKICAgICAgICAgICAgLSBuYW1lOiBEVVJBVElPTl9XQUlUX0ZPUl9ORVRXT1JLCiAgICAgICAgICAgICAgdmFsdWU6ICIyMTAiCiAgICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgICAgIC0gbmFtZTogY25pLWJpbgogICAgICAgICAgICAgIG1vdW50UGF0aDogL21udC9jbmktYmluCiAgICAgICAgICAgIC0gbmFtZTogY25pLWNvbmYKICAgICAgICAgICAgICBtb3VudFBhdGg6IC9tbnQvY25pLWNvbmYKICAgICAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3ZhcgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3J1bgogICAgICAgICAgICAtIG5hbWU6IG9wZmxleC1ob3N0Y29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvb3BmbGV4LWFnZW50LW92cy9iYXNlLWNvbmYuZAogICAgICAgICAgICAtIG5hbWU6IGhvc3QtY29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvYWNpLWNvbnRhaW5lcnMvCiAgICAgICAgICAgIC0gbW91bnRQYXRoOiAvcnVuL25ldG5zCiAgICAgICAgICAgICAgbmFtZTogaG9zdC1ydW4tbmV0bnMKICAgICAgICAgICAgICByZWFkT25seTogdHJ1ZQogICAgICAgICAgICAgIG1vdW50UHJvcGFnYXRpb246IEhvc3RUb0NvbnRhaW5lcgogICAgICAgICAgbGl2ZW5lc3NQcm9iZToKICAgICAgICAgICAgZmFpbHVyZVRocmVzaG9sZDogMTAKICAgICAgICAgICAgaHR0cEdldDoKICAgICAgICAgICAgICBwYXRoOiAvc3RhdHVzCiAgICAgICAgICAgICAgcG9ydDogODA5MAogICAgICAgICAgICAgIHNjaGVtZTogSFRUUAogICAgICAgICAgICBpbml0aWFsRGVsYXlTZWNvbmRzOiAxMjAKICAgICAgICAgICAgcGVyaW9kU2Vjb25kczogNjAKICAgICAgICAgICAgc3VjY2Vzc1RocmVzaG9sZDogMQogICAgICAgICAgICB0aW1lb3V0U2Vjb25kczogMzAKICAgICAgICAtIG5hbWU6IG9wZmxleC1hZ2VudAogICAgICAgICAgZW52OgogICAgICAgICAgICAtIG5hbWU6IFJFQk9PVF9XSVRIX09WUwogICAgICAgICAgICAgIHZhbHVlOiAidHJ1ZSIKICAgICAgICAgIGltYWdlOiBub2lyby9vcGZsZXg6NS4yLjMuNC4xZDE1MGRhCiAgICAgICAgICBpbWFnZVB1bGxQb2xpY3k6IEFsd2F5cwogICAgICAgICAgc2VjdXJpdHlDb250ZXh0OgogICAgICAgICAgICBjYXBhYmlsaXRpZXM6CiAgICAgICAgICAgICAgYWRkOgogICAgICAgICAgICAgICAgLSBORVRfQURNSU4KICAgICAgICAgIHZvbHVtZU1vdW50czoKICAgICAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3ZhcgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC9ydW4KICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL3J1bgogICAgICAgICAgICAtIG5hbWU6IG9wZmxleC1ob3N0Y29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvb3BmbGV4LWFnZW50LW92cy9iYXNlLWNvbmYuZAogICAgICAgICAgICAtIG5hbWU6IG9wZmxleC1jb25maWctdm9sdW1lCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvdXNyL2xvY2FsL2V0Yy9vcGZsZXgtYWdlbnQtb3ZzL2NvbmYuZAogICAgICAgIC0gbmFtZTogbWNhc3QtZGFlbW9uCiAgICAgICAgICBpbWFnZTogbm9pcm8vb3BmbGV4OjUuMi4zLjQuMWQxNTBkYQogICAgICAgICAgY29tbWFuZDogWyIvYmluL3NoIl0KICAgICAgICAgIGFyZ3M6IFsiL3Vzci9sb2NhbC9iaW4vbGF1bmNoLW1jYXN0ZGFlbW9uLnNoIl0KICAgICAgICAgIGltYWdlUHVsbFBvbGljeTogQWx3YXlzCiAgICAgICAgICB2b2x1bWVNb3VudHM6CiAgICAgICAgICAgIC0gbmFtZTogaG9zdHZhcgogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC92YXIKICAgICAgICAgICAgLSBuYW1lOiBob3N0cnVuCiAgICAgICAgICAgICAgbW91bnRQYXRoOiAvcnVuCiAgICAgICAgICAgIC0gbmFtZTogaG9zdHJ1bgogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ydW4KICAgICAgcmVzdGFydFBvbGljeTogQWx3YXlzCiAgICAgIHZvbHVtZXM6CiAgICAgICAgLSBuYW1lOiBjbmktYmluCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL29wdAogICAgICAgIC0gbmFtZTogY25pLWNvbmYKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvZXRjCiAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL3ZhcgogICAgICAgIC0gbmFtZTogaG9zdHJ1bgogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC9ydW4KICAgICAgICAtIG5hbWU6IGhvc3QtY29uZmlnLXZvbHVtZQogICAgICAgICAgY29uZmlnTWFwOgogICAgICAgICAgICBuYW1lOiBhY2ktY29udGFpbmVycy1jb25maWcKICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgLSBrZXk6IGhvc3QtYWdlbnQtY29uZmlnCiAgICAgICAgICAgICAgICBwYXRoOiBob3N0LWFnZW50LmNvbmYKICAgICAgICAtIG5hbWU6IG9wZmxleC1ob3N0Y29uZmlnLXZvbHVtZQogICAgICAgICAgZW1wdHlEaXI6CiAgICAgICAgICAgIG1lZGl1bTogTWVtb3J5CiAgICAgICAgLSBuYW1lOiBvcGZsZXgtY29uZmlnLXZvbHVtZQogICAgICAgICAgY29uZmlnTWFwOgogICAgICAgICAgICBuYW1lOiBhY2ktY29udGFpbmVycy1jb25maWcKICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgLSBrZXk6IG9wZmxleC1hZ2VudC1jb25maWcKICAgICAgICAgICAgICAgIHBhdGg6IGxvY2FsLmNvbmYKICAgICAgICAtIG5hbWU6IGhvc3QtcnVuLW5ldG5zCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL3J1bi9uZXRucwotLS0KYXBpVmVyc2lvbjogYXBwcy92MQpraW5kOiBEYWVtb25TZXQKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnMtb3BlbnZzd2l0Y2gKICBuYW1lc3BhY2U6IGFjaS1jb250YWluZXJzLXN5c3RlbQogIGxhYmVsczoKICAgIGFjaS1jb250YWluZXJzLWNvbmZpZy12ZXJzaW9uOiAiZHVtbXkiCiAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKc3BlYzoKICB1cGRhdGVTdHJhdGVneToKICAgIHR5cGU6IFJvbGxpbmdVcGRhdGUKICBzZWxlY3RvcjoKICAgIG1hdGNoTGFiZWxzOgogICAgICBuYW1lOiBhY2ktY29udGFpbmVycy1vcGVudnN3aXRjaAogICAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKICB0ZW1wbGF0ZToKICAgIG1ldGFkYXRhOgogICAgICBsYWJlbHM6CiAgICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtb3BlbnZzd2l0Y2gKICAgICAgICBuZXR3b3JrLXBsdWdpbjogYWNpLWNvbnRhaW5lcnMKICAgICAgYW5ub3RhdGlvbnM6CiAgICAgICAgc2NoZWR1bGVyLmFscGhhLmt1YmVybmV0ZXMuaW8vY3JpdGljYWwtcG9kOiAnJwogICAgc3BlYzoKICAgICAgaG9zdE5ldHdvcms6IHRydWUKICAgICAgaG9zdFBJRDogdHJ1ZQogICAgICBob3N0SVBDOiB0cnVlCiAgICAgIHNlcnZpY2VBY2NvdW50TmFtZTogYWNpLWNvbnRhaW5lcnMtaG9zdC1hZ2VudAogICAgICB0b2xlcmF0aW9uczoKICAgICAgICAtIG9wZXJhdG9yOiBFeGlzdHMKICAgICAgcHJpb3JpdHlDbGFzc05hbWU6IHN5c3RlbS1jbHVzdGVyLWNyaXRpY2FsCiAgICAgIGNvbnRhaW5lcnM6CiAgICAgICAgLSBuYW1lOiBhY2ktY29udGFpbmVycy1vcGVudnN3aXRjaAogICAgICAgICAgaW1hZ2U6IG5vaXJvL29wZW52c3dpdGNoOjUuMi4zLjQuMWQxNTBkYQogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIHJlc291cmNlczoKICAgICAgICAgICAgbGltaXRzOgogICAgICAgICAgICAgIG1lbW9yeTogIjFHaSIKICAgICAgICAgIHNlY3VyaXR5Q29udGV4dDoKICAgICAgICAgICAgY2FwYWJpbGl0aWVzOgogICAgICAgICAgICAgIGFkZDoKICAgICAgICAgICAgICAgIC0gTkVUX0FETUlOCiAgICAgICAgICAgICAgICAtIFNZU19NT0RVTEUKICAgICAgICAgICAgICAgIC0gU1lTX05JQ0UKICAgICAgICAgICAgICAgIC0gSVBDX0xPQ0sKICAgICAgICAgIGVudjoKICAgICAgICAgICAgLSBuYW1lOiBPVlNfUlVORElSCiAgICAgICAgICAgICAgdmFsdWU6IC91c3IvbG9jYWwvdmFyL3J1bi9vcGVudnN3aXRjaAogICAgICAgICAgdm9sdW1lTW91bnRzOgogICAgICAgICAgICAtIG5hbWU6IGhvc3R2YXIKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvdmFyCiAgICAgICAgICAgIC0gbmFtZTogaG9zdHJ1bgogICAgICAgICAgICAgIG1vdW50UGF0aDogL3J1bgogICAgICAgICAgICAtIG5hbWU6IGhvc3RydW4KICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvcnVuCiAgICAgICAgICAgIC0gbmFtZTogaG9zdGV0YwogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMKICAgICAgICAgICAgLSBuYW1lOiBob3N0bW9kdWxlcwogICAgICAgICAgICAgIG1vdW50UGF0aDogL2xpYi9tb2R1bGVzCiAgICAgICAgICBsaXZlbmVzc1Byb2JlOgogICAgICAgICAgICBleGVjOgogICAgICAgICAgICAgIGNvbW1hbmQ6CiAgICAgICAgICAgICAgICAtIC91c3IvbG9jYWwvYmluL2xpdmVuZXNzLW92cy5zaAogICAgICByZXN0YXJ0UG9saWN5OiBBbHdheXMKICAgICAgdm9sdW1lczoKICAgICAgICAtIG5hbWU6IGhvc3RldGMKICAgICAgICAgIGhvc3RQYXRoOgogICAgICAgICAgICBwYXRoOiAvZXRjCiAgICAgICAgLSBuYW1lOiBob3N0dmFyCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL3ZhcgogICAgICAgIC0gbmFtZTogaG9zdHJ1bgogICAgICAgICAgaG9zdFBhdGg6CiAgICAgICAgICAgIHBhdGg6IC9ydW4KICAgICAgICAtIG5hbWU6IGhvc3Rtb2R1bGVzCiAgICAgICAgICBob3N0UGF0aDoKICAgICAgICAgICAgcGF0aDogL2xpYi9tb2R1bGVzCi0tLQphcGlWZXJzaW9uOiBhcHBzL3YxCmtpbmQ6IERlcGxveW1lbnQKbWV0YWRhdGE6CiAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgogIG5hbWVzcGFjZTogYWNpLWNvbnRhaW5lcnMtc3lzdGVtCiAgbGFiZWxzOgogICAgYWNpLWNvbnRhaW5lcnMtY29uZmlnLXZlcnNpb246ICJkdW1teSIKICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgpzcGVjOgogIHJlcGxpY2FzOiAxCiAgc3RyYXRlZ3k6CiAgICB0eXBlOiBSZWNyZWF0ZQogIHNlbGVjdG9yOgogICAgbWF0Y2hMYWJlbHM6CiAgICAgIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICAgICAgbmV0d29yay1wbHVnaW46IGFjaS1jb250YWluZXJzCiAgdGVtcGxhdGU6CiAgICBtZXRhZGF0YToKICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgogICAgICBuYW1lc3BhY2U6IGFjaS1jb250YWluZXJzLXN5c3RlbQogICAgICBsYWJlbHM6CiAgICAgICAgbmFtZTogYWNpLWNvbnRhaW5lcnMtY29udHJvbGxlcgogICAgICAgIG5ldHdvcmstcGx1Z2luOiBhY2ktY29udGFpbmVycwogICAgICBhbm5vdGF0aW9uczoKICAgICAgICBzY2hlZHVsZXIuYWxwaGEua3ViZXJuZXRlcy5pby9jcml0aWNhbC1wb2Q6ICcnCiAgICBzcGVjOgogICAgICBob3N0TmV0d29yazogdHJ1ZQogICAgICBzZXJ2aWNlQWNjb3VudE5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICAgICAgdG9sZXJhdGlvbnM6CiAgICAgICAgLSBlZmZlY3Q6IE5vRXhlY3V0ZQogICAgICAgICAgb3BlcmF0b3I6IEV4aXN0cwogICAgICAgICAgdG9sZXJhdGlvblNlY29uZHM6IDYwCiAgICAgICAgLSBlZmZlY3Q6IE5vU2NoZWR1bGUKICAgICAgICAgIGtleTogbm9kZS5rdWJlcm5ldGVzLmlvL25vdC1yZWFkeQogICAgICAgICAgb3BlcmF0b3I6IEV4aXN0cwogICAgICAgIC0gZWZmZWN0OiBOb1NjaGVkdWxlCiAgICAgICAgICBrZXk6IG5vZGUtcm9sZS5rdWJlcm5ldGVzLmlvL21hc3RlcgogICAgICAgICAgb3BlcmF0b3I6IEV4aXN0cwogICAgICBwcmlvcml0eUNsYXNzTmFtZTogc3lzdGVtLW5vZGUtY3JpdGljYWwKICAgICAgY29udGFpbmVyczoKICAgICAgICAtIG5hbWU6IGFjaS1jb250YWluZXJzLWNvbnRyb2xsZXIKICAgICAgICAgIGltYWdlOiBub2lyby9hY2ktY29udGFpbmVycy1jb250cm9sbGVyOjUuMi4zLjQuMWQxNTBkYQogICAgICAgICAgaW1hZ2VQdWxsUG9saWN5OiBBbHdheXMKICAgICAgICAgIGVudjoKICAgICAgICAgICAgLSBuYW1lOiBXQVRDSF9OQU1FU1BBQ0UKICAgICAgICAgICAgICB2YWx1ZTogIiIKICAgICAgICAgICAgLSBuYW1lOiBBQ0lfU05BVF9OQU1FU1BBQ0UKICAgICAgICAgICAgICB2YWx1ZTogImFjaS1jb250YWluZXJzLXN5c3RlbSIKICAgICAgICAgICAgLSBuYW1lOiBBQ0lfU05BR0xPQkFMSU5GT19OQU1FCiAgICAgICAgICAgICAgdmFsdWU6ICJzbmF0Z2xvYmFsaW5mbyIKICAgICAgICAgICAgLSBuYW1lOiBBQ0lfUkRDT05GSUdfTkFNRQogICAgICAgICAgICAgIHZhbHVlOiAicm91dGluZ2RvbWFpbi1jb25maWciCiAgICAgICAgICAgIC0gbmFtZTogU1lTVEVNX05BTUVTUEFDRQogICAgICAgICAgICAgIHZhbHVlOiAiYWNpLWNvbnRhaW5lcnMtc3lzdGVtIgogICAgICAgICAgdm9sdW1lTW91bnRzOgogICAgICAgICAgICAtIG5hbWU6IGNvbnRyb2xsZXItY29uZmlnLXZvbHVtZQogICAgICAgICAgICAgIG1vdW50UGF0aDogL3Vzci9sb2NhbC9ldGMvYWNpLWNvbnRhaW5lcnMvCiAgICAgICAgICAgIC0gbmFtZTogYWNpLXVzZXItY2VydC12b2x1bWUKICAgICAgICAgICAgICBtb3VudFBhdGg6IC91c3IvbG9jYWwvZXRjL2FjaS1jZXJ0LwogICAgICAgICAgbGl2ZW5lc3NQcm9iZToKICAgICAgICAgICAgZmFpbHVyZVRocmVzaG9sZDogMTAKICAgICAgICAgICAgaHR0cEdldDoKICAgICAgICAgICAgICBwYXRoOiAvc3RhdHVzCiAgICAgICAgICAgICAgcG9ydDogODA5MQogICAgICAgICAgICAgIHNjaGVtZTogSFRUUAogICAgICAgICAgICBpbml0aWFsRGVsYXlTZWNvbmRzOiAxMjAKICAgICAgICAgICAgcGVyaW9kU2Vjb25kczogNjAKICAgICAgICAgICAgc3VjY2Vzc1RocmVzaG9sZDogMQogICAgICAgICAgICB0aW1lb3V0U2Vjb25kczogMzAKICAgICAgdm9sdW1lczoKICAgICAgICAtIG5hbWU6IGFjaS11c2VyLWNlcnQtdm9sdW1lCiAgICAgICAgICBzZWNyZXQ6CiAgICAgICAgICAgIHNlY3JldE5hbWU6IGFjaS11c2VyLWNlcnQKICAgICAgICAtIG5hbWU6IGNvbnRyb2xsZXItY29uZmlnLXZvbHVtZQogICAgICAgICAgY29uZmlnTWFwOgogICAgICAgICAgICBuYW1lOiBhY2ktY29udGFpbmVycy1jb25maWcKICAgICAgICAgICAgaXRlbXM6CiAgICAgICAgICAgICAgLSBrZXk6IGNvbnRyb2xsZXItY29uZmlnCiAgICAgICAgICAgICAgICBwYXRoOiBjb250cm9sbGVyLmNvbmYK"
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: acc-provision-config
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  spec: |-
+    {
+        "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
+            "aci_config": {
+                "system_id": "rke2",
+                "apic_hosts": [
+                    "10.30.120.100",
+                    "10.30.120.101",
+                    "10.30.120.102"
+                ],
+                "aep": "rke2-aep",
+                "vrf": {
+                    "name": "rke2",
+                    "tenant": "common"
+                },
+                "sync_login": {
+                    "certfile": "user.crt", 
+                    "keyfile": "user.key"
+                },
+                "vmm_domain": {
+                    "type": "Kubernetes",
+                    "encap_type": "vxlan",
+                    "mcast_fabric": "225.1.2.3",
+                    "mcast_range": {
+                        "start": "225.2.1.1",
+                        "end": "225.2.255.255"
+                    }
+                },
+                "l3out": {
+                    "name": "l3out",
+                    "external_networks": [
+                        "default",
+                        "test_ext_net"
+                    ]
+                }
+            },
+            "logging": {
+               "controller_log_level": "info", 
+               "hostagent_log_level": "info", 
+               "opflexagent_log_level": "info"
+            },
+            "net_config": {
+                "infra_vlan": 4093,
+                "service_vlan": 4003, 
+                "kubeapi_vlan": 4001,
+                "extern_static": "10.4.0.1/24",
+                "extern_dynamic": "10.3.0.1/24",
+                "node_svc_subnet": "10.5.0.1/24",
+                "pod_subnet_chunk_size": 256,
+                "node_subnet": "10.1.0.1/16",
+                "pod_subnet": "10.2.0.1/16"
+            }
+        }
+     }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aci-containers-config
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  controller-config: |-
+    {
+        "flavor": "RKE2-kubernetes-1.24",
+        "log-level": "info",
+        "apic-hosts": [
+            "10.30.120.100",
+            "10.30.120.101",
+            "10.30.120.102"
+        ],
+        "apic-username": "rke2",
+        "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "aci-prefix": "rke2",
+        "aci-vmm-type": "Kubernetes",
+        "aci-vmm-domain": "rke2",
+        "aci-vmm-controller": "rke2",
+        "aci-policy-tenant": "rke2",
+        "aci-podbd-dn": "uni/tn-rke2/BD-aci-containers-rke2-pod-bd",
+        "aci-nodebd-dn": "uni/tn-rke2/BD-aci-containers-rke2-node-bd",
+        "aci-service-phys-dom": "rke2-pdom",
+        "aci-service-encap": "vlan-4003",
+        "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
+        "aci-vrf-tenant": "common",
+        "aci-vrf-dn": "uni/tn-common/ctx-rke2",
+        "aci-l3out": "l3out",
+        "aci-ext-networks": [
+            "default",
+            "test_ext_net"
+        ],
+        "aci-vrf": "rke2",
+        "default-endpoint-group": {
+            "policy-space": "rke2",
+            "name": "aci-containers-rke2|aci-containers-default"
+        },
+        "max-nodes-svc-graph": 32,
+        "namespace-default-endpoint-group": {
+            "aci-containers-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "cattle-logging-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "cattle-monitoring-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "cattle-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "istio-operator": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-istio"
+            },
+            "istio-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-istio"
+            },
+            "kube-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            }        },
+        "service-ip-pool": [
+            {
+                "end": "10.3.0.254",
+                "start": "10.3.0.2"
+            }
+        ],
+        "extern-static": "10.4.0.1/24",
+        "extern-dynamic": "10.3.0.1/24",
+        "snat-contract-scope": "global",
+        "static-service-ip-pool": [
+            {
+                "end": "10.4.0.254",
+                "start": "10.4.0.2"
+            }
+        ],
+        "pod-ip-pool": [
+            {
+                "end": "10.2.255.254",
+                "start": "10.2.0.2"
+            }
+        ],
+        "pod-subnet-chunk-size": 256,
+        "node-service-ip-pool": [
+            {
+                "end": "10.5.0.254",
+                "start": "10.5.0.2"
+            }
+        ],
+        "node-service-subnets": [
+            "10.5.0.1/24"
+        ]
+    }
+  host-agent-config: |-
+    {
+        "flavor": "RKE2-kubernetes-1.24",
+        "app-profile": "aci-containers-rke2",
+        "opflex-mode": null,
+        "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
+        "aci-vmm-type": "Kubernetes",
+        "aci-vmm-domain": "rke2",
+        "aci-vmm-controller": "rke2",
+        "aci-prefix": "rke2",
+        "aci-vrf": "rke2",
+        "aci-vrf-tenant": "common",
+        "service-vlan": 4003,
+        "kubeapi-vlan": 4001,
+        "pod-subnet": "10.2.0.1/16",
+        "node-subnet": "10.1.0.1/16",
+        "encap-type": "vxlan",
+        "aci-infra-vlan": 4093,
+        "cni-netconfig": [
+            {
+                "gateway": "10.2.0.1",
+                "routes": [
+                    {
+                        "dst": "0.0.0.0/0",
+                        "gw": "10.2.0.1"
+                    }
+                ],
+                "subnet": "10.2.0.0/16"
+            }
+        ],
+        "default-endpoint-group": {
+            "policy-space": "rke2",
+            "name": "aci-containers-rke2|aci-containers-default"
+        },
+        "namespace-default-endpoint-group": {
+            "aci-containers-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "cattle-logging-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "cattle-monitoring-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "cattle-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "istio-operator": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-istio"
+            },
+            "istio-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-istio"
+            },
+            "kube-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            }        },
+        "enable-drop-log": true,
+        "enable-nodepodif": false,
+        "enable-ovs-hw-offload": false
+    }
+  opflex-agent-config: |-
+    {
+        "log": {
+            "level": "info"
+        },
+        "opflex": {
+            "notif" : { "enabled" : "false" },
+            "asyncjson": { "enabled" : "false" }
+        },
+        "ovs": {
+            "asyncjson": { "enabled" : "false" }
+        },
+        "prometheus": {
+            "enabled": "false"
+        }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snat-operator-config
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+    "start": "5000"
+    "end": "65000"
+    "ports-per-node": "3000"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aci-user-cert
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+data:
+  user.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUNkZ0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQW1Bd2dnSmNBZ0VBQW9HQkFOcitBK2dPS2JBVlZySnMKYjMrWldiY25WWG8vZ2R1eElUa3ZtMDlrZWlGQ24rVXAvU0dkcXY2QWgramxKZkY3dXYrRmdDSnRDeEQ4N3FZdwowcTVEY0dWTEljZkY0WlViOUI4ckpXS0JJNndKZnh0TWZGdVVOWTI0Y2d3UXBKcXJNVXFBRHovTVcrd3JaZWhzClNuRnN5ZXdYUjM4OGVSN0VLakRXZWdkSnlQY1hBZ01CQUFFQ2dZQjlBWGIxWmZCQ0JVeEIrVWdFVEdNNys0WDkKakhieUUwQmx4bGtmanJsd2R2bVM5TTc3KzJaNmRLQWdQMzNUUk0vUHdFTU9ZN1JuZEJvK1g2eERzVmRjVEpJeQo1Vnc4eFVabHIrYXVFT2xzMlpuWngxMWU1emg3c1UzTmo1SzM1QldSOUdUWEo2UE1kcFQ0OWxCOWJsbE1qRHJMCjcrNWJDc2R1NjNPOEthTjlZUUpCQVBHTWJwSHBGc3RDMWNXR3BSUXgzaXdGK1pMWUFyQVViQ0tiV1FmYmlaVHAKQ1M4RGdPbXlVN3VLVFJLaUMrMlJZVFMzcHJMVjU3R3ZmZkZ4SmpUd0d5a0NRUURvR0J3ZjVpT3N5dU1RTno3SwpSaXJiRDBKN1I2WWVRa0paK3BDZUt3eStOeUlxeGgwTEJEbUJ5bVNLdlgwV0VLQ2l0T2dwaTMyRldCb3FIamYzCk1RZy9Ba0JMQkxScWVKdnRzT28zbUtPNGEreDJlN3lSVUtrMUNvS3pGTkJIMG5VZVhHblB3aVROYitiMWZmU0YKN3ZJSmJIZG1LZ3VKeTBsVU5BN0haNzdYL2lKUkFrQWpuYmVMS1p6bDRraVA3M3BpUGZ4TG0zN2ZQakoreURvNApacHdVdVpSK0NDWGxISHZPZWZwOU1WcldjNWVqY0MvR2FDNk1XWXlNanVXTSt4QXBqY3V2QWtFQXpZK3AxNDBDCnh3cHI5NWxpbm52V2NDN043MDhBSkZpbTMvRlUxMEdEbzc3eUlPSTVoKzUzN0piWWRtNTU1aE9lSC9LalNla2gKRUY0TW14UlBtaXQ5OXc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==
+  user.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUI2RENDQVZFQ0FnUG9NQTBHQ1NxR1NJYjNEUUVCQlFVQU1Ed3hDekFKQmdOVkJBWVRBbFZUTVJZd0ZBWUQKVlFRS0RBMURhWE5qYnlCVGVYTjBaVzF6TVJVd0V3WURWUVFEREF4VmMyVnlJRzFoYm1SbFpYQXdIaGNOTVRjdwpOVEUyTWpFeU9UTXdXaGNOTWpjd05URTBNakV5T1RNd1dqQThNUXN3Q1FZRFZRUUdFd0pWVXpFV01CUUdBMVVFCkNnd05RMmx6WTI4Z1UzbHpkR1Z0Y3pFVk1CTUdBMVVFQXd3TVZYTmxjaUJ0WVc1a1pXVndNSUdmTUEwR0NTcUcKU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FEYS9nUG9EaW13RlZheWJHOS9tVm0zSjFWNlA0SGJzU0U1TDV0UApaSG9oUXAvbEtmMGhuYXIrZ0lmbzVTWHhlN3IvaFlBaWJRc1EvTzZtTU5LdVEzQmxTeUhIeGVHVkcvUWZLeVZpCmdTT3NDWDhiVEh4YmxEV051SElNRUtTYXF6RktnQTgvekZ2c0syWG9iRXB4Yk1uc0YwZC9QSGtleENvdzFub0gKU2NqM0Z3SURBUUFCTUEwR0NTcUdTSWIzRFFFQkJRVUFBNEdCQUhYK2tMVGU2TENBQmV3bUNUdk1zanVzSGRwWgpraTAxK25RN0tobkVSYkJtL3RaNXNjWkU0Y3RJcWNoM255MUVJVEhOdFlXS0JONENkVUtjanZEVzJoMnZrSGVnCnJ0WWJWK0FhRXNxMG00dkdGOUVtdnQxY3A5WTQxSXlNQlpZcXc4Yy9WMUF0bVJRY1JUWVFBOEgzT0ZEY2h5QjIKMEpIU0RuQm9TN2ZmU2JCeAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-controller
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-host-agent
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers:controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - endpoints
+  - services
+  - events
+  - replicationcontrollers
+  - serviceaccounts
+  verbs:
+  - list
+  - watch
+  - get
+  - patch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - services/status
+  verbs:
+  - update
+- apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatpolicies/finalizers
+  - snatpolicies/status
+  - nodeinfos
+  verbs:
+  - update
+  - create
+  - list
+  - watch
+  - get
+  - delete
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatglobalinfos
+  - snatpolicies
+  - nodeinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "aci.qos"
+  resources:
+  - qospolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - "aci.netflow"
+  resources:
+  - netflowpolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - "aci.erspan"
+  resources:
+  - erspanpolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - "aci.aw"
+  resources:
+  - nodepodifs
+  verbs:
+  - '*'
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "aci.netpol"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "aci.dnsnetpol"
+  resources:
+  - dnsnetworkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers:host-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - endpoints
+  - services
+  - replicationcontrollers
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatpolicies
+  - snatglobalinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.qos"
+  resources:
+  - qospolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - "aci.droplog"
+  resources:
+  - enabledroplogs
+  - prunedroplogs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - nodeinfos
+  - snatlocalinfos
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+  - delete
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "aci.netpol"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "aci.aw"
+  resources:
+  - nodepodifs
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers:controller
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers:controller
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-controller
+  namespace: aci-containers-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers:host-agent
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers:host-agent
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-host-agent
+  namespace: aci-containers-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aci-containers-host
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-host
+      network-plugin: aci-containers
+  template:
+    metadata:
+      labels:
+        name: aci-containers-host
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      serviceAccountName: aci-containers-host-agent
+      tolerations:
+        - operator: Exists
+      initContainers:
+        - name: cnideploy
+          image: noiro/cnideploy:5.2.3.4.1d150da
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+          volumeMounts:
+            - name: cni-bin
+              mountPath: /mnt/cni-bin
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: aci-containers-host
+          image: noiro/aci-containers-host:5.2.3.4.1d150da
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - NET_ADMIN
+                - SYS_PTRACE
+                - NET_RAW
+          env:
+            - name: GOTRACEBACK
+              value: "2"
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: TENANT
+              value: "rke2"
+            - name: NODE_EPG
+              value: "aci-containers-rke2|aci-containers-nodes"
+            - name: DURATION_WAIT_FOR_NETWORK
+              value: "210"
+          volumeMounts:
+            - name: cni-bin
+              mountPath: /mnt/cni-bin
+            - name: cni-conf
+              mountPath: /mnt/cni-conf
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: opflex-hostconfig-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+            - name: host-config-volume
+              mountPath: /usr/local/etc/aci-containers/
+            - mountPath: /run/netns
+              name: host-run-netns
+              readOnly: true
+              mountPropagation: HostToContainer
+          livenessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /status
+              port: 8090
+              scheme: HTTP
+            initialDelaySeconds: 120
+            periodSeconds: 60
+            successThreshold: 1
+            timeoutSeconds: 30
+        - name: opflex-agent
+          env:
+            - name: REBOOT_WITH_OVS
+              value: "true"
+          image: noiro/opflex:5.2.3.4.1d150da
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: opflex-hostconfig-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+            - name: opflex-config-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
+        - name: mcast-daemon
+          image: noiro/opflex:5.2.3.4.1d150da
+          command: ["/bin/sh"]
+          args: ["/usr/local/bin/launch-mcastdaemon.sh"]
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+      restartPolicy: Always
+      volumes:
+        - name: cni-bin
+          hostPath:
+            path: /opt
+        - name: cni-conf
+          hostPath:
+            path: /etc
+        - name: hostvar
+          hostPath:
+            path: /var
+        - name: hostrun
+          hostPath:
+            path: /run
+        - name: host-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: host-agent-config
+                path: host-agent.conf
+        - name: opflex-hostconfig-volume
+          emptyDir:
+            medium: Memory
+        - name: opflex-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: opflex-agent-config
+                path: local.conf
+        - name: host-run-netns
+          hostPath:
+            path: /run/netns
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aci-containers-openvswitch
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-openvswitch
+      network-plugin: aci-containers
+  template:
+    metadata:
+      labels:
+        name: aci-containers-openvswitch
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      serviceAccountName: aci-containers-host-agent
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: aci-containers-openvswitch
+          image: noiro/openvswitch:5.2.3.4.1d150da
+          imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "1Gi"
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - SYS_MODULE
+                - SYS_NICE
+                - IPC_LOCK
+          env:
+            - name: OVS_RUNDIR
+              value: /usr/local/var/run/openvswitch
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostrun
+              mountPath: /usr/local/run
+            - name: hostetc
+              mountPath: /usr/local/etc
+            - name: hostmodules
+              mountPath: /lib/modules
+          livenessProbe:
+            exec:
+              command:
+                - /usr/local/bin/liveness-ovs.sh
+      restartPolicy: Always
+      volumes:
+        - name: hostetc
+          hostPath:
+            path: /etc
+        - name: hostvar
+          hostPath:
+            path: /var
+        - name: hostrun
+          hostPath:
+            path: /run
+        - name: hostmodules
+          hostPath:
+            path: /lib/modules
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aci-containers-controller
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+    name: aci-containers-controller
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: aci-containers-controller
+      network-plugin: aci-containers
+  template:
+    metadata:
+      name: aci-containers-controller
+      namespace: aci-containers-system
+      labels:
+        name: aci-containers-controller
+        network-plugin: aci-containers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      serviceAccountName: aci-containers-controller
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+          tolerationSeconds: 60
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+      priorityClassName: system-node-critical
+      containers:
+        - name: aci-containers-controller
+          image: noiro/aci-containers-controller:5.2.3.4.1d150da
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: ACI_SNAT_NAMESPACE
+              value: "aci-containers-system"
+            - name: ACI_SNAGLOBALINFO_NAME
+              value: "snatglobalinfo"
+            - name: ACI_RDCONFIG_NAME
+              value: "routingdomain-config"
+            - name: SYSTEM_NAMESPACE
+              value: "aci-containers-system"
+          volumeMounts:
+            - name: controller-config-volume
+              mountPath: /usr/local/etc/aci-containers/
+            - name: aci-user-cert-volume
+              mountPath: /usr/local/etc/aci-cert/
+          livenessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /status
+              port: 8091
+              scheme: HTTP
+            initialDelaySeconds: 120
+            periodSeconds: 60
+            successThreshold: 1
+            timeoutSeconds: 30
+      volumes:
+        - name: aci-user-cert-volume
+          secret:
+            secretName: aci-user-cert
+        - name: controller-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: controller-config
+                path: controller.conf
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-operator
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers-operator
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  - namespaces
+  - configmaps
+  - secrets
+  - pods
+  - services
+  - serviceaccounts
+  - serviceaccounts/token
+  - endpoints
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.ctrl
+  resources:
+  - acicontainersoperators
+  - acicontainersoperators/status
+  - acicontainersoperators/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.ctrl
+  resources:
+  - accprovisioninputs
+  - accprovisioninputs/status
+  - accprovisioninputs/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.snat
+  resources:
+  - snatpolicies
+  - snatglobalinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - aci.snat
+  resources:
+  - nodeinfos
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+- apiGroups:
+  - config.openshift.io
+  - operator.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers-operator
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers-operator
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-operator
+  namespace: aci-containers-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aci-containers-operator
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    name: aci-containers-operator
+    network-plugin: aci-containers
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: aci-containers-operator
+      network-plugin: aci-containers
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: aci-containers-operator
+      namespace: aci-containers-system
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: aci-containers-operator
+        network-plugin: aci-containers
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
+      containers:
+      - image: noiro/aci-containers-operator:5.2.3.4.1d150da
+        imagePullPolicy: Always
+        name: aci-containers-operator
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - name: aci-operator-config
+          mountPath: /usr/local/etc/aci-containers/
+        - name: acc-provision-config
+          mountPath: /usr/local/etc/acc-provision/
+        env:
+        - name: SYSTEM_NAMESPACE
+          value: "aci-containers-system"
+        - name: ACC_PROVISION_FLAVOR
+          value: "RKE2-kubernetes-1.24"
+      - env:
+        - name: ANSIBLE_GATHERING
+          value: explicit
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ACC_PROVISION_FLAVOR
+          value: "RKE2-kubernetes-1.24"
+        - name: ACC_PROVISION_INPUT_CR_NAME
+          value: "accprovisioninput"
+        image: noiro/acc-provision-operator:5.2.3.4.1d150da
+        imagePullPolicy: Always
+        name: acc-provision-operator
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: aci-containers-operator
+      serviceAccountName: aci-containers-operator
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - name: aci-operator-config
+        configMap:
+          name: aci-operator-config
+          items:
+            - key: spec
+              path: aci-operator.conf
+      - name: acc-provision-config
+        configMap:
+          name: acc-provision-config
+          items:
+            - key: spec
+              path: acc-provision-operator.conf

--- a/provision/testdata/list_flavors.stdout.txt
+++ b/provision/testdata/list_flavors.stdout.txt
@@ -26,6 +26,7 @@ INFO: kubernetes-1.23:	Kubernetes 1.23
 INFO: kubernetes-1.22:	Kubernetes 1.22
 INFO: kubernetes-1.21:	Kubernetes 1.21
 INFO: kubernetes-1.20:	Kubernetes 1.20
+INFO: RKE2-kubernetes-1.24:	Rancher Kubernetes Engine Government kubernetes version 1.24
 INFO: RKE-1.3.18:	Rancher Kubernetes Engine min version 1.3.18
 INFO: RKE-1.3.17:	Rancher Kubernetes Engine min version 1.3.17
 INFO: RKE-1.3.13:	Rancher Kubernetes Engine min version 1.3.13


### PR DESCRIPTION
(cherry picked from commit 779da3707fd372659ddea8ea85e947b999716e5c)

added the rke2 namespace changes of provision_config.yaml in master branch to all aci-cni versions in cko-mvp-1 branch, that is in, 
acc_provision/templates/cni/aci/5.2.3.3/provision-config.yaml
acc_provision/templates/cni/aci/5.2.3.4/provision-config.yaml
acc_provision/templates/cni/aci/5.2.3.5/provision-config.yaml
acc_provision/templates/cni/aci/5.2.3.6/provision-config.yaml