### PR TITLE
add l3out-allow-all as consumer contract to istio epg to

### DIFF
--- a/provision/testdata/cko_aci_openshift_410_esx.apic.txt
+++ b/provision/testdata/cko_aci_openshift_410_esx.apic.txt
@@ -724,6 +724,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_410_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_410_baremetal.apic.txt
@@ -665,6 +665,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_410_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_410_esx.apic.txt
@@ -724,6 +724,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_410_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_410_esx_vDS_6_6_above.apic.txt
@@ -733,6 +733,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_410_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_410_openstack.apic.txt
@@ -626,6 +626,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_411_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_411_baremetal.apic.txt
@@ -665,6 +665,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_411_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_411_esx.apic.txt
@@ -724,6 +724,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_411_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_411_openstack.apic.txt
@@ -626,6 +626,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_412_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_412_baremetal.apic.txt
@@ -665,6 +665,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_412_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_412_esx.apic.txt
@@ -724,6 +724,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_412_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_412_openstack.apic.txt
@@ -626,6 +626,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_48_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_48_baremetal.apic.txt
@@ -665,6 +665,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_48_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_48_esx.apic.txt
@@ -724,6 +724,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_48_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_48_esx_vDS_6_6_above.apic.txt
@@ -733,6 +733,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_48_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_48_openstack.apic.txt
@@ -626,6 +626,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_49_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_49_baremetal.apic.txt
@@ -665,6 +665,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_49_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_49_esx.apic.txt
@@ -724,6 +724,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_49_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_49_esx_vDS_6_6_above.apic.txt
@@ -733,6 +733,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/provision/testdata/flavor_openshift_49_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_49_openstack.apic.txt
@@ -626,6 +626,14 @@ None
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "kube-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
                                     }
                                 ]
                             }


### PR DESCRIPTION
provide external communications to service mesh istio pods.

(cherry picked from commit 943eec43b95061cbc27fa5cce39c77a56554a669)