### PR TITLE
add dns contract as consumer relationship to node EPG,

### DIFF
--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -8007,6 +8007,7 @@ def openshift_flavor_specific_handling(data, items, system_id, old_naming, aci_p
         ]
     )
     data['fvTenant']['children'][0]['fvAp']['children'][1]['fvAEPg']['children'].append(consume_dns_contract_os)
+    data['fvTenant']['children'][0]['fvAp']['children'][2]['fvAEPg']['children'].append(consume_dns_contract_os)
 
     # add new contract
     for item in items:

--- a/provision/testdata/flavor_openshift_310.apic.txt
+++ b/provision/testdata/flavor_openshift_310.apic.txt
@@ -561,6 +561,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_311.apic.txt
+++ b/provision/testdata/flavor_openshift_311.apic.txt
@@ -561,6 +561,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_410_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_410_baremetal.apic.txt
@@ -577,6 +577,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_410_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_410_esx.apic.txt
@@ -636,6 +636,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_410_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_410_esx_vDS_6_6_above.apic.txt
@@ -645,6 +645,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_410_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_410_openstack.apic.txt
@@ -538,6 +538,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_411_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_411_baremetal.apic.txt
@@ -577,6 +577,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_411_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_411_esx.apic.txt
@@ -636,6 +636,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_411_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_411_esx_vDS_6_6_above.apic.txt
@@ -645,6 +645,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_411_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_411_openstack.apic.txt
@@ -538,6 +538,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_412_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_412_baremetal.apic.txt
@@ -577,6 +577,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_412_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_412_esx.apic.txt
@@ -636,6 +636,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_412_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_412_openstack.apic.txt
@@ -538,6 +538,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_43.apic.txt
+++ b/provision/testdata/flavor_openshift_43.apic.txt
@@ -577,6 +577,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_44_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_44_esx.apic.txt
@@ -636,6 +636,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_44_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_44_esx_vDS_6_6_above.apic.txt
@@ -645,6 +645,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_44_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_44_openstack.apic.txt
@@ -538,6 +538,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_45_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_45_esx.apic.txt
@@ -636,6 +636,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_45_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_45_esx_vDS_6_6_above.apic.txt
@@ -645,6 +645,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_45_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_45_openstack.apic.txt
@@ -538,6 +538,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_46_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_46_baremetal.apic.txt
@@ -577,6 +577,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_46_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_46_esx.apic.txt
@@ -636,6 +636,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_46_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_46_esx_vDS_6_6_above.apic.txt
@@ -645,6 +645,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_46_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_46_openstack.apic.txt
@@ -538,6 +538,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_47_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_47_baremetal.apic.txt
@@ -577,6 +577,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_47_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_47_esx.apic.txt
@@ -636,6 +636,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_47_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_47_esx_vDS_6_6_above.apic.txt
@@ -645,6 +645,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_47_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_47_openstack.apic.txt
@@ -538,6 +538,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_48_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_48_baremetal.apic.txt
@@ -577,6 +577,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_48_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_48_esx.apic.txt
@@ -636,6 +636,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_48_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_48_esx_vDS_6_6_above.apic.txt
@@ -645,6 +645,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_48_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_48_openstack.apic.txt
@@ -538,6 +538,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_49_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_49_baremetal.apic.txt
@@ -577,6 +577,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_49_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_49_esx.apic.txt
@@ -636,6 +636,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_49_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_49_esx_vDS_6_6_above.apic.txt
@@ -645,6 +645,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/flavor_openshift_49_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_49_openstack.apic.txt
@@ -538,6 +538,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",

--- a/provision/testdata/with_new_naming_convention_openshift.apic.txt
+++ b/provision/testdata/with_new_naming_convention_openshift.apic.txt
@@ -561,6 +561,14 @@ None
                                         }
                                     },
                                     {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-kube-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "fvRsProv": {
                                             "attributes": {
                                                 "tnVzBrCPName": "openshift-svc-catalog",


### PR DESCRIPTION
this contract is needed as dnspolicy for pod has changed to clusterfirstwithhostname from clusterfirst from OCP version 4.10 onwards.