### PR TITLE
To revert the aci-prefix change in template as prefix is only tied to…

### DIFF
--- a/provision/acc_provision/templates/cni/aci/5.2.3.3/aci-containers.yaml
+++ b/provision/acc_provision/templates/cni/aci/5.2.3.3/aci-containers.yaml
@@ -1353,11 +1353,7 @@ data:
         {% endif %}
         "apic-username": {{config.aci_config.sync_login.username|json}},
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
-        {% if config.aci_config.tenant.name %}
-        "aci-prefix": {{config.aci_config.tenant.name|json}},
-        {% else %}
         "aci-prefix": {{config.aci_config.system_id|json}},
-        {% endif %}
         "aci-vmm-type": {{config.aci_config.vmm_domain.type|json}},
         "aci-vmm-domain": {{config.aci_config.vmm_domain.domain|json}},
         "aci-vmm-controller": {{config.aci_config.vmm_domain.controller|json}},


### PR DESCRIPTION
… systemid

(cherry picked from commit 35a14341b7537e443b5e0fe0f2ceb36257db4a2d)