### PR TITLE
Pinned cryptography version to 40.0.2

### DIFF
--- a/provision/setup.py
+++ b/provision/setup.py
@@ -40,6 +40,7 @@ setup(
         ]
     },
     install_requires=[
+          'cryptography==40.0.2',
           'requests',
           'pyyaml',
           'jinja2',


### PR DESCRIPTION
cryptography 41.0.0 requires working Rust toolchain. So, pinning cryptograhy to 40.0.2