### PR TITLE
Add RKE-1.4.9 and  RKE-1.3.24 flavors.

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -1937,6 +1937,29 @@ def generate_rancher_1_3_21_yaml(config, operator_output, operator_tar, operator
             template.stream(config=config).dump(operator_output)
 
 
+def generate_rancher_1_4_9_yaml(config, operator_output, operator_tar, operator_cr_output):
+    if operator_output and operator_output != "/dev/null":
+        template = get_jinja_template('aci-network-provider-cluster-1-4-9.yaml')
+        outname = operator_output
+        # At this time, we do not use the aci-containers-operator with Rancher.
+        # The template to generate ACI CNI components is upstream in RKE code
+        # Here we generate the input file to feed into RKE, which looks almost
+        # the same as the acc-provision_input file
+
+        # If no output containers(-o) deployment file is provided, print to stdout.
+        # Else, save to file.
+        if operator_output == "-":
+            outname = "<stdout>"
+            operator_output = sys.stdout
+        info("Writing Rancher network provider portion of cluster.yml to %s" % outname)
+        info("Use this network provider section in the cluster.yml you use with RKE")
+        if operator_output != sys.stdout:
+            with open(operator_output, "w") as fh:
+                fh.write(template.render(config=config))
+        else:
+            template.stream(config=config).dump(operator_output)
+
+
 def is_calico_flavor(flavor):
     return SafeDict(FLAVORS[flavor]).get("calico_cni")
 

--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -1960,6 +1960,29 @@ def generate_rancher_1_4_9_yaml(config, operator_output, operator_tar, operator_
             template.stream(config=config).dump(operator_output)
 
 
+def generate_rancher_1_3_24_yaml(config, operator_output, operator_tar, operator_cr_output):
+    if operator_output and operator_output != "/dev/null":
+        template = get_jinja_template('aci-network-provider-cluster-1-3-24.yaml')
+        outname = operator_output
+        # At this time, we do not use the aci-containers-operator with Rancher.
+        # The template to generate ACI CNI components is upstream in RKE code
+        # Here we generate the input file to feed into RKE, which looks almost
+        # the same as the acc-provision_input file
+
+        # If no output containers(-o) deployment file is provided, print to stdout.
+        # Else, save to file.
+        if operator_output == "-":
+            outname = "<stdout>"
+            operator_output = sys.stdout
+        info("Writing Rancher network provider portion of cluster.yml to %s" % outname)
+        info("Use this network provider section in the cluster.yml you use with RKE")
+        if operator_output != sys.stdout:
+            with open(operator_output, "w") as fh:
+                fh.write(template.render(config=config))
+        else:
+            template.stream(config=config).dump(operator_output)
+
+
 def is_calico_flavor(flavor):
     return SafeDict(FLAVORS[flavor]).get("calico_cni")
 

--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -4314,6 +4314,62 @@ flavors:
     hidden: False
     status: null
     order: 54
+  RKE-1.3.24:
+    desc: Rancher Kubernetes Engine min version 1.3.24
+    default_version: 6.0
+    options:
+      template_generator: generate_rancher_1_3_24_yaml
+    config:
+      rke_config:
+        contracts:
+          - name: prometheus-monitoring
+            provided: ["aci-containers-system"]
+            consumed: ["aci-containers-istio"]
+            filter: "access-prometheus"
+        filters:
+          - name: access-prometheus
+            items:
+              - name: http
+                range: [8080, 8080]
+                etherT: ip
+                prot: tcp
+                stateful: "no"
+      kube_config:
+        allow_kube_api_default_epg: True
+        allow_pods_external_access: True
+      aci_config:
+        items:
+          - name: metrics-kubelet
+            range: [10250, 10250]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+          - name: monitoring-node
+            range: [9796, 9796]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+          - name: monitoring-ingress
+            range: [10254, 10254]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+          - name: rancher-ui
+            range: [443, 443]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+        vmm_domain:
+          type: Kubernetes
+          injected_cluster_type: RKE
+          injected_cluster_provider: Rancher
+      istio_config:
+        install_istio: False
+      multus:
+        disable: False
+    hidden: False
+    status: null
+    order: 55
   RKE-1.3.21:
     desc: Rancher Kubernetes Engine min version 1.3.21
     default_version: 6.0
@@ -4369,7 +4425,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 55
+    order: 56
   RKE-1.3.20:
     desc: Rancher Kubernetes Engine min version 1.3.20
     default_version: 6.0
@@ -4425,7 +4481,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 56
+    order: 57
   RKE-1.3.18:
     desc: Rancher Kubernetes Engine min version 1.3.18
     default_version: 6.0
@@ -4481,7 +4537,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 57
+    order: 58
   RKE-1.3.17:
     desc: Rancher Kubernetes Engine min version 1.3.17
     default_version: 6.0
@@ -4537,7 +4593,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 58
+    order: 59
   RKE-1.3.13:
     desc: Rancher Kubernetes Engine min version 1.3.13
     default_version: 6.0
@@ -4593,7 +4649,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 59
+    order: 60
   RKE-1.2.3:
     desc: Rancher Kubernetes Engine min version 1.2.3
     default_version: 6.0
@@ -4649,7 +4705,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 60
+    order: 61
   k8s-overlay:
     desc: Kubernetes basic overlay
     default_version: 6.0
@@ -4695,7 +4751,7 @@ flavors:
         enable: true
     status: Experimental
     hidden: true
-    order: 61
+    order: 62
   aks:
     desc: Azure Kubernetes Service
     default_version: 6.0
@@ -4754,7 +4810,7 @@ flavors:
                   prot: tcp
     status: Experimental
     hidden: true
-    order: 62
+    order: 63
   cloud:
     desc: Openshift IPI/AWS
     default_version: 6.0
@@ -4882,7 +4938,7 @@ flavors:
             
     status: Experimental
     hidden: true
-    order: 63
+    order: 64
   eks:
     desc: Elastic Kubernetes Service (aws)
     default_version: 6.0
@@ -5008,7 +5064,7 @@ flavors:
             
     status: Experimental
     hidden: true
-    order: 64
+    order: 65
   calico-3.23.2:
     desc: calico-3.23.2
     default_version: 5.2.3.3
@@ -5017,7 +5073,7 @@ flavors:
       template_generator: generate_calico_deployment_files
     status: Experimental
     hidden: False
-    order: 65
+    order: 66
   openshift-sdn-ovn-baremetal:
     desc: Chained CNI for Red Hat OpenShift Container Platform 4.12 on Baremetal
     default_version: 6.0
@@ -5046,4 +5102,4 @@ flavors:
         kube_default_provide_kube_api: True
     status: null
     hidden: false
-    order: 66
+    order: 67

--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -4202,6 +4202,62 @@ flavors:
     status: null
     hidden: false
     order: 52
+  RKE-1.4.9:
+    desc: Rancher Kubernetes Engine min version 1.4.9
+    default_version: 6.0
+    options:
+      template_generator: generate_rancher_1_4_9_yaml
+    config:
+      rke_config:
+        contracts:
+          - name: prometheus-monitoring
+            provided: ["aci-containers-system"]
+            consumed: ["aci-containers-istio"]
+            filter: "access-prometheus"
+        filters:
+          - name: access-prometheus
+            items:
+              - name: http
+                range: [8080, 8080]
+                etherT: ip
+                prot: tcp
+                stateful: "no"
+      kube_config:
+        allow_kube_api_default_epg: True
+        allow_pods_external_access: True
+      aci_config:
+        items:
+          - name: metrics-kubelet
+            range: [10250, 10250]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+          - name: monitoring-node
+            range: [9796, 9796]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+          - name: monitoring-ingress
+            range: [10254, 10254]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+          - name: rancher-ui
+            range: [443, 443]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+        vmm_domain:
+          type: Kubernetes
+          injected_cluster_type: RKE
+          injected_cluster_provider: Rancher
+      istio_config:
+        install_istio: False
+      multus:
+        disable: False
+    hidden: False
+    status: null
+    order: 53
   RKE-1.4.6:
     desc: Rancher Kubernetes Engine min version 1.4.6
     default_version: 6.0
@@ -4257,7 +4313,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 53
+    order: 54
   RKE-1.3.21:
     desc: Rancher Kubernetes Engine min version 1.3.21
     default_version: 6.0
@@ -4313,7 +4369,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 54
+    order: 55
   RKE-1.3.20:
     desc: Rancher Kubernetes Engine min version 1.3.20
     default_version: 6.0
@@ -4369,7 +4425,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 55
+    order: 56
   RKE-1.3.18:
     desc: Rancher Kubernetes Engine min version 1.3.18
     default_version: 6.0
@@ -4425,7 +4481,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 56
+    order: 57
   RKE-1.3.17:
     desc: Rancher Kubernetes Engine min version 1.3.17
     default_version: 6.0
@@ -4481,7 +4537,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 57
+    order: 58
   RKE-1.3.13:
     desc: Rancher Kubernetes Engine min version 1.3.13
     default_version: 6.0
@@ -4537,7 +4593,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 58
+    order: 59
   RKE-1.2.3:
     desc: Rancher Kubernetes Engine min version 1.2.3
     default_version: 6.0
@@ -4593,7 +4649,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 59
+    order: 60
   k8s-overlay:
     desc: Kubernetes basic overlay
     default_version: 6.0
@@ -4639,7 +4695,7 @@ flavors:
         enable: true
     status: Experimental
     hidden: true
-    order: 60
+    order: 61
   aks:
     desc: Azure Kubernetes Service
     default_version: 6.0
@@ -4698,7 +4754,7 @@ flavors:
                   prot: tcp
     status: Experimental
     hidden: true
-    order: 61
+    order: 62
   cloud:
     desc: Openshift IPI/AWS
     default_version: 6.0
@@ -4826,7 +4882,7 @@ flavors:
             
     status: Experimental
     hidden: true
-    order: 62
+    order: 63
   eks:
     desc: Elastic Kubernetes Service (aws)
     default_version: 6.0
@@ -4952,7 +5008,7 @@ flavors:
             
     status: Experimental
     hidden: true
-    order: 63
+    order: 64
   calico-3.23.2:
     desc: calico-3.23.2
     default_version: 5.2.3.3
@@ -4961,7 +5017,7 @@ flavors:
       template_generator: generate_calico_deployment_files
     status: Experimental
     hidden: False
-    order: 64
+    order: 65
   openshift-sdn-ovn-baremetal:
     desc: Chained CNI for Red Hat OpenShift Container Platform 4.12 on Baremetal
     default_version: 6.0
@@ -4990,4 +5046,4 @@ flavors:
         kube_default_provide_kube_api: True
     status: null
     hidden: false
-    order: 65
+    order: 66

--- a/provision/acc_provision/templates/aci-network-provider-cluster-1-3-24.yaml
+++ b/provision/acc_provision/templates/aci-network-provider-cluster-1-3-24.yaml
@@ -1,0 +1,203 @@
+network:
+  plugin: "aci"
+  aci_network_provider:
+    system_id: "{{ config.aci_config.system_id }}"
+    {% if config.aci_config.apic_refreshtime %}
+    apic_refresh_time: "{{ config.aci_config.apic_refreshtime }}"
+    {% endif %}
+    {% if config.aci_config.apic_hosts|length > 1 %}
+    apic_hosts: [{%- for apic_host in config.aci_config.apic_hosts %}{% if loop.first %}{{'"'}}{% endif %}{% if not loop.last %}{{ "\\\"%s\\\","|format(apic_host) }}{% else %}{{ "\\\"%s\\\"\""|format(apic_host) }}{% endif %}{% endfor -%}]
+    {% else %}
+    apic_hosts: [{% for apic_host in config.aci_config.apic_hosts %}{{ "\"\\\"%s\\\"\""|format(apic_host) }}{% endfor %}]
+    {% endif %}
+    token: "{{ config.registry.configuration_version }}"
+    apic_user_name: "{{ config.aci_config.sync_login.username }}"
+    apic_user_key: "{{ config.aci_config.sync_login.key_data|base64enc }}"
+    apic_user_crt: "{{ config.aci_config.sync_login.cert_data|base64enc }}"
+    encap_type: "{{ config.node_config.encap_type }}"
+    mcast_range_start: "{{ config.aci_config.vmm_domain.mcast_range.start }}"
+    mcast_range_end: "{{ config.aci_config.vmm_domain.mcast_range.end }}"
+    aep: "{{ config.aci_config.aep }}"
+    vrf_name: "{{ config.aci_config.vrf.name }}"
+    vrf_tenant: "{{ config.aci_config.vrf.tenant }}"
+    l3out: "{{ config.aci_config.l3out.name }}"
+    node_subnet: "{%- for node_subnet in config.net_config.node_subnet %}{% if loop.last %}{{ "%s"|format(node_subnet) }}{% else %}{{ "%s,"|format(node_subnet) }}{% endif %}{% endfor -%}"
+    {% if config.aci_config.l3out.external_networks|length > 1 %}
+    l3out_external_networks: [{%- for ext_net in config.aci_config.l3out.external_networks %}{% if loop.first %}{{'"'}}{% endif %}{% if not loop.last %}{{ "\\\"%s\\\","|format(ext_net) }}{% else %}{{ "\\\"%s\\\"\""|format(ext_net) }}{% endif %}{% endfor -%}]
+    {% else %}
+    l3out_external_networks: [{% for ext_net in config.aci_config.l3out.external_networks %}{{ "\"\\\"%s\\\"\""|format(ext_net) }}{% endfor %}]
+    {% endif %}
+    extern_dynamic: "{%- for extern_dynamic in config.net_config.extern_dynamic %}{% if loop.last %}{{ "%s"|format(extern_dynamic) }}{% else %}{{ "%s,"|format(extern_dynamic) }}{% endif %}{% endfor -%}"
+    extern_static: "{%- for extern_static in config.net_config.extern_static %}{% if loop.last %}{{ "%s"|format(extern_static) }}{% else %}{{ "%s,"|format(extern_static) }}{% endif %}{% endfor -%}"
+    node_svc_subnet: "{{ config.net_config.node_svc_subnet }}"
+    kube_api_vlan: "{{ config.net_config.kubeapi_vlan }}"
+    service_vlan: "{{ config.net_config.service_vlan }}"
+    infra_vlan: "{{ config.net_config.infra_vlan }}"
+    {% if config.aci_config.tenant.name %}
+    tenant: "{{ config.aci_config.tenant.name }}"
+    {% endif %}
+    {% if config.net_config.service_monitor_interval %}
+    service_monitor_interval: "{{ config.net_config.service_monitor_interval }}"
+    {% endif %}
+    {% if config.net_config.pbr_tracking_non_snat %}
+    pbr_tracking_non_snat: "{{ config.net_config.pbr_tracking_non_snat|lower() }}"
+    {% endif %}
+    {% if config.istio_config.install_istio != False %}
+    install_istio: "{{ config.istio_config.install_istio|lower() }}"
+    {% endif %}
+    {% if config.istio_config.istio_profile %}
+    istio_profile: "{{ config.istio_config.istio_profile }}"
+    {% endif %}
+    {% if config.drop_log_config.enable != True %}
+    drop_log_enable: "{{ config.drop_log_config.enable|lower() }}"
+    {% endif %}
+    {% if config.logging.size %}
+    size: {{ config.logging.size }}
+    {% endif %}
+    {% if config.logging.controller_log_level != "info" %}
+    controller_log_level: "{{ config.logging.controller_log_level }}"
+    {% endif %}
+    {% if config.logging.hostagent_log_level != "info" %}
+    hostagent_log_level: "{{ config.logging.hostagent_log_level }}"
+    {% endif %}
+    {% if config.logging.opflexagent_log_level != "info" %}
+    opflexagent_log_level: "{{ config.logging.opflexagent_log_level }}"
+    {% endif %}
+    {% if config.kube_config.ovs_memory_limit != "1Gi" %}
+    ovs_memory_limit: "{{ config.kube_config.ovs_memory_limit }}"
+    {% endif %}
+    {% if config.kube_config.ovs_memory_request != "128Mi" %}
+    ovs_memory_request: "{{ config.kube_config.ovs_memory_request }}"
+    {% endif %}
+    {% if config.kube_config.image_pull_policy != "Always" %}
+    image_pull_policy: "{{ config.kube_config.image_pull_policy }}"
+    {% endif %}
+    {% if config.registry.image_pull_secret %}
+    image_pull_secret: "{{ config.registry.image_pull_secret }}"
+    {% endif %}
+    {% if config.aci_config.apic_refreshticker_adjust %}
+    apic_refresh_ticker_adjust: "{{ config.aci_config.apic_refreshticker_adjust }}"
+    {% endif %}
+    {% if config.aci_config.apic_subscription_delay %}
+    apic_subscription_delay: "{{ config.aci_config.apic_subscription_delay }}"
+    {% endif %}
+    {% if config.aci_config.opflex_device_delete_timeout %}
+    opflex_device_delete_timeout: "{{ config.aci_config.opflex_device_delete_timeout }}"
+    {% endif %}
+    {% if config.net_config.disable_wait_for_network != False %}
+    disable_wait_for_network: "{{ config.net_config.disable_wait_for_network|lower() }}"
+    {% endif %}
+    {% if config.net_config.interface_mtu_headroom %}
+    mtu_head_room: "{{ config.net_config.interface_mtu_headroom }}"
+    {% endif %}
+    {% if config.net_config.duration_wait_for_network != 210 %}
+    duration_wait_for_network: "{{ config.net_config.duration_wait_for_network }}"
+    {% endif %}
+    {% if config.nodepodif_config.enable != False %}
+    node_pod_if_enable: "{{ config.nodepodif_config.enable|lower() }}"
+    {% endif %}
+    {% if config.sriov_config.enable != False %}
+    sriov_enable: "{{ config.sriov_config.enable|lower() }}"
+    {% endif %}
+    {% if config.kube_config.use_cluster_role != True %}
+    use_cluster_role: "{{ config.kube_config.use_cluster_role|lower() }}"
+    {% endif %}
+    {% if config.kube_config.snat_operator.disable_periodic_snat_global_info_sync != False %}
+    disable_periodic_snat_global_info_sync: "{{ config.kube_config.snat_operator.disable_periodic_snat_global_info_sync|lower() }}"
+    {% endif %}
+    {% if config.kube_config.no_wait_for_service_ep_readiness != False %}
+    no_wait_for_service_ep_readiness: "{{ config.kube_config.no_wait_for_service_ep_readiness|lower() }}"
+    {% endif %}
+    {% if config.kube_config.add_external_subnets_to_rdconfig != False %}
+    add_external_subnets_to_rdconfig: "{{ config.kube_config.add_external_subnets_to_rdconfig|lower() }}"
+    {% endif %}
+    {% if config.kube_config.service_graph_endpoint_add_delay %}
+    {% if config.kube_config.service_graph_endpoint_add_delay.delay != 0 %}
+    service_graph_endpoint_add_delay: "{{ config.kube_config.service_graph_endpoint_add_delay.delay }}"
+    {% if config.kube_config.service_graph_endpoint_add_delay.services|length > 0 %}
+    service_graph_endpoint_add_services: ["{% for delaysvc in config.kube_config.service_graph_endpoint_add_delay.services %}{{ '{' }}{% for delaysvckey, delaysvcvalue in delaysvc.items() %}{% if delaysvckey == 'name' or delaysvckey == 'namespace' or delaysvckey == 'delay' %}{{'\\\"'}}{{ "%s"|format(delaysvckey) }}{{'\\\"'}}:{{'\\\"'}}{{ "%s"|format(delaysvcvalue) }}{{'\\\"'}}{{ ", " if not loop.last else "" }}{% endif %}{% endfor %}{{ '}' }}{{ "," if not loop.last else "" }}{% endfor %}"]
+    {% endif %}
+    {% endif %}
+    {% endif %}
+    {% if config.net_config.interface_mtu %}
+    mtu: {{ config.net_config.interface_mtu }}
+    {% endif %}
+    {% if config.kube_config.snat_operator.sleep_time_snat_global_info_sync %}
+    sleep_time_snat_global_info_sync: "{{ config.kube_config.snat_operator.sleep_time_snat_global_info_sync }}"
+    {% endif %}
+    {% if config.kube_config.opflex_agent_opflex_asyncjson_enabled != "false" %}
+    opflex_agent_opflex_asyncjson_enabled: "{{ config.kube_config.opflex_agent_opflex_asyncjson_enabled|lower() }}"
+    {% endif %}
+    {% if config.kube_config.opflex_agent_ovs_asyncjson_enabled != "false" %}
+    opflex_agent_ovs_asyncjson_enabled: "{{ config.kube_config.opflex_agent_ovs_asyncjson_enabled|lower() }}"
+    {% endif %}
+    {% if config.kube_config.hpp_optimization %}
+    hpp_optimization: "{{ config.kube_config.hpp_optimization|lower() }}"
+    {% endif %}
+    {% if config.kube_config.aci_multipod == True %}
+    aci_multipod: "{{ config.kube_config.aci_multipod|lower() }}"
+    {% endif %}
+    {% if config.kube_config.aci_multipod_ubuntu == True %}
+    aci_multipod_ubuntu: "{{ config.kube_config.aci_multipod_ubuntu|lower() }}"
+    {% endif %}
+    {% if config.kube_config.dhcp_renew_max_retry_count %}
+    dhcp_renew_max_retry_count: "{{ config.kube_config.dhcp_renew_max_retry_count }}"
+    {% endif %}
+    {% if config.kube_config.dhcp_delay %}
+    dhcp_delay: "{{ config.kube_config.dhcp_delay }}"
+    {% endif %}
+    {% if config.kube_config.opflex_agent_policy_retry_delay_timer %}
+    opflex_agent_policy_retry_delay_timer: "{{ config.kube_config.opflex_agent_policy_retry_delay_timer }}"
+    {% endif %}
+    {% if config.kube_config.aci_containers_controller_memory_limit %}
+    aci_containers_controller_memory_limit: "{{ config.kube_config.aci_containers_controller_memory_limit }}"
+    {% endif %}
+    {% if config.kube_config.aci_containers_controller_memory_request %}
+    aci_containers_controller_memory_request: "{{ config.kube_config.aci_containers_controller_memory_request }}"
+    {% endif %}
+    {% if config.kube_config.aci_containers_host_memory_limit %}
+    aci_containers_host_memory_limit: "{{ config.kube_config.aci_containers_host_memory_limit }}"
+    {% endif %}
+    {% if config.kube_config.aci_containers_host_memory_request %}
+    aci_containers_host_memory_request: "{{ config.kube_config.aci_containers_host_memory_request }}"
+    {% endif %}
+    {% if config.kube_config.mcast_daemon_memory_limit %}
+    mcast_daemon_memory_limit: "{{ config.kube_config.mcast_daemon_memory_limit }}"
+    {% endif %}
+    {% if config.kube_config.mcast_daemon_memory_request %}
+    mcast_daemon_memory_request: "{{ config.kube_config.mcast_daemon_memory_request }}"
+    {% endif %}
+    {% if config.kube_config.opflex_agent_memory_limit %}
+    opflex_agent_memory_limit: "{{ config.kube_config.opflex_agent_memory_limit }}"
+    {% endif %}
+    {% if config.kube_config.opflex_agent_memory_request %}
+    opflex_agent_memory_request: "{{ config.kube_config.opflex_agent_memory_request }}"
+    {% endif %}
+    {% if config.kube_config.aci_containers_memory_limit != "3Gi" %}
+    aci_containers_memory_limit: "{{ config.kube_config.aci_containers_memory_limit }}"
+    {% endif %}
+    {% if config.kube_config.aci_containers_memory_request != "128Mi" %}
+    aci_containers_memory_request: "{{ config.kube_config.aci_containers_memory_request }}"
+    {% endif %}
+    {% if config.kube_config.use_system_node_priority_class == True %}
+    use_system_node_priority_class: "{{ config.kube_config.use_system_node_priority_class|lower() }}"
+    {% endif %}
+    {% if config.kube_config.opflex_device_reconnect_wait_timeout %}
+    opflex_device_reconnect_wait_timeout: "{{ config.kube_config.opflex_device_reconnect_wait_timeout }}"
+    {% endif %}
+services:
+  kube-controller:
+    {% if config.net_config.pod_subnet %}
+    cluster_cidr: "{%- for pod_subnet in config.net_config.pod_subnet %}{% if loop.last %}{{ "%s"|format(pod_subnet) }}{% else %}{{ "%s,"|format(pod_subnet) }}{% endif %}{% endfor -%}"  
+    {% endif %}
+{% with image_name_suffix = "" %}{% if config.registry.use_digest %}{% set image_name_suffix = "@sha256" %}{% endif %}
+{% if config.user_config.registry %}
+system_images:
+  aci_cni_deploy_container: {{ config.registry.image_prefix }}/cnideploy{{ image_name_suffix }}:{{ config.registry.cnideploy_version }}
+  aci_host_container: {{ config.registry.image_prefix }}/aci-containers-host{{ image_name_suffix }}:{{ config.registry.aci_containers_host_version }}
+  aci_opflex_container: {{ config.registry.image_prefix }}/opflex{{ image_name_suffix }}:{{ config.registry.opflex_agent_version }}
+  aci_mcast_container: {{ config.registry.image_prefix }}/opflex{{ image_name_suffix }}:{{ config.registry.opflex_agent_version }}
+  aci_ovs_container: {{ config.registry.image_prefix }}/openvswitch{{ image_name_suffix }}:{{ config.registry.openvswitch_version }}
+  aci_controller_container: {{ config.registry.image_prefix }}/aci-containers-controller{{ image_name_suffix }}:{{ config.registry.aci_containers_controller_version }}
+{% endif %}
+{% endwith %}

--- a/provision/acc_provision/templates/aci-network-provider-cluster-1-4-9.yaml
+++ b/provision/acc_provision/templates/aci-network-provider-cluster-1-4-9.yaml
@@ -1,0 +1,203 @@
+network:
+  plugin: "aci"
+  aci_network_provider:
+    system_id: "{{ config.aci_config.system_id }}"
+    {% if config.aci_config.apic_refreshtime %}
+    apic_refresh_time: "{{ config.aci_config.apic_refreshtime }}"
+    {% endif %}
+    {% if config.aci_config.apic_hosts|length > 1 %}
+    apic_hosts: [{%- for apic_host in config.aci_config.apic_hosts %}{% if loop.first %}{{'"'}}{% endif %}{% if not loop.last %}{{ "\\\"%s\\\","|format(apic_host) }}{% else %}{{ "\\\"%s\\\"\""|format(apic_host) }}{% endif %}{% endfor -%}]
+    {% else %}
+    apic_hosts: [{% for apic_host in config.aci_config.apic_hosts %}{{ "\"\\\"%s\\\"\""|format(apic_host) }}{% endfor %}]
+    {% endif %}
+    token: "{{ config.registry.configuration_version }}"
+    apic_user_name: "{{ config.aci_config.sync_login.username }}"
+    apic_user_key: "{{ config.aci_config.sync_login.key_data|base64enc }}"
+    apic_user_crt: "{{ config.aci_config.sync_login.cert_data|base64enc }}"
+    encap_type: "{{ config.node_config.encap_type }}"
+    mcast_range_start: "{{ config.aci_config.vmm_domain.mcast_range.start }}"
+    mcast_range_end: "{{ config.aci_config.vmm_domain.mcast_range.end }}"
+    aep: "{{ config.aci_config.aep }}"
+    vrf_name: "{{ config.aci_config.vrf.name }}"
+    vrf_tenant: "{{ config.aci_config.vrf.tenant }}"
+    l3out: "{{ config.aci_config.l3out.name }}"
+    node_subnet: "{%- for node_subnet in config.net_config.node_subnet %}{% if loop.last %}{{ "%s"|format(node_subnet) }}{% else %}{{ "%s,"|format(node_subnet) }}{% endif %}{% endfor -%}"
+    {% if config.aci_config.l3out.external_networks|length > 1 %}
+    l3out_external_networks: [{%- for ext_net in config.aci_config.l3out.external_networks %}{% if loop.first %}{{'"'}}{% endif %}{% if not loop.last %}{{ "\\\"%s\\\","|format(ext_net) }}{% else %}{{ "\\\"%s\\\"\""|format(ext_net) }}{% endif %}{% endfor -%}]
+    {% else %}
+    l3out_external_networks: [{% for ext_net in config.aci_config.l3out.external_networks %}{{ "\"\\\"%s\\\"\""|format(ext_net) }}{% endfor %}]
+    {% endif %}
+    extern_dynamic: "{%- for extern_dynamic in config.net_config.extern_dynamic %}{% if loop.last %}{{ "%s"|format(extern_dynamic) }}{% else %}{{ "%s,"|format(extern_dynamic) }}{% endif %}{% endfor -%}"
+    extern_static: "{%- for extern_static in config.net_config.extern_static %}{% if loop.last %}{{ "%s"|format(extern_static) }}{% else %}{{ "%s,"|format(extern_static) }}{% endif %}{% endfor -%}"
+    node_svc_subnet: "{{ config.net_config.node_svc_subnet }}"
+    kube_api_vlan: "{{ config.net_config.kubeapi_vlan }}"
+    service_vlan: "{{ config.net_config.service_vlan }}"
+    infra_vlan: "{{ config.net_config.infra_vlan }}"
+    {% if config.aci_config.tenant.name %}
+    tenant: "{{ config.aci_config.tenant.name }}"
+    {% endif %}
+    {% if config.net_config.service_monitor_interval %}
+    service_monitor_interval: "{{ config.net_config.service_monitor_interval }}"
+    {% endif %}
+    {% if config.net_config.pbr_tracking_non_snat %}
+    pbr_tracking_non_snat: "{{ config.net_config.pbr_tracking_non_snat|lower() }}"
+    {% endif %}
+    {% if config.istio_config.install_istio != False %}
+    install_istio: "{{ config.istio_config.install_istio|lower() }}"
+    {% endif %}
+    {% if config.istio_config.istio_profile %}
+    istio_profile: "{{ config.istio_config.istio_profile }}"
+    {% endif %}
+    {% if config.drop_log_config.enable != True %}
+    drop_log_enable: "{{ config.drop_log_config.enable|lower() }}"
+    {% endif %}
+    {% if config.logging.size %}
+    size: {{ config.logging.size }}
+    {% endif %}
+    {% if config.logging.controller_log_level != "info" %}
+    controller_log_level: "{{ config.logging.controller_log_level }}"
+    {% endif %}
+    {% if config.logging.hostagent_log_level != "info" %}
+    hostagent_log_level: "{{ config.logging.hostagent_log_level }}"
+    {% endif %}
+    {% if config.logging.opflexagent_log_level != "info" %}
+    opflexagent_log_level: "{{ config.logging.opflexagent_log_level }}"
+    {% endif %}
+    {% if config.kube_config.ovs_memory_limit != "1Gi" %}
+    ovs_memory_limit: "{{ config.kube_config.ovs_memory_limit }}"
+    {% endif %}
+    {% if config.kube_config.ovs_memory_request != "128Mi" %}
+    ovs_memory_request: "{{ config.kube_config.ovs_memory_request }}"
+    {% endif %}
+    {% if config.kube_config.image_pull_policy != "Always" %}
+    image_pull_policy: "{{ config.kube_config.image_pull_policy }}"
+    {% endif %}
+    {% if config.registry.image_pull_secret %}
+    image_pull_secret: "{{ config.registry.image_pull_secret }}"
+    {% endif %}
+    {% if config.aci_config.apic_refreshticker_adjust %}
+    apic_refresh_ticker_adjust: "{{ config.aci_config.apic_refreshticker_adjust }}"
+    {% endif %}
+    {% if config.aci_config.apic_subscription_delay %}
+    apic_subscription_delay: "{{ config.aci_config.apic_subscription_delay }}"
+    {% endif %}
+    {% if config.aci_config.opflex_device_delete_timeout %}
+    opflex_device_delete_timeout: "{{ config.aci_config.opflex_device_delete_timeout }}"
+    {% endif %}
+    {% if config.net_config.disable_wait_for_network != False %}
+    disable_wait_for_network: "{{ config.net_config.disable_wait_for_network|lower() }}"
+    {% endif %}
+    {% if config.net_config.interface_mtu_headroom %}
+    mtu_head_room: "{{ config.net_config.interface_mtu_headroom }}"
+    {% endif %}
+    {% if config.net_config.duration_wait_for_network != 210 %}
+    duration_wait_for_network: "{{ config.net_config.duration_wait_for_network }}"
+    {% endif %}
+    {% if config.nodepodif_config.enable != False %}
+    node_pod_if_enable: "{{ config.nodepodif_config.enable|lower() }}"
+    {% endif %}
+    {% if config.sriov_config.enable != False %}
+    sriov_enable: "{{ config.sriov_config.enable|lower() }}"
+    {% endif %}
+    {% if config.kube_config.use_cluster_role != True %}
+    use_cluster_role: "{{ config.kube_config.use_cluster_role|lower() }}"
+    {% endif %}
+    {% if config.kube_config.snat_operator.disable_periodic_snat_global_info_sync != False %}
+    disable_periodic_snat_global_info_sync: "{{ config.kube_config.snat_operator.disable_periodic_snat_global_info_sync|lower() }}"
+    {% endif %}
+    {% if config.kube_config.no_wait_for_service_ep_readiness != False %}
+    no_wait_for_service_ep_readiness: "{{ config.kube_config.no_wait_for_service_ep_readiness|lower() }}"
+    {% endif %}
+    {% if config.kube_config.add_external_subnets_to_rdconfig != False %}
+    add_external_subnets_to_rdconfig: "{{ config.kube_config.add_external_subnets_to_rdconfig|lower() }}"
+    {% endif %}
+    {% if config.kube_config.service_graph_endpoint_add_delay %}
+    {% if config.kube_config.service_graph_endpoint_add_delay.delay != 0 %}
+    service_graph_endpoint_add_delay: "{{ config.kube_config.service_graph_endpoint_add_delay.delay }}"
+    {% if config.kube_config.service_graph_endpoint_add_delay.services|length > 0 %}
+    service_graph_endpoint_add_services: ["{% for delaysvc in config.kube_config.service_graph_endpoint_add_delay.services %}{{ '{' }}{% for delaysvckey, delaysvcvalue in delaysvc.items() %}{% if delaysvckey == 'name' or delaysvckey == 'namespace' or delaysvckey == 'delay' %}{{'\\\"'}}{{ "%s"|format(delaysvckey) }}{{'\\\"'}}:{{'\\\"'}}{{ "%s"|format(delaysvcvalue) }}{{'\\\"'}}{{ ", " if not loop.last else "" }}{% endif %}{% endfor %}{{ '}' }}{{ "," if not loop.last else "" }}{% endfor %}"]
+    {% endif %}
+    {% endif %}
+    {% endif %}
+    {% if config.net_config.interface_mtu %}
+    mtu: {{ config.net_config.interface_mtu }}
+    {% endif %}
+    {% if config.kube_config.snat_operator.sleep_time_snat_global_info_sync %}
+    sleep_time_snat_global_info_sync: "{{ config.kube_config.snat_operator.sleep_time_snat_global_info_sync }}"
+    {% endif %}
+    {% if config.kube_config.opflex_agent_opflex_asyncjson_enabled != "false" %}
+    opflex_agent_opflex_asyncjson_enabled: "{{ config.kube_config.opflex_agent_opflex_asyncjson_enabled|lower() }}"
+    {% endif %}
+    {% if config.kube_config.opflex_agent_ovs_asyncjson_enabled != "false" %}
+    opflex_agent_ovs_asyncjson_enabled: "{{ config.kube_config.opflex_agent_ovs_asyncjson_enabled|lower() }}"
+    {% endif %}
+    {% if config.kube_config.hpp_optimization %}
+    hpp_optimization: "{{ config.kube_config.hpp_optimization|lower() }}"
+    {% endif %}
+    {% if config.kube_config.aci_multipod == True %}
+    aci_multipod: "{{ config.kube_config.aci_multipod|lower() }}"
+    {% endif %}
+    {% if config.kube_config.aci_multipod_ubuntu == True %}
+    aci_multipod_ubuntu: "{{ config.kube_config.aci_multipod_ubuntu|lower() }}"
+    {% endif %}
+    {% if config.kube_config.dhcp_renew_max_retry_count %}
+    dhcp_renew_max_retry_count: "{{ config.kube_config.dhcp_renew_max_retry_count }}"
+    {% endif %}
+    {% if config.kube_config.dhcp_delay %}
+    dhcp_delay: "{{ config.kube_config.dhcp_delay }}"
+    {% endif %}
+    {% if config.kube_config.opflex_agent_policy_retry_delay_timer %}
+    opflex_agent_policy_retry_delay_timer: "{{ config.kube_config.opflex_agent_policy_retry_delay_timer }}"
+    {% endif %}
+    {% if config.kube_config.aci_containers_controller_memory_limit %}
+    aci_containers_controller_memory_limit: "{{ config.kube_config.aci_containers_controller_memory_limit }}"
+    {% endif %}
+    {% if config.kube_config.aci_containers_controller_memory_request %}
+    aci_containers_controller_memory_request: "{{ config.kube_config.aci_containers_controller_memory_request }}"
+    {% endif %}
+    {% if config.kube_config.aci_containers_host_memory_limit %}
+    aci_containers_host_memory_limit: "{{ config.kube_config.aci_containers_host_memory_limit }}"
+    {% endif %}
+    {% if config.kube_config.aci_containers_host_memory_request %}
+    aci_containers_host_memory_request: "{{ config.kube_config.aci_containers_host_memory_request }}"
+    {% endif %}
+    {% if config.kube_config.mcast_daemon_memory_limit %}
+    mcast_daemon_memory_limit: "{{ config.kube_config.mcast_daemon_memory_limit }}"
+    {% endif %}
+    {% if config.kube_config.mcast_daemon_memory_request %}
+    mcast_daemon_memory_request: "{{ config.kube_config.mcast_daemon_memory_request }}"
+    {% endif %}
+    {% if config.kube_config.opflex_agent_memory_limit %}
+    opflex_agent_memory_limit: "{{ config.kube_config.opflex_agent_memory_limit }}"
+    {% endif %}
+    {% if config.kube_config.opflex_agent_memory_request %}
+    opflex_agent_memory_request: "{{ config.kube_config.opflex_agent_memory_request }}"
+    {% endif %}
+    {% if config.kube_config.aci_containers_memory_limit != "3Gi" %}
+    aci_containers_memory_limit: "{{ config.kube_config.aci_containers_memory_limit }}"
+    {% endif %}
+    {% if config.kube_config.aci_containers_memory_request != "128Mi" %}
+    aci_containers_memory_request: "{{ config.kube_config.aci_containers_memory_request }}"
+    {% endif %}
+    {% if config.kube_config.use_system_node_priority_class == True %}
+    use_system_node_priority_class: "{{ config.kube_config.use_system_node_priority_class|lower() }}"
+    {% endif %}
+    {% if config.kube_config.opflex_device_reconnect_wait_timeout %}
+    opflex_device_reconnect_wait_timeout: "{{ config.kube_config.opflex_device_reconnect_wait_timeout }}"
+    {% endif %}
+services:
+  kube-controller:
+    {% if config.net_config.pod_subnet %}
+    cluster_cidr: "{%- for pod_subnet in config.net_config.pod_subnet %}{% if loop.last %}{{ "%s"|format(pod_subnet) }}{% else %}{{ "%s,"|format(pod_subnet) }}{% endif %}{% endfor -%}"  
+    {% endif %}
+{% with image_name_suffix = "" %}{% if config.registry.use_digest %}{% set image_name_suffix = "@sha256" %}{% endif %}
+{% if config.user_config.registry %}
+system_images:
+  aci_cni_deploy_container: {{ config.registry.image_prefix }}/cnideploy{{ image_name_suffix }}:{{ config.registry.cnideploy_version }}
+  aci_host_container: {{ config.registry.image_prefix }}/aci-containers-host{{ image_name_suffix }}:{{ config.registry.aci_containers_host_version }}
+  aci_opflex_container: {{ config.registry.image_prefix }}/opflex{{ image_name_suffix }}:{{ config.registry.opflex_agent_version }}
+  aci_mcast_container: {{ config.registry.image_prefix }}/opflex{{ image_name_suffix }}:{{ config.registry.opflex_agent_version }}
+  aci_ovs_container: {{ config.registry.image_prefix }}/openvswitch{{ image_name_suffix }}:{{ config.registry.openvswitch_version }}
+  aci_controller_container: {{ config.registry.image_prefix }}/aci-containers-controller{{ image_name_suffix }}:{{ config.registry.aci_containers_controller_version }}
+{% endif %}
+{% endwith %}

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -1312,6 +1312,18 @@ def test_flavor_RKE_1_3_21_base():
 
 
 @in_testdir
+def test_flavor_RKE_1_3_24_base():
+    run_provision(
+        "flavor_RKE_1_3_24.inp.yaml",
+        "flavor_RKE_1_3_24.rke.yaml",
+        None,
+        None,
+        "flavor_RKE_1_3_24.apic.txt",
+        overrides={"flavor": "RKE-1.3.24"}
+    )
+
+
+@in_testdir
 def test_flavor_RKE_1_4_6_base():
     run_provision(
         "flavor_RKE_1_4_6.inp.yaml",

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -1324,6 +1324,18 @@ def test_flavor_RKE_1_4_6_base():
 
 
 @in_testdir
+def test_flavor_RKE_1_4_9_base():
+    run_provision(
+        "flavor_RKE_1_4_9.inp.yaml",
+        "flavor_RKE_1_4_9.rke.yaml",
+        None,
+        None,
+        "flavor_RKE_1_4_9.apic.txt",
+        overrides={"flavor": "RKE-1.4.9"}
+    )
+
+
+@in_testdir
 def test_sample():
     with tempfile.NamedTemporaryFile("wb") as tmpout:
         sys.stdout = tmpout

--- a/provision/testdata/flavor_RKE_1_3_24.apic.txt
+++ b/provision/testdata/flavor_RKE_1_3_24.apic.txt
@@ -1,0 +1,1370 @@
+/api/mo/uni/infra/vlanns-[rke-pool]-static.json
+{
+    "fvnsVlanInstP": {
+        "attributes": {
+            "name": "rke-pool",
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvnsEncapBlk": {
+                    "attributes": {
+                        "allocMode": "static",
+                        "from": "vlan-4001",
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "fvnsEncapBlk": {
+                    "attributes": {
+                        "allocMode": "static",
+                        "from": "vlan-4003",
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra/maddrns-rke-mpool.json
+{
+    "fvnsMcastAddrInstP": {
+        "attributes": {
+            "name": "rke-mpool",
+            "dn": "uni/infra/maddrns-rke-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvnsMcastAddrBlk": {
+                    "attributes": {
+                        "from": "225.2.1.1",
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/vmmp-Kubernetes/dom-rke.json
+{
+    "vmmDomP": {
+        "attributes": {
+            "name": "rke",
+            "mode": "rancher",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "vmmCtrlrP": {
+                    "attributes": {
+                        "name": "rke",
+                        "mode": "rancher",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "vmmRsDomMcastAddrNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/maddrns-rke-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra.json
+{
+    "infraAttEntityP": {
+        "attributes": {
+            "name": "rke-aep",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsDomP": {
+                    "attributes": {
+                        "tDn": "uni/vmmp-Kubernetes/dom-rke",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "infraRsDomP": {
+                    "attributes": {
+                        "tDn": "uni/phys-rke-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "infraProvAcc": {
+                    "attributes": {
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "infraRsFuncToEpg": {
+                                "attributes": {
+                                    "encap": "vlan-4093",
+                                    "mode": "regular",
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "dhcpInfraProvP": {
+                                "attributes": {
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "infraGeneric": {
+                    "attributes": {
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "infraRsFuncToEpg": {
+                                "attributes": {
+                                    "tDn": "uni/tn-tenant-1/ap-aci-containers-rke/epg-aci-containers-nodes",
+                                    "encap": "vlan-4001",
+                                    "mode": "regular",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra/attentp-rke-aep/rsdomP-[uni/vmmp-Kubernetes/dom-rke].json
+None
+/api/mo/uni/infra/attentp-rke-aep/rsdomP-[uni/phys-rke-pdom].json
+None
+/api/mo/uni/infra/attentp-rke-aep/gen-default/rsfuncToEpg-[uni/tn-tenant-1/ap-aci-containers-rke/epg-aci-containers-nodes].json
+None
+/api/mo/uni/infra.json
+{
+    "infraSetPol": {
+        "attributes": {
+            "opflexpAuthenticateClients": "no",
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/node/mo/comp/prov-Kubernetes/ctrlr-[rke]-rke/injcont/info.json
+{
+    "vmmInjectedClusterInfo": {
+        "attributes": {
+            "name": "rke",
+            "accountName": "tenant-1",
+            "type": "RKE",
+            "provider": "Rancher"
+        },
+        "children": [
+            {
+                "vmmInjectedClusterDetails": {
+                    "attributes": {
+                        "accProvisionInput": "aci_config:\n  system_id: rke\n  #use_legacy_kube_naming_convention: False\n  tenant:\n    name: tenant-1\n  apic_hosts:\n  - 10.30.120.100\n  - 10.30.120.101\n  - 10.30.120.102\n  apic_login:\n    username: admin\n    \n  apic_version: \"5.1\"\n  aep: rke-aep\n  vrf:\n    name: rke\n    tenant: common\n  l3out:\n    name: l3out\n    external_networks:\n    - default\n    - test_ext_net\n  sync_login:\n    certfile: user.crt\n    keyfile: user.key\n  vmm_domain:\n    encap_type: vxlan\n    mcast_range:\n        start: 225.2.1.1\n        end: 225.2.255.255\n  apic_refreshticker_adjust: 1\n  apic_subscription_delay: 1\n  opflex_device_delete_timeout: 1\n\nnet_config:\n  node_subnet:\n  - 10.1.0.1/16\n  - 11.1.0.1/16\n  pod_subnet:\n  - 10.2.0.1/16\n  - 12.3.0.1/16\n  extern_dynamic:\n  - 10.3.0.1/24\n  extern_static: 10.4.0.1/24\n  node_svc_subnet: 10.5.0.1/24\n  kubeapi_vlan: 4001\n  service_vlan: 4003\n  infra_vlan: 4093\n  disable_wait_for_network: True\n  duration_wait_for_network: 200\n  interface_mtu_headroom: 51\n\nkube_config:\n  aci_multipod: True\n  aci_multipod_ubuntu: True\n  dhcp_renew_max_retry_count: 12\n  dhcp_delay: 12\n  use_cluster_role: False\n  no_wait_for_service_ep_readiness: True\n  service_graph_endpoint_add_delay:\n    delay: 30 \n    services:\n    - name: \"service-name-1\"\n      namespace: \"service-ns-1\"\n    - name: \"service-name-2\"\n      namespace: \"service-ns-2\"\n      delay: 60\n  add_external_subnets_to_rdconfig: True\n  snat_operator:\n    disable_periodic_snat_global_info_sync: True\n    sleep_time_snat_global_info_sync: 60\n  hpp_optimization: True\n  opflex_agent_opflex_asyncjson_enabled: True\n  opflex_agent_ovs_asyncjson_enabled: True\n  opflex_agent_policy_retry_delay_timer: 90\n  opflex_device_reconnect_wait_timeout: 10\n  use_system_node_priority_class: False\n  aci_containers_controller_memory_limit: \"5Gi\"\n  aci_containers_controller_memory_request: \"256Mi\"\n  aci_containers_host_memory_limit: \"5Gi\"\n  aci_containers_host_memory_request: \"256Mi\"\n  mcast_daemon_memory_limit: \"5Gi\"\n  mcast_daemon_memory_request: \"256Mi\"\n  opflex_agent_memory_limit: \"5Gi\"\n  opflex_agent_memory_request: \"256Mi\"\n  aci_containers_memory_limit: \"2Gi\"\n  aci_containers_memory_request: \"256Mi\"\n  ovs_memory_limit: \"2Gi\"\n  ovs_memory_request: \"256Mi\"\n\nregistry:\n  image_prefix: quay.io/noiro\n  use_digest: True\n  aci_containers_controller_version: 375c61f113c207b152f70b4c1abc8390f23dedb73245e3d67b99c6a00dbd6bca\n  aci_containers_host_version: d37de5ac9093dff471c0602a79064a7cbac85f6513785ed86eb037ef8740ceed\n  cnideploy_version: 96f1df66843660905fa2cb07b058d8ecc5cb956c4799d661459cc0bfdfd291d2\n  opflex_agent_version: 6ae620eb8ba66a627a9c96b0e34b5d31b05aa22c9196b1885362c6273b0b76e4\n  openvswitch_version: 71d04aa713ff90ce26382bc234941beff9e51a365b3f85c76666a524b7384766\n\nlogging:\n  controller_log_level: info\n  hostagent_log_level: info\n  opflexagent_log_level: info\n\nsriov_config:\n  enable: True\n\nnodepodif_config:\n  enable: True\n",
+                        "userKey": "-----BEGIN PRIVATE KEY-----\nMIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBANr+A+gOKbAVVrJs\nb3+ZWbcnVXo/gduxITkvm09keiFCn+Up/SGdqv6Ah+jlJfF7uv+FgCJtCxD87qYw\n0q5DcGVLIcfF4ZUb9B8rJWKBI6wJfxtMfFuUNY24cgwQpJqrMUqADz/MW+wrZehs\nSnFsyewXR388eR7EKjDWegdJyPcXAgMBAAECgYB9AXb1ZfBCBUxB+UgETGM7+4X9\njHbyE0BlxlkfjrlwdvmS9M77+2Z6dKAgP33TRM/PwEMOY7RndBo+X6xDsVdcTJIy\n5Vw8xUZlr+auEOls2ZnZx11e5zh7sU3Nj5K35BWR9GTXJ6PMdpT49lB9bllMjDrL\n7+5bCsdu63O8KaN9YQJBAPGMbpHpFstC1cWGpRQx3iwF+ZLYArAUbCKbWQfbiZTp\nCS8DgOmyU7uKTRKiC+2RYTS3prLV57GvffFxJjTwGykCQQDoGBwf5iOsyuMQNz7K\nRirbD0J7R6YeQkJZ+pCeKwy+NyIqxh0LBDmBymSKvX0WEKCitOgpi32FWBoqHjf3\nMQg/AkBLBLRqeJvtsOo3mKO4a+x2e7yRUKk1CoKzFNBH0nUeXGnPwiTNb+b1ffSF\n7vIJbHdmKguJy0lUNA7HZ77X/iJRAkAjnbeLKZzl4kiP73piPfxLm37fPjJ+yDo4\nZpwUuZR+CCXlHHvOefp9MVrWc5ejcC/GaC6MWYyMjuWM+xApjcuvAkEAzY+p140C\nxwpr95linnvWcC7N708AJFim3/FU10GDo77yIOI5h+537JbYdm555hOeH/KjSekh\nEF4MmxRPmit99w==\n-----END PRIVATE KEY-----\n",
+                        "userCert": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common.json
+{
+    "fvTenant": {
+        "attributes": {
+            "name": "common",
+            "dn": "uni/tn-common"
+        },
+        "children": [
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "rke-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "rke-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "rke-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common/flt-rke-allow-all-filter.json
+None
+/api/mo/uni/tn-common/brc-rke-l3out-allow-all.json
+None
+/api/mo/uni/tn-tenant-1.json
+{
+    "fvTenant": {
+        "attributes": {
+            "name": "tenant-1",
+            "dn": "uni/tn-tenant-1"
+        },
+        "children": [
+            {
+                "fvAp": {
+                    "attributes": {
+                        "name": "aci-containers-rke",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-istio",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "rke-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-prometheus-opflex-agent",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "rke-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-prometheus-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-prometheus-opflex-agent",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "rke-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "encap": "vlan-4001",
+                                                "tDn": "uni/phys-rke-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-prometheus-opflex-agent",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-istio",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-istio",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-prometheus-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "fvBD": {
+                    "attributes": {
+                        "name": "aci-containers-rke-node-bd",
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvRsCtx": {
+                                "attributes": {
+                                    "tnFvCtxName": "rke",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsBDToOut": {
+                                "attributes": {
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "10.1.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "11.1.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "fvBD": {
+                    "attributes": {
+                        "name": "aci-containers-rke-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvRsCtx": {
+                                "attributes": {
+                                    "tnFvCtxName": "rke",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsBDToOut": {
+                                "attributes": {
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "10.2.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "12.3.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "icmp",
+                                    "etherT": "ipv4",
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "icmp6",
+                                    "etherT": "ipv6",
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "health-check",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "health-check",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "stateful": "no",
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "dns-udp",
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "6443",
+                                    "dToPort": "6443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "8443",
+                                    "dToPort": "8443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "metrics-kubelet",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "10250",
+                                    "dToPort": "10250",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "monitoring-node",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9796",
+                                    "dToPort": "9796",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "monitoring-ingress",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "10254",
+                                    "dToPort": "10254",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "rancher-ui",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "443",
+                                    "dToPort": "443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-istio-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-9080",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "sFromPort": "9080",
+                                    "sToPort": "9080",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-mixer-9090:91",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9090",
+                                    "dToPort": "9091",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-prometheus-15090",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "sFromPort": "15090",
+                                    "sToPort": "15090",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot-15010:12",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-api",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "aci-containers-api-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "health-check-subj",
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzOutTerm": {
+                                            "attributes": {
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            },
+                                            "children": [
+                                                {
+                                                    "vzRsFiltAtt": {
+                                                        "attributes": {
+                                                            "tnVzFilterName": "aci-containers-rke-health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "vzInTerm": {
+                                            "attributes": {
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            },
+                                            "children": [
+                                                {
+                                                    "vzRsFiltAtt": {
+                                                        "attributes": {
+                                                            "tnVzFilterName": "aci-containers-rke-health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-dns",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke-dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke-icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-istio",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "istio-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke-istio-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-prometheus-monitoring",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "aci-containers-rke-prometheus-monitoring-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke-access-prometheus",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-access-prometheus",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "http",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "8080",
+                                    "dToPort": "8080",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-prometheus-opflex-agent-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "prometheus-opflex-agent",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9612",
+                                    "dToPort": "9612",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-prometheus-opflex-agent",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "prometheus-opflex-agent-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke-prometheus-opflex-agent-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-default.json
+{
+    "fvRsProv": {
+        "attributes": {
+            "matchT": "AtleastOne",
+            "tnVzBrCPName": "rke-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-rke-l3out-allow-all.json
+None
+/api/mo/uni/tn-common/out-l3out/instP-test_ext_net.json
+{
+    "fvRsProv": {
+        "attributes": {
+            "matchT": "AtleastOne",
+            "tnVzBrCPName": "rke-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-test_ext_net/rsprov-rke-l3out-allow-all.json
+None
+/api/node/mo/uni/userext/user-rke.json
+{
+    "aaaUser": {
+        "attributes": {
+            "name": "rke",
+            "accountStatus": "active",
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "aaaUserDomain": {
+                    "attributes": {
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "aaaUserRole": {
+                                "attributes": {
+                                    "name": "admin",
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/node/mo/uni/userext/user-rke.json
+{
+    "aaaUser": {
+        "attributes": {
+            "name": "rke",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "aaaUserCert": {
+                    "attributes": {
+                        "name": "rke.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/provision/testdata/flavor_RKE_1_3_24.inp.yaml
+++ b/provision/testdata/flavor_RKE_1_3_24.inp.yaml
@@ -1,0 +1,109 @@
+aci_config:
+  system_id: rke
+  #use_legacy_kube_naming_convention: False
+  tenant:
+    name: tenant-1
+  apic_hosts:
+  - 10.30.120.100
+  - 10.30.120.101
+  - 10.30.120.102
+  apic_login:
+    username: admin
+    password: dummy
+  apic_version: "5.1"
+  aep: rke-aep
+  vrf:
+    name: rke
+    tenant: common
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+    - test_ext_net
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  apic_refreshticker_adjust: 1
+  apic_subscription_delay: 1
+  opflex_device_delete_timeout: 1
+
+net_config:
+  node_subnet:
+  - 10.1.0.1/16
+  - 11.1.0.1/16
+  pod_subnet:
+  - 10.2.0.1/16
+  - 12.3.0.1/16
+  extern_dynamic:
+  - 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+  disable_wait_for_network: True
+  duration_wait_for_network: 200
+  interface_mtu_headroom: 51
+
+kube_config:
+  aci_multipod: True
+  aci_multipod_ubuntu: True
+  dhcp_renew_max_retry_count: 12
+  dhcp_delay: 12
+  use_cluster_role: False
+  no_wait_for_service_ep_readiness: True
+  service_graph_endpoint_add_delay:
+    delay: 30 
+    services:
+    - name: "service-name-1"
+      namespace: "service-ns-1"
+    - name: "service-name-2"
+      namespace: "service-ns-2"
+      delay: 60
+  add_external_subnets_to_rdconfig: True
+  snat_operator:
+    disable_periodic_snat_global_info_sync: True
+    sleep_time_snat_global_info_sync: 60
+  hpp_optimization: True
+  opflex_agent_opflex_asyncjson_enabled: True
+  opflex_agent_ovs_asyncjson_enabled: True
+  opflex_agent_policy_retry_delay_timer: 90
+  opflex_device_reconnect_wait_timeout: 10
+  use_system_node_priority_class: False
+  aci_containers_controller_memory_limit: "5Gi"
+  aci_containers_controller_memory_request: "256Mi"
+  aci_containers_host_memory_limit: "5Gi"
+  aci_containers_host_memory_request: "256Mi"
+  mcast_daemon_memory_limit: "5Gi"
+  mcast_daemon_memory_request: "256Mi"
+  opflex_agent_memory_limit: "5Gi"
+  opflex_agent_memory_request: "256Mi"
+  aci_containers_memory_limit: "2Gi"
+  aci_containers_memory_request: "256Mi"
+  ovs_memory_limit: "2Gi"
+  ovs_memory_request: "256Mi"
+
+registry:
+  image_prefix: quay.io/noiro
+  use_digest: True
+  aci_containers_controller_version: 375c61f113c207b152f70b4c1abc8390f23dedb73245e3d67b99c6a00dbd6bca
+  aci_containers_host_version: d37de5ac9093dff471c0602a79064a7cbac85f6513785ed86eb037ef8740ceed
+  cnideploy_version: 96f1df66843660905fa2cb07b058d8ecc5cb956c4799d661459cc0bfdfd291d2
+  opflex_agent_version: 6ae620eb8ba66a627a9c96b0e34b5d31b05aa22c9196b1885362c6273b0b76e4
+  openvswitch_version: 71d04aa713ff90ce26382bc234941beff9e51a365b3f85c76666a524b7384766
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info
+
+sriov_config:
+  enable: True
+
+nodepodif_config:
+  enable: True

--- a/provision/testdata/flavor_RKE_1_3_24.rke.yaml
+++ b/provision/testdata/flavor_RKE_1_3_24.rke.yaml
@@ -1,0 +1,72 @@
+network:
+  plugin: "aci"
+  aci_network_provider:
+    system_id: "rke"
+    apic_hosts: ["\"10.30.120.100\",\"10.30.120.101\",\"10.30.120.102\""]
+    token: "dummy"
+    apic_user_name: "rke"
+    apic_user_key: "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUNkZ0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQW1Bd2dnSmNBZ0VBQW9HQkFOcitBK2dPS2JBVlZySnMKYjMrWldiY25WWG8vZ2R1eElUa3ZtMDlrZWlGQ24rVXAvU0dkcXY2QWgramxKZkY3dXYrRmdDSnRDeEQ4N3FZdwowcTVEY0dWTEljZkY0WlViOUI4ckpXS0JJNndKZnh0TWZGdVVOWTI0Y2d3UXBKcXJNVXFBRHovTVcrd3JaZWhzClNuRnN5ZXdYUjM4OGVSN0VLakRXZWdkSnlQY1hBZ01CQUFFQ2dZQjlBWGIxWmZCQ0JVeEIrVWdFVEdNNys0WDkKakhieUUwQmx4bGtmanJsd2R2bVM5TTc3KzJaNmRLQWdQMzNUUk0vUHdFTU9ZN1JuZEJvK1g2eERzVmRjVEpJeQo1Vnc4eFVabHIrYXVFT2xzMlpuWngxMWU1emg3c1UzTmo1SzM1QldSOUdUWEo2UE1kcFQ0OWxCOWJsbE1qRHJMCjcrNWJDc2R1NjNPOEthTjlZUUpCQVBHTWJwSHBGc3RDMWNXR3BSUXgzaXdGK1pMWUFyQVViQ0tiV1FmYmlaVHAKQ1M4RGdPbXlVN3VLVFJLaUMrMlJZVFMzcHJMVjU3R3ZmZkZ4SmpUd0d5a0NRUURvR0J3ZjVpT3N5dU1RTno3SwpSaXJiRDBKN1I2WWVRa0paK3BDZUt3eStOeUlxeGgwTEJEbUJ5bVNLdlgwV0VLQ2l0T2dwaTMyRldCb3FIamYzCk1RZy9Ba0JMQkxScWVKdnRzT28zbUtPNGEreDJlN3lSVUtrMUNvS3pGTkJIMG5VZVhHblB3aVROYitiMWZmU0YKN3ZJSmJIZG1LZ3VKeTBsVU5BN0haNzdYL2lKUkFrQWpuYmVMS1p6bDRraVA3M3BpUGZ4TG0zN2ZQakoreURvNApacHdVdVpSK0NDWGxISHZPZWZwOU1WcldjNWVqY0MvR2FDNk1XWXlNanVXTSt4QXBqY3V2QWtFQXpZK3AxNDBDCnh3cHI5NWxpbm52V2NDN043MDhBSkZpbTMvRlUxMEdEbzc3eUlPSTVoKzUzN0piWWRtNTU1aE9lSC9LalNla2gKRUY0TW14UlBtaXQ5OXc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg=="
+    apic_user_crt: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUI2RENDQVZFQ0FnUG9NQTBHQ1NxR1NJYjNEUUVCQlFVQU1Ed3hDekFKQmdOVkJBWVRBbFZUTVJZd0ZBWUQKVlFRS0RBMURhWE5qYnlCVGVYTjBaVzF6TVJVd0V3WURWUVFEREF4VmMyVnlJRzFoYm1SbFpYQXdIaGNOTVRjdwpOVEUyTWpFeU9UTXdXaGNOTWpjd05URTBNakV5T1RNd1dqQThNUXN3Q1FZRFZRUUdFd0pWVXpFV01CUUdBMVVFCkNnd05RMmx6WTI4Z1UzbHpkR1Z0Y3pFVk1CTUdBMVVFQXd3TVZYTmxjaUJ0WVc1a1pXVndNSUdmTUEwR0NTcUcKU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FEYS9nUG9EaW13RlZheWJHOS9tVm0zSjFWNlA0SGJzU0U1TDV0UApaSG9oUXAvbEtmMGhuYXIrZ0lmbzVTWHhlN3IvaFlBaWJRc1EvTzZtTU5LdVEzQmxTeUhIeGVHVkcvUWZLeVZpCmdTT3NDWDhiVEh4YmxEV051SElNRUtTYXF6RktnQTgvekZ2c0syWG9iRXB4Yk1uc0YwZC9QSGtleENvdzFub0gKU2NqM0Z3SURBUUFCTUEwR0NTcUdTSWIzRFFFQkJRVUFBNEdCQUhYK2tMVGU2TENBQmV3bUNUdk1zanVzSGRwWgpraTAxK25RN0tobkVSYkJtL3RaNXNjWkU0Y3RJcWNoM255MUVJVEhOdFlXS0JONENkVUtjanZEVzJoMnZrSGVnCnJ0WWJWK0FhRXNxMG00dkdGOUVtdnQxY3A5WTQxSXlNQlpZcXc4Yy9WMUF0bVJRY1JUWVFBOEgzT0ZEY2h5QjIKMEpIU0RuQm9TN2ZmU2JCeAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+    encap_type: "vxlan"
+    mcast_range_start: "225.2.1.1"
+    mcast_range_end: "225.2.255.255"
+    aep: "rke-aep"
+    vrf_name: "rke"
+    vrf_tenant: "common"
+    l3out: "l3out"
+    node_subnet: "10.1.0.1/16,11.1.0.1/16"
+    l3out_external_networks: ["\"default\",\"test_ext_net\""]
+    extern_dynamic: "10.3.0.1/24"
+    extern_static: "10.4.0.1/24"
+    node_svc_subnet: "10.5.0.1/24"
+    kube_api_vlan: "4001"
+    service_vlan: "4003"
+    infra_vlan: "4093"
+    tenant: "tenant-1"
+    service_monitor_interval: "5"
+    ovs_memory_limit: "2Gi"
+    ovs_memory_request: "256Mi"
+    apic_refresh_ticker_adjust: "1"
+    apic_subscription_delay: "1"
+    opflex_device_delete_timeout: "1"
+    disable_wait_for_network: "true"
+    mtu_head_room: "51"
+    duration_wait_for_network: "200"
+    node_pod_if_enable: "true"
+    sriov_enable: "true"
+    use_cluster_role: "false"
+    disable_periodic_snat_global_info_sync: "true"
+    no_wait_for_service_ep_readiness: "true"
+    add_external_subnets_to_rdconfig: "true"
+    service_graph_endpoint_add_delay: "30"
+    service_graph_endpoint_add_services: ["{\"name\":\"service-name-1\", \"namespace\":\"service-ns-1\"},{\"name\":\"service-name-2\", \"namespace\":\"service-ns-2\", \"delay\":\"60\"}"]
+    sleep_time_snat_global_info_sync: "60"
+    opflex_agent_opflex_asyncjson_enabled: "true"
+    opflex_agent_ovs_asyncjson_enabled: "true"
+    hpp_optimization: "true"
+    aci_multipod: "true"
+    aci_multipod_ubuntu: "true"
+    dhcp_renew_max_retry_count: "12"
+    dhcp_delay: "12"
+    opflex_agent_policy_retry_delay_timer: "90"
+    aci_containers_controller_memory_limit: "5Gi"
+    aci_containers_controller_memory_request: "256Mi"
+    aci_containers_host_memory_limit: "5Gi"
+    aci_containers_host_memory_request: "256Mi"
+    mcast_daemon_memory_limit: "5Gi"
+    mcast_daemon_memory_request: "256Mi"
+    opflex_agent_memory_limit: "5Gi"
+    opflex_agent_memory_request: "256Mi"
+    aci_containers_memory_limit: "2Gi"
+    aci_containers_memory_request: "256Mi"
+    opflex_device_reconnect_wait_timeout: "10"
+services:
+  kube-controller:
+    cluster_cidr: "10.2.0.1/16,12.3.0.1/16"  
+system_images:
+  aci_cni_deploy_container: quay.io/noiro/cnideploy@sha256:96f1df66843660905fa2cb07b058d8ecc5cb956c4799d661459cc0bfdfd291d2
+  aci_host_container: quay.io/noiro/aci-containers-host@sha256:d37de5ac9093dff471c0602a79064a7cbac85f6513785ed86eb037ef8740ceed
+  aci_opflex_container: quay.io/noiro/opflex@sha256:6ae620eb8ba66a627a9c96b0e34b5d31b05aa22c9196b1885362c6273b0b76e4
+  aci_mcast_container: quay.io/noiro/opflex@sha256:6ae620eb8ba66a627a9c96b0e34b5d31b05aa22c9196b1885362c6273b0b76e4
+  aci_ovs_container: quay.io/noiro/openvswitch@sha256:71d04aa713ff90ce26382bc234941beff9e51a365b3f85c76666a524b7384766
+  aci_controller_container: quay.io/noiro/aci-containers-controller@sha256:375c61f113c207b152f70b4c1abc8390f23dedb73245e3d67b99c6a00dbd6bca

--- a/provision/testdata/flavor_RKE_1_4_9.apic.txt
+++ b/provision/testdata/flavor_RKE_1_4_9.apic.txt
@@ -1,0 +1,1370 @@
+/api/mo/uni/infra/vlanns-[rke-pool]-static.json
+{
+    "fvnsVlanInstP": {
+        "attributes": {
+            "name": "rke-pool",
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvnsEncapBlk": {
+                    "attributes": {
+                        "allocMode": "static",
+                        "from": "vlan-4001",
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "fvnsEncapBlk": {
+                    "attributes": {
+                        "allocMode": "static",
+                        "from": "vlan-4003",
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra/maddrns-rke-mpool.json
+{
+    "fvnsMcastAddrInstP": {
+        "attributes": {
+            "name": "rke-mpool",
+            "dn": "uni/infra/maddrns-rke-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvnsMcastAddrBlk": {
+                    "attributes": {
+                        "from": "225.2.1.1",
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/vmmp-Kubernetes/dom-rke.json
+{
+    "vmmDomP": {
+        "attributes": {
+            "name": "rke",
+            "mode": "rancher",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "vmmCtrlrP": {
+                    "attributes": {
+                        "name": "rke",
+                        "mode": "rancher",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "vmmRsDomMcastAddrNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/maddrns-rke-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra.json
+{
+    "infraAttEntityP": {
+        "attributes": {
+            "name": "rke-aep",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsDomP": {
+                    "attributes": {
+                        "tDn": "uni/vmmp-Kubernetes/dom-rke",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "infraRsDomP": {
+                    "attributes": {
+                        "tDn": "uni/phys-rke-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "infraProvAcc": {
+                    "attributes": {
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "infraRsFuncToEpg": {
+                                "attributes": {
+                                    "encap": "vlan-4093",
+                                    "mode": "regular",
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "dhcpInfraProvP": {
+                                "attributes": {
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "infraGeneric": {
+                    "attributes": {
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "infraRsFuncToEpg": {
+                                "attributes": {
+                                    "tDn": "uni/tn-tenant-1/ap-aci-containers-rke/epg-aci-containers-nodes",
+                                    "encap": "vlan-4001",
+                                    "mode": "regular",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra/attentp-rke-aep/rsdomP-[uni/vmmp-Kubernetes/dom-rke].json
+None
+/api/mo/uni/infra/attentp-rke-aep/rsdomP-[uni/phys-rke-pdom].json
+None
+/api/mo/uni/infra/attentp-rke-aep/gen-default/rsfuncToEpg-[uni/tn-tenant-1/ap-aci-containers-rke/epg-aci-containers-nodes].json
+None
+/api/mo/uni/infra.json
+{
+    "infraSetPol": {
+        "attributes": {
+            "opflexpAuthenticateClients": "no",
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/node/mo/comp/prov-Kubernetes/ctrlr-[rke]-rke/injcont/info.json
+{
+    "vmmInjectedClusterInfo": {
+        "attributes": {
+            "name": "rke",
+            "accountName": "tenant-1",
+            "type": "RKE",
+            "provider": "Rancher"
+        },
+        "children": [
+            {
+                "vmmInjectedClusterDetails": {
+                    "attributes": {
+                        "accProvisionInput": "aci_config:\n  system_id: rke\n  #use_legacy_kube_naming_convention: False\n  tenant:\n    name: tenant-1\n  apic_hosts:\n  - 10.30.120.100\n  - 10.30.120.101\n  - 10.30.120.102\n  apic_login:\n    username: admin\n    \n  apic_version: \"5.1\"\n  aep: rke-aep\n  vrf:\n    name: rke\n    tenant: common\n  l3out:\n    name: l3out\n    external_networks:\n    - default\n    - test_ext_net\n  sync_login:\n    certfile: user.crt\n    keyfile: user.key\n  vmm_domain:\n    encap_type: vxlan\n    mcast_range:\n        start: 225.2.1.1\n        end: 225.2.255.255\n  apic_refreshticker_adjust: 1\n  apic_subscription_delay: 1\n  opflex_device_delete_timeout: 1\n\nnet_config:\n  node_subnet:\n  - 10.1.0.1/16\n  - 11.1.0.1/16\n  pod_subnet:\n  - 10.2.0.1/16\n  - 12.3.0.1/16\n  extern_dynamic:\n  - 10.3.0.1/24\n  extern_static: 10.4.0.1/24\n  node_svc_subnet: 10.5.0.1/24\n  kubeapi_vlan: 4001\n  service_vlan: 4003\n  infra_vlan: 4093\n  disable_wait_for_network: True\n  duration_wait_for_network: 200\n  interface_mtu_headroom: 51\n\nkube_config:\n  aci_multipod: True\n  aci_multipod_ubuntu: True\n  dhcp_renew_max_retry_count: 12\n  dhcp_delay: 12\n  use_cluster_role: False\n  no_wait_for_service_ep_readiness: True\n  service_graph_endpoint_add_delay:\n    delay: 30 \n    services:\n    - name: \"service-name-1\"\n      namespace: \"service-ns-1\"\n    - name: \"service-name-2\"\n      namespace: \"service-ns-2\"\n      delay: 60\n  add_external_subnets_to_rdconfig: True\n  snat_operator:\n    disable_periodic_snat_global_info_sync: True\n    sleep_time_snat_global_info_sync: 60\n  hpp_optimization: True\n  opflex_agent_opflex_asyncjson_enabled: True\n  opflex_agent_ovs_asyncjson_enabled: True\n  opflex_agent_policy_retry_delay_timer: 90\n  opflex_device_reconnect_wait_timeout: 10\n  use_system_node_priority_class: False\n  aci_containers_controller_memory_limit: \"5Gi\"\n  aci_containers_controller_memory_request: \"256Mi\"\n  aci_containers_host_memory_limit: \"5Gi\"\n  aci_containers_host_memory_request: \"256Mi\"\n  mcast_daemon_memory_limit: \"5Gi\"\n  mcast_daemon_memory_request: \"256Mi\"\n  opflex_agent_memory_limit: \"5Gi\"\n  opflex_agent_memory_request: \"256Mi\"\n  aci_containers_memory_limit: \"2Gi\"\n  aci_containers_memory_request: \"256Mi\"\n  ovs_memory_limit: \"2Gi\"\n  ovs_memory_request: \"256Mi\"\n\nregistry:\n  image_prefix: quay.io/noiro\n  use_digest: True\n  aci_containers_controller_version: 375c61f113c207b152f70b4c1abc8390f23dedb73245e3d67b99c6a00dbd6bca\n  aci_containers_host_version: d37de5ac9093dff471c0602a79064a7cbac85f6513785ed86eb037ef8740ceed\n  cnideploy_version: 96f1df66843660905fa2cb07b058d8ecc5cb956c4799d661459cc0bfdfd291d2\n  opflex_agent_version: 6ae620eb8ba66a627a9c96b0e34b5d31b05aa22c9196b1885362c6273b0b76e4\n  openvswitch_version: 71d04aa713ff90ce26382bc234941beff9e51a365b3f85c76666a524b7384766\n\nlogging:\n  controller_log_level: info\n  hostagent_log_level: info\n  opflexagent_log_level: info\n\nsriov_config:\n  enable: True\n\nnodepodif_config:\n  enable: True\n",
+                        "userKey": "-----BEGIN PRIVATE KEY-----\nMIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBANr+A+gOKbAVVrJs\nb3+ZWbcnVXo/gduxITkvm09keiFCn+Up/SGdqv6Ah+jlJfF7uv+FgCJtCxD87qYw\n0q5DcGVLIcfF4ZUb9B8rJWKBI6wJfxtMfFuUNY24cgwQpJqrMUqADz/MW+wrZehs\nSnFsyewXR388eR7EKjDWegdJyPcXAgMBAAECgYB9AXb1ZfBCBUxB+UgETGM7+4X9\njHbyE0BlxlkfjrlwdvmS9M77+2Z6dKAgP33TRM/PwEMOY7RndBo+X6xDsVdcTJIy\n5Vw8xUZlr+auEOls2ZnZx11e5zh7sU3Nj5K35BWR9GTXJ6PMdpT49lB9bllMjDrL\n7+5bCsdu63O8KaN9YQJBAPGMbpHpFstC1cWGpRQx3iwF+ZLYArAUbCKbWQfbiZTp\nCS8DgOmyU7uKTRKiC+2RYTS3prLV57GvffFxJjTwGykCQQDoGBwf5iOsyuMQNz7K\nRirbD0J7R6YeQkJZ+pCeKwy+NyIqxh0LBDmBymSKvX0WEKCitOgpi32FWBoqHjf3\nMQg/AkBLBLRqeJvtsOo3mKO4a+x2e7yRUKk1CoKzFNBH0nUeXGnPwiTNb+b1ffSF\n7vIJbHdmKguJy0lUNA7HZ77X/iJRAkAjnbeLKZzl4kiP73piPfxLm37fPjJ+yDo4\nZpwUuZR+CCXlHHvOefp9MVrWc5ejcC/GaC6MWYyMjuWM+xApjcuvAkEAzY+p140C\nxwpr95linnvWcC7N708AJFim3/FU10GDo77yIOI5h+537JbYdm555hOeH/KjSekh\nEF4MmxRPmit99w==\n-----END PRIVATE KEY-----\n",
+                        "userCert": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common.json
+{
+    "fvTenant": {
+        "attributes": {
+            "name": "common",
+            "dn": "uni/tn-common"
+        },
+        "children": [
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "rke-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "rke-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "rke-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common/flt-rke-allow-all-filter.json
+None
+/api/mo/uni/tn-common/brc-rke-l3out-allow-all.json
+None
+/api/mo/uni/tn-tenant-1.json
+{
+    "fvTenant": {
+        "attributes": {
+            "name": "tenant-1",
+            "dn": "uni/tn-tenant-1"
+        },
+        "children": [
+            {
+                "fvAp": {
+                    "attributes": {
+                        "name": "aci-containers-rke",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-istio",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "rke-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-prometheus-opflex-agent",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "rke-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-prometheus-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-prometheus-opflex-agent",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "rke-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "encap": "vlan-4001",
+                                                "tDn": "uni/phys-rke-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-prometheus-opflex-agent",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-istio",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-istio",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke-prometheus-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "fvBD": {
+                    "attributes": {
+                        "name": "aci-containers-rke-node-bd",
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvRsCtx": {
+                                "attributes": {
+                                    "tnFvCtxName": "rke",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsBDToOut": {
+                                "attributes": {
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "10.1.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "11.1.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "fvBD": {
+                    "attributes": {
+                        "name": "aci-containers-rke-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvRsCtx": {
+                                "attributes": {
+                                    "tnFvCtxName": "rke",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsBDToOut": {
+                                "attributes": {
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "10.2.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "12.3.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "icmp",
+                                    "etherT": "ipv4",
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "icmp6",
+                                    "etherT": "ipv6",
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "health-check",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "health-check",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "stateful": "no",
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "dns-udp",
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "6443",
+                                    "dToPort": "6443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "8443",
+                                    "dToPort": "8443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "metrics-kubelet",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "10250",
+                                    "dToPort": "10250",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "monitoring-node",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9796",
+                                    "dToPort": "9796",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "monitoring-ingress",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "10254",
+                                    "dToPort": "10254",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "rancher-ui",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "443",
+                                    "dToPort": "443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-istio-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-9080",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "sFromPort": "9080",
+                                    "sToPort": "9080",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-mixer-9090:91",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9090",
+                                    "dToPort": "9091",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-prometheus-15090",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "sFromPort": "15090",
+                                    "sToPort": "15090",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot-15010:12",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-api",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "aci-containers-api-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "health-check-subj",
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzOutTerm": {
+                                            "attributes": {
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            },
+                                            "children": [
+                                                {
+                                                    "vzRsFiltAtt": {
+                                                        "attributes": {
+                                                            "tnVzFilterName": "aci-containers-rke-health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "vzInTerm": {
+                                            "attributes": {
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            },
+                                            "children": [
+                                                {
+                                                    "vzRsFiltAtt": {
+                                                        "attributes": {
+                                                            "tnVzFilterName": "aci-containers-rke-health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-dns",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke-dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke-icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-istio",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "istio-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke-istio-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-prometheus-monitoring",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "aci-containers-rke-prometheus-monitoring-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke-access-prometheus",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-access-prometheus",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "http",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "8080",
+                                    "dToPort": "8080",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke-prometheus-opflex-agent-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "prometheus-opflex-agent",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9612",
+                                    "dToPort": "9612",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke-prometheus-opflex-agent",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "prometheus-opflex-agent-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke-prometheus-opflex-agent-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-default.json
+{
+    "fvRsProv": {
+        "attributes": {
+            "matchT": "AtleastOne",
+            "tnVzBrCPName": "rke-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-rke-l3out-allow-all.json
+None
+/api/mo/uni/tn-common/out-l3out/instP-test_ext_net.json
+{
+    "fvRsProv": {
+        "attributes": {
+            "matchT": "AtleastOne",
+            "tnVzBrCPName": "rke-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-test_ext_net/rsprov-rke-l3out-allow-all.json
+None
+/api/node/mo/uni/userext/user-rke.json
+{
+    "aaaUser": {
+        "attributes": {
+            "name": "rke",
+            "accountStatus": "active",
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "aaaUserDomain": {
+                    "attributes": {
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "aaaUserRole": {
+                                "attributes": {
+                                    "name": "admin",
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/node/mo/uni/userext/user-rke.json
+{
+    "aaaUser": {
+        "attributes": {
+            "name": "rke",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "aaaUserCert": {
+                    "attributes": {
+                        "name": "rke.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/provision/testdata/flavor_RKE_1_4_9.inp.yaml
+++ b/provision/testdata/flavor_RKE_1_4_9.inp.yaml
@@ -1,0 +1,109 @@
+aci_config:
+  system_id: rke
+  #use_legacy_kube_naming_convention: False
+  tenant:
+    name: tenant-1
+  apic_hosts:
+  - 10.30.120.100
+  - 10.30.120.101
+  - 10.30.120.102
+  apic_login:
+    username: admin
+    password: dummy
+  apic_version: "5.1"
+  aep: rke-aep
+  vrf:
+    name: rke
+    tenant: common
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+    - test_ext_net
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  apic_refreshticker_adjust: 1
+  apic_subscription_delay: 1
+  opflex_device_delete_timeout: 1
+
+net_config:
+  node_subnet:
+  - 10.1.0.1/16
+  - 11.1.0.1/16
+  pod_subnet:
+  - 10.2.0.1/16
+  - 12.3.0.1/16
+  extern_dynamic:
+  - 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+  disable_wait_for_network: True
+  duration_wait_for_network: 200
+  interface_mtu_headroom: 51
+
+kube_config:
+  aci_multipod: True
+  aci_multipod_ubuntu: True
+  dhcp_renew_max_retry_count: 12
+  dhcp_delay: 12
+  use_cluster_role: False
+  no_wait_for_service_ep_readiness: True
+  service_graph_endpoint_add_delay:
+    delay: 30 
+    services:
+    - name: "service-name-1"
+      namespace: "service-ns-1"
+    - name: "service-name-2"
+      namespace: "service-ns-2"
+      delay: 60
+  add_external_subnets_to_rdconfig: True
+  snat_operator:
+    disable_periodic_snat_global_info_sync: True
+    sleep_time_snat_global_info_sync: 60
+  hpp_optimization: True
+  opflex_agent_opflex_asyncjson_enabled: True
+  opflex_agent_ovs_asyncjson_enabled: True
+  opflex_agent_policy_retry_delay_timer: 90
+  opflex_device_reconnect_wait_timeout: 10
+  use_system_node_priority_class: False
+  aci_containers_controller_memory_limit: "5Gi"
+  aci_containers_controller_memory_request: "256Mi"
+  aci_containers_host_memory_limit: "5Gi"
+  aci_containers_host_memory_request: "256Mi"
+  mcast_daemon_memory_limit: "5Gi"
+  mcast_daemon_memory_request: "256Mi"
+  opflex_agent_memory_limit: "5Gi"
+  opflex_agent_memory_request: "256Mi"
+  aci_containers_memory_limit: "2Gi"
+  aci_containers_memory_request: "256Mi"
+  ovs_memory_limit: "2Gi"
+  ovs_memory_request: "256Mi"
+
+registry:
+  image_prefix: quay.io/noiro
+  use_digest: True
+  aci_containers_controller_version: 375c61f113c207b152f70b4c1abc8390f23dedb73245e3d67b99c6a00dbd6bca
+  aci_containers_host_version: d37de5ac9093dff471c0602a79064a7cbac85f6513785ed86eb037ef8740ceed
+  cnideploy_version: 96f1df66843660905fa2cb07b058d8ecc5cb956c4799d661459cc0bfdfd291d2
+  opflex_agent_version: 6ae620eb8ba66a627a9c96b0e34b5d31b05aa22c9196b1885362c6273b0b76e4
+  openvswitch_version: 71d04aa713ff90ce26382bc234941beff9e51a365b3f85c76666a524b7384766
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info
+
+sriov_config:
+  enable: True
+
+nodepodif_config:
+  enable: True

--- a/provision/testdata/flavor_RKE_1_4_9.rke.yaml
+++ b/provision/testdata/flavor_RKE_1_4_9.rke.yaml
@@ -1,0 +1,72 @@
+network:
+  plugin: "aci"
+  aci_network_provider:
+    system_id: "rke"
+    apic_hosts: ["\"10.30.120.100\",\"10.30.120.101\",\"10.30.120.102\""]
+    token: "dummy"
+    apic_user_name: "rke"
+    apic_user_key: "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUNkZ0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQW1Bd2dnSmNBZ0VBQW9HQkFOcitBK2dPS2JBVlZySnMKYjMrWldiY25WWG8vZ2R1eElUa3ZtMDlrZWlGQ24rVXAvU0dkcXY2QWgramxKZkY3dXYrRmdDSnRDeEQ4N3FZdwowcTVEY0dWTEljZkY0WlViOUI4ckpXS0JJNndKZnh0TWZGdVVOWTI0Y2d3UXBKcXJNVXFBRHovTVcrd3JaZWhzClNuRnN5ZXdYUjM4OGVSN0VLakRXZWdkSnlQY1hBZ01CQUFFQ2dZQjlBWGIxWmZCQ0JVeEIrVWdFVEdNNys0WDkKakhieUUwQmx4bGtmanJsd2R2bVM5TTc3KzJaNmRLQWdQMzNUUk0vUHdFTU9ZN1JuZEJvK1g2eERzVmRjVEpJeQo1Vnc4eFVabHIrYXVFT2xzMlpuWngxMWU1emg3c1UzTmo1SzM1QldSOUdUWEo2UE1kcFQ0OWxCOWJsbE1qRHJMCjcrNWJDc2R1NjNPOEthTjlZUUpCQVBHTWJwSHBGc3RDMWNXR3BSUXgzaXdGK1pMWUFyQVViQ0tiV1FmYmlaVHAKQ1M4RGdPbXlVN3VLVFJLaUMrMlJZVFMzcHJMVjU3R3ZmZkZ4SmpUd0d5a0NRUURvR0J3ZjVpT3N5dU1RTno3SwpSaXJiRDBKN1I2WWVRa0paK3BDZUt3eStOeUlxeGgwTEJEbUJ5bVNLdlgwV0VLQ2l0T2dwaTMyRldCb3FIamYzCk1RZy9Ba0JMQkxScWVKdnRzT28zbUtPNGEreDJlN3lSVUtrMUNvS3pGTkJIMG5VZVhHblB3aVROYitiMWZmU0YKN3ZJSmJIZG1LZ3VKeTBsVU5BN0haNzdYL2lKUkFrQWpuYmVMS1p6bDRraVA3M3BpUGZ4TG0zN2ZQakoreURvNApacHdVdVpSK0NDWGxISHZPZWZwOU1WcldjNWVqY0MvR2FDNk1XWXlNanVXTSt4QXBqY3V2QWtFQXpZK3AxNDBDCnh3cHI5NWxpbm52V2NDN043MDhBSkZpbTMvRlUxMEdEbzc3eUlPSTVoKzUzN0piWWRtNTU1aE9lSC9LalNla2gKRUY0TW14UlBtaXQ5OXc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg=="
+    apic_user_crt: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUI2RENDQVZFQ0FnUG9NQTBHQ1NxR1NJYjNEUUVCQlFVQU1Ed3hDekFKQmdOVkJBWVRBbFZUTVJZd0ZBWUQKVlFRS0RBMURhWE5qYnlCVGVYTjBaVzF6TVJVd0V3WURWUVFEREF4VmMyVnlJRzFoYm1SbFpYQXdIaGNOTVRjdwpOVEUyTWpFeU9UTXdXaGNOTWpjd05URTBNakV5T1RNd1dqQThNUXN3Q1FZRFZRUUdFd0pWVXpFV01CUUdBMVVFCkNnd05RMmx6WTI4Z1UzbHpkR1Z0Y3pFVk1CTUdBMVVFQXd3TVZYTmxjaUJ0WVc1a1pXVndNSUdmTUEwR0NTcUcKU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FEYS9nUG9EaW13RlZheWJHOS9tVm0zSjFWNlA0SGJzU0U1TDV0UApaSG9oUXAvbEtmMGhuYXIrZ0lmbzVTWHhlN3IvaFlBaWJRc1EvTzZtTU5LdVEzQmxTeUhIeGVHVkcvUWZLeVZpCmdTT3NDWDhiVEh4YmxEV051SElNRUtTYXF6RktnQTgvekZ2c0syWG9iRXB4Yk1uc0YwZC9QSGtleENvdzFub0gKU2NqM0Z3SURBUUFCTUEwR0NTcUdTSWIzRFFFQkJRVUFBNEdCQUhYK2tMVGU2TENBQmV3bUNUdk1zanVzSGRwWgpraTAxK25RN0tobkVSYkJtL3RaNXNjWkU0Y3RJcWNoM255MUVJVEhOdFlXS0JONENkVUtjanZEVzJoMnZrSGVnCnJ0WWJWK0FhRXNxMG00dkdGOUVtdnQxY3A5WTQxSXlNQlpZcXc4Yy9WMUF0bVJRY1JUWVFBOEgzT0ZEY2h5QjIKMEpIU0RuQm9TN2ZmU2JCeAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+    encap_type: "vxlan"
+    mcast_range_start: "225.2.1.1"
+    mcast_range_end: "225.2.255.255"
+    aep: "rke-aep"
+    vrf_name: "rke"
+    vrf_tenant: "common"
+    l3out: "l3out"
+    node_subnet: "10.1.0.1/16,11.1.0.1/16"
+    l3out_external_networks: ["\"default\",\"test_ext_net\""]
+    extern_dynamic: "10.3.0.1/24"
+    extern_static: "10.4.0.1/24"
+    node_svc_subnet: "10.5.0.1/24"
+    kube_api_vlan: "4001"
+    service_vlan: "4003"
+    infra_vlan: "4093"
+    tenant: "tenant-1"
+    service_monitor_interval: "5"
+    ovs_memory_limit: "2Gi"
+    ovs_memory_request: "256Mi"
+    apic_refresh_ticker_adjust: "1"
+    apic_subscription_delay: "1"
+    opflex_device_delete_timeout: "1"
+    disable_wait_for_network: "true"
+    mtu_head_room: "51"
+    duration_wait_for_network: "200"
+    node_pod_if_enable: "true"
+    sriov_enable: "true"
+    use_cluster_role: "false"
+    disable_periodic_snat_global_info_sync: "true"
+    no_wait_for_service_ep_readiness: "true"
+    add_external_subnets_to_rdconfig: "true"
+    service_graph_endpoint_add_delay: "30"
+    service_graph_endpoint_add_services: ["{\"name\":\"service-name-1\", \"namespace\":\"service-ns-1\"},{\"name\":\"service-name-2\", \"namespace\":\"service-ns-2\", \"delay\":\"60\"}"]
+    sleep_time_snat_global_info_sync: "60"
+    opflex_agent_opflex_asyncjson_enabled: "true"
+    opflex_agent_ovs_asyncjson_enabled: "true"
+    hpp_optimization: "true"
+    aci_multipod: "true"
+    aci_multipod_ubuntu: "true"
+    dhcp_renew_max_retry_count: "12"
+    dhcp_delay: "12"
+    opflex_agent_policy_retry_delay_timer: "90"
+    aci_containers_controller_memory_limit: "5Gi"
+    aci_containers_controller_memory_request: "256Mi"
+    aci_containers_host_memory_limit: "5Gi"
+    aci_containers_host_memory_request: "256Mi"
+    mcast_daemon_memory_limit: "5Gi"
+    mcast_daemon_memory_request: "256Mi"
+    opflex_agent_memory_limit: "5Gi"
+    opflex_agent_memory_request: "256Mi"
+    aci_containers_memory_limit: "2Gi"
+    aci_containers_memory_request: "256Mi"
+    opflex_device_reconnect_wait_timeout: "10"
+services:
+  kube-controller:
+    cluster_cidr: "10.2.0.1/16,12.3.0.1/16"  
+system_images:
+  aci_cni_deploy_container: quay.io/noiro/cnideploy@sha256:96f1df66843660905fa2cb07b058d8ecc5cb956c4799d661459cc0bfdfd291d2
+  aci_host_container: quay.io/noiro/aci-containers-host@sha256:d37de5ac9093dff471c0602a79064a7cbac85f6513785ed86eb037ef8740ceed
+  aci_opflex_container: quay.io/noiro/opflex@sha256:6ae620eb8ba66a627a9c96b0e34b5d31b05aa22c9196b1885362c6273b0b76e4
+  aci_mcast_container: quay.io/noiro/opflex@sha256:6ae620eb8ba66a627a9c96b0e34b5d31b05aa22c9196b1885362c6273b0b76e4
+  aci_ovs_container: quay.io/noiro/openvswitch@sha256:71d04aa713ff90ce26382bc234941beff9e51a365b3f85c76666a524b7384766
+  aci_controller_container: quay.io/noiro/aci-containers-controller@sha256:375c61f113c207b152f70b4c1abc8390f23dedb73245e3d67b99c6a00dbd6bca

--- a/provision/testdata/list_flavors.stdout.txt
+++ b/provision/testdata/list_flavors.stdout.txt
@@ -29,6 +29,7 @@ INFO: kubernetes-1.25:	Kubernetes 1.25
 INFO: RKE2-kubernetes-1.24:	Rancher Kubernetes Engine Government kubernetes version 1.24
 INFO: RKE-1.4.9:	Rancher Kubernetes Engine min version 1.4.9
 INFO: RKE-1.4.6:	Rancher Kubernetes Engine min version 1.4.6
+INFO: RKE-1.3.24:	Rancher Kubernetes Engine min version 1.3.24
 INFO: RKE-1.3.21:	Rancher Kubernetes Engine min version 1.3.21
 INFO: RKE-1.3.20:	Rancher Kubernetes Engine min version 1.3.20
 INFO: RKE-1.3.18:	Rancher Kubernetes Engine min version 1.3.18

--- a/provision/testdata/list_flavors.stdout.txt
+++ b/provision/testdata/list_flavors.stdout.txt
@@ -27,6 +27,7 @@ INFO: kubernetes-1.27:	Kubernetes 1.27
 INFO: kubernetes-1.26:	Kubernetes 1.26
 INFO: kubernetes-1.25:	Kubernetes 1.25
 INFO: RKE2-kubernetes-1.24:	Rancher Kubernetes Engine Government kubernetes version 1.24
+INFO: RKE-1.4.9:	Rancher Kubernetes Engine min version 1.4.9
 INFO: RKE-1.4.6:	Rancher Kubernetes Engine min version 1.4.6
 INFO: RKE-1.3.21:	Rancher Kubernetes Engine min version 1.3.21
 INFO: RKE-1.3.20:	Rancher Kubernetes Engine min version 1.3.20


### PR DESCRIPTION
**Added new variables as below:**
kube_config:
use_system_node_priority_class
ovs_memory_request
aci_containers_controller_memory_limit
aci_containers_controller_memory_request
aci_containers_host_memory_limit
aci_containers_host_memory_request
mcast_daemon_memory_limit
mcast_daemon_memory_request
opflex_agent_memory_limit
opflex_agent_memory_request
aci_containers_memory_limit
aci_containers_memory_request
opflex_device_reconnect_wait_timeout

registry:
use_digest
image_prefix
image_pull_secret
cnideploy_version
aci_containers_host_version
opflex_agent_version
openvswitch_version
aci_containers_controller_version