### PR TITLE
Add ruamel pkg version

### DIFF
--- a/provision/setup.py
+++ b/provision/setup.py
@@ -46,6 +46,6 @@ setup(
           'pyopenssl',
           'MarkupSafe',
           'boto3',
-          'ruamel.yaml',
+          'ruamel.yaml==0.17.21',
     ],
 )


### PR DESCRIPTION
ruamel.yaml has released latest version 0.18.5, we have used 0.17.21 for yaml operations(load, edit, write etc). As per release notes, there are changes in the way functions are used/behaving in the latest version. For now fixing ruamel version to 0.17.21, meanwhile will fix unit test framework to adjust to new ruamel version