### PR TITLE
Add condition while adding comma after node_snat_redirect_exclude

### DIFF
--- a/provision/acc_provision/templates/acc-provision-configmap.yaml
+++ b/provision/acc_provision/templates/acc-provision-configmap.yaml
@@ -133,7 +133,7 @@ data:
                 {% endfor %}
                 }
                 {% elif key == 'node_snat_redirect_exclude' %}
-                "node_snat_redirect_exclude": {{ config.kube_config.node_snat_redirect_exclude|json|indent(width=8) }},
+                "node_snat_redirect_exclude": {{ config.kube_config.node_snat_redirect_exclude|json|indent(width=8) }}{{ "," if not loop.last else "" }}
                 {% elif key == 'service_graph_endpoint_add_delay' %}
                 "service_graph_endpoint_add_delay": {
                 {% for delaykey, delayvalue in config.kube_config.service_graph_endpoint_add_delay.items() %}


### PR DESCRIPTION
Issue: If the node_snat_redirect_exclude is last item in the acc-provision-configmap then an extra ',' will be added leading to syntax error.

Change:
Add condition to add comma(',') after config item node_snat_redirect_exclude only if its not last item.