### PR TITLE
Script to set serviceBdRoutingDisable as yes

### DIFF
--- a/provision/acc_provision/aci_set_service_bd_routing_disable_yes.py
+++ b/provision/acc_provision/aci_set_service_bd_routing_disable_yes.py
@@ -1,3 +1,10 @@
+# Script to set serviceBdRoutingDisable attribute of service BD as yes
+#
+# Run python3 aci_set_service_bd_routing_disable_yes.py --help for usage
+#
+# eg: python3 aci_set_service_bd_routing_disable_yes.py -c <acc-provision input yaml file>
+#     -u <APIC username> -p <APIC password>
+
 from __future__ import print_function, unicode_literals
 import collections
 import json


### PR DESCRIPTION
usage: aci_set_service_bd_routing_disable_yes.py [-h] [--debug]
                                         [-c file] [-u name]
					 [-p pass] [-w timeout]
					 [--apic-oobm-ip ip]

options:
  -h, --help            show this help message and exit
  --debug               enable debug
  -c, --config file     input file with your fabric configuration
  -u, --username name   apic-admin username to use for APIC API access
  -p, --password pass   apic-admin password to use for APIC API access
  -w timeout, --timeout timeout wait/timeout to use for APIC API access
  --apic-oobm-ip ip     APIC out of band management IP for day0
                        configuration

eg: python3 aci_set_service_bd_routing_disable_yes.py
    -c <acc-provision input yaml file> -u <APIC username> -p <APIC password>