### PR TITLE
Create/Delete physDom after creaion/deletion of AEP

### DIFF
--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -669,7 +669,6 @@ class ApicKubeConfig(object):
             update(data, self.mcast_pool())
             phys_name = self.config["aci_config"]["physical_domain"]["domain"]
             pool_name = self.config["aci_config"]["physical_domain"]["vlan_pool"]
-            update(data, self.phys_dom(phys_name, pool_name))
             update(data, self.kube_dom(apic_version))
             update(data, self.nested_dom())
             update(data, self.associate_aep())
@@ -682,6 +681,7 @@ class ApicKubeConfig(object):
             update(data, getattr(self, self.tenant_generator)(self.config['flavor']))
             update(data, self.add_apivlan_for_second_portgroup())
             update(data, self.nested_dom_second_portgroup())
+            update(data, self.phys_dom(phys_name, pool_name))
 
         else:
             cluster_l3out_vrf_details = self.get_cluster_l3out_vrf_details()

--- a/provision/testdata/apic_oobm_ip.apic.txt
+++ b/provision/testdata/apic_oobm_ip.apic.txt
@@ -73,26 +73,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1182,6 +1162,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/base_case.apic.txt
+++ b/provision/testdata/base_case.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1252,6 +1232,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/base_case_apic_5_2_3.apic.txt
+++ b/provision/testdata/base_case_apic_5_2_3.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1274,6 +1254,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/base_case_ipv6.apic.txt
+++ b/provision/testdata/base_case_ipv6.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1137,6 +1117,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/dualstack_base.apic.txt
+++ b/provision/testdata/dualstack_base.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1301,6 +1281,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/dualstack_extern_dynamic.apic.txt
+++ b/provision/testdata/dualstack_extern_dynamic.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1301,6 +1281,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/dualstack_extern_static.apic.txt
+++ b/provision/testdata/dualstack_extern_static.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1301,6 +1281,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/dualstack_node_subnet.apic.txt
+++ b/provision/testdata/dualstack_node_subnet.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1262,6 +1242,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/dualstack_only_ipv4.apic.txt
+++ b/provision/testdata/dualstack_only_ipv4.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1252,6 +1232,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/dualstack_pod_and_node_subnet.apic.txt
+++ b/provision/testdata/dualstack_pod_and_node_subnet.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1301,6 +1281,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/enable_aci_cilium_chaining.apic.txt
+++ b/provision/testdata/enable_aci_cilium_chaining.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1322,6 +1302,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/enable_opflex_agent_prometheus.apic.txt
+++ b/provision/testdata/enable_opflex_agent_prometheus.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kubernetes-control.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kubernetes-control",
-            "name": "kubernetes-control",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kubernetes1.json
 {
     "vmmDomP": {
@@ -1126,6 +1106,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kubernetes-control.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kubernetes-control",
+            "name": "kubernetes-control",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE2_kubernetes_1_24.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_24.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke2-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke2-pdom",
-            "name": "rke2-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke2-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke2.json
 {
     "vmmDomP": {
@@ -1270,6 +1250,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke2-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke2-pdom",
+            "name": "rke2-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke2-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE2_kubernetes_1_25.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_25.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke2-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke2-pdom",
-            "name": "rke2-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke2-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke2.json
 {
     "vmmDomP": {
@@ -1270,6 +1250,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke2-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke2-pdom",
+            "name": "rke2-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke2-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE2_kubernetes_1_26.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_26.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke2-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke2-pdom",
-            "name": "rke2-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke2-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke2.json
 {
     "vmmDomP": {
@@ -1270,6 +1250,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke2-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke2-pdom",
+            "name": "rke2-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke2-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE2_kubernetes_1_27.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_27.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke2-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke2-pdom",
-            "name": "rke2-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke2-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke2.json
 {
     "vmmDomP": {
@@ -1270,6 +1250,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke2-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke2-pdom",
+            "name": "rke2-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke2-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE2_kubernetes_1_28.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_28.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke2-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke2-pdom",
-            "name": "rke2-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke2-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke2.json
 {
     "vmmDomP": {
@@ -1270,6 +1250,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke2-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke2-pdom",
+            "name": "rke2-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke2-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_2_3.apic.txt
+++ b/provision/testdata/flavor_RKE_1_2_3.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1270,6 +1250,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_3_13.apic.txt
+++ b/provision/testdata/flavor_RKE_1_3_13.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1270,6 +1250,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_3_17.apic.txt
+++ b/provision/testdata/flavor_RKE_1_3_17.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1270,6 +1250,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_3_18.apic.txt
+++ b/provision/testdata/flavor_RKE_1_3_18.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1270,6 +1250,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_3_20.apic.txt
+++ b/provision/testdata/flavor_RKE_1_3_20.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1270,6 +1250,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_3_21.apic.txt
+++ b/provision/testdata/flavor_RKE_1_3_21.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1287,6 +1267,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_3_24.apic.txt
+++ b/provision/testdata/flavor_RKE_1_3_24.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1287,6 +1267,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_4_13.apic.txt
+++ b/provision/testdata/flavor_RKE_1_4_13.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1287,6 +1267,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_4_16.apic.txt
+++ b/provision/testdata/flavor_RKE_1_4_16.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1287,6 +1267,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_4_20.apic.txt
+++ b/provision/testdata/flavor_RKE_1_4_20.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1287,6 +1267,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_4_6.apic.txt
+++ b/provision/testdata/flavor_RKE_1_4_6.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1287,6 +1267,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_4_9.apic.txt
+++ b/provision/testdata/flavor_RKE_1_4_9.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1287,6 +1267,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_5_11.apic.txt
+++ b/provision/testdata/flavor_RKE_1_5_11.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1287,6 +1267,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_5_12.apic.txt
+++ b/provision/testdata/flavor_RKE_1_5_12.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1287,6 +1267,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_5_3.apic.txt
+++ b/provision/testdata/flavor_RKE_1_5_3.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1287,6 +1267,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_5_6.apic.txt
+++ b/provision/testdata/flavor_RKE_1_5_6.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1287,6 +1267,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_6_0.apic.txt
+++ b/provision/testdata/flavor_RKE_1_6_0.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1287,6 +1267,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_RKE_1_6_1.apic.txt
+++ b/provision/testdata/flavor_RKE_1_6_1.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-rke-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-rke-pdom",
-            "name": "rke-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-rke.json
 {
     "vmmDomP": {
@@ -1287,6 +1267,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke-pdom",
+            "name": "rke-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_dockerucp.apic.txt
+++ b/provision/testdata/flavor_dockerucp.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1284,6 +1264,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_k8s_aci_cilium.apic.txt
+++ b/provision/testdata/flavor_k8s_aci_cilium.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1322,6 +1302,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_310.apic.txt
+++ b/provision/testdata/flavor_openshift_310.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1486,6 +1466,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_311.apic.txt
+++ b/provision/testdata/flavor_openshift_311.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1486,6 +1466,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_410_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_410_baremetal.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1916,6 +1896,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_410_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_410_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1793,6 +1773,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_410_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_410_esx_vDS_6_6_above.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1819,6 +1799,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_410_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_410_openstack.apic.txt
@@ -41,26 +41,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1868,6 +1848,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_411_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_411_baremetal.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1916,6 +1896,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_411_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_411_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1793,6 +1773,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_411_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_411_esx_vDS_6_6_above.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1819,6 +1799,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_411_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_411_openstack.apic.txt
@@ -41,26 +41,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1868,6 +1848,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_412_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_412_baremetal.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1916,6 +1896,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_412_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_412_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1793,6 +1773,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_412_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_412_openstack.apic.txt
@@ -41,26 +41,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1868,6 +1848,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_413_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_413_baremetal.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1916,6 +1896,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_413_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_413_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1793,6 +1773,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_413_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_413_openstack.apic.txt
@@ -41,26 +41,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1868,6 +1848,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_414_aci_cilium_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_414_aci_cilium_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1863,6 +1843,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_414_agent_based_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_414_agent_based_baremetal.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -2176,6 +2156,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_414_agent_based_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_414_agent_based_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -2021,6 +2001,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_414_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_414_baremetal.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1916,6 +1896,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_414_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_414_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1793,6 +1773,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_414_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_414_openstack.apic.txt
@@ -41,26 +41,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1868,6 +1848,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_415_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_415_baremetal.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1916,6 +1896,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_415_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_415_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1793,6 +1773,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_415_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_415_openstack.apic.txt
@@ -41,26 +41,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1868,6 +1848,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_43.apic.txt
+++ b/provision/testdata/flavor_openshift_43.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1698,6 +1678,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_44_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_44_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1729,6 +1709,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_44_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_44_esx_vDS_6_6_above.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1755,6 +1735,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_44_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_44_openstack.apic.txt
@@ -41,26 +41,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1804,6 +1784,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_45_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_45_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1729,6 +1709,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_45_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_45_esx_vDS_6_6_above.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1755,6 +1735,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_45_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_45_openstack.apic.txt
@@ -41,26 +41,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1804,6 +1784,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_46_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_46_baremetal.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1908,6 +1888,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_46_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_46_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1785,6 +1765,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_46_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_46_esx_vDS_6_6_above.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1811,6 +1791,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_46_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_46_openstack.apic.txt
@@ -41,26 +41,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1860,6 +1840,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_47_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_47_baremetal.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1908,6 +1888,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_47_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_47_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1785,6 +1765,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_47_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_47_esx_vDS_6_6_above.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1811,6 +1791,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_47_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_47_openstack.apic.txt
@@ -41,26 +41,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1860,6 +1840,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_48_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_48_baremetal.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1916,6 +1896,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_48_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_48_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1793,6 +1773,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_48_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_48_esx_vDS_6_6_above.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1819,6 +1799,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_48_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_48_openstack.apic.txt
@@ -41,26 +41,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1868,6 +1848,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_49_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_49_baremetal.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1916,6 +1896,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_49_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_49_esx.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1793,6 +1773,26 @@ None
             "annotation": "orchestrator:aci-containers-controller"
         },
         "children": []
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
     }
 }
 /api/mo/uni/tn-common/out-l3out/instP-default.json

--- a/provision/testdata/flavor_openshift_49_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_49_esx_vDS_6_6_above.apic.txt
@@ -63,26 +63,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1819,6 +1799,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/flavor_openshift_49_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_49_openstack.apic.txt
@@ -41,26 +41,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1868,6 +1848,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/multiple_subnets.apic.txt
+++ b/provision/testdata/multiple_subnets.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1268,6 +1248,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/nested-elag.apic.txt
+++ b/provision/testdata/nested-elag.apic.txt
@@ -73,26 +73,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1191,6 +1171,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/nested-portgroup.apic.txt
+++ b/provision/testdata/nested-portgroup.apic.txt
@@ -73,26 +73,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1182,6 +1162,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/nested-vlan.apic.txt
+++ b/provision/testdata/nested-vlan.apic.txt
@@ -73,26 +73,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1182,6 +1162,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/nested-vxlan.apic.txt
+++ b/provision/testdata/nested-vxlan.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1143,6 +1123,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/pod_ext_access.apic.txt
+++ b/provision/testdata/pod_ext_access.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1286,6 +1266,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/vlan_case.apic.txt
+++ b/provision/testdata/vlan_case.apic.txt
@@ -73,26 +73,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1134,6 +1114,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/with_comments.apic.txt
+++ b/provision/testdata/with_comments.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1104,6 +1084,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/with_interface_mtu.apic.txt
+++ b/provision/testdata/with_interface_mtu.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1252,6 +1232,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/with_interface_mtu_headroom.apic.txt
+++ b/provision/testdata/with_interface_mtu_headroom.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1252,6 +1232,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/with_new_naming_convention.apic.txt
+++ b/provision/testdata/with_new_naming_convention.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1252,6 +1232,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/with_new_naming_convention_dockerucp.apic.txt
+++ b/provision/testdata/with_new_naming_convention_dockerucp.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1284,6 +1264,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/with_new_naming_convention_openshift.apic.txt
+++ b/provision/testdata/with_new_naming_convention_openshift.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-OpenShift/dom-kube.json
 {
     "vmmDomP": {
@@ -1486,6 +1466,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/with_overrides.apic.txt
+++ b/provision/testdata/with_overrides.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kubernetes-control.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kubernetes-control",
-            "name": "kubernetes-control",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kubernetes1.json
 {
     "vmmDomP": {
@@ -1126,6 +1106,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kubernetes-control.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kubernetes-control",
+            "name": "kubernetes-control",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/with_preexisting_tenant.apic.txt
+++ b/provision/testdata/with_preexisting_tenant.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1251,6 +1231,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/with_tenant_l3out.apic.txt
+++ b/provision/testdata/with_tenant_l3out.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kube-pdom.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kube-pdom",
-            "name": "kube-pdom",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kube.json
 {
     "vmmDomP": {
@@ -1105,6 +1085,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kube-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kube-pdom",
+            "name": "kube-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]

--- a/provision/testdata/with_wait_for_network.apic.txt
+++ b/provision/testdata/with_wait_for_network.apic.txt
@@ -51,26 +51,6 @@
         ]
     }
 }
-/api/mo/uni/phys-kubernetes-control.json
-{
-    "physDomP": {
-        "attributes": {
-            "dn": "uni/phys-kubernetes-control",
-            "name": "kubernetes-control",
-            "annotation": "orchestrator:aci-containers-controller"
-        },
-        "children": [
-            {
-                "infraRsVlanNs": {
-                    "attributes": {
-                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
-                        "annotation": "orchestrator:aci-containers-controller"
-                    }
-                }
-            }
-        ]
-    }
-}
 /api/mo/uni/vmmp-Kubernetes/dom-kubernetes1.json
 {
     "vmmDomP": {
@@ -1126,6 +1106,26 @@ None
                             }
                         }
                     ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-kubernetes-control.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-kubernetes-control",
+            "name": "kubernetes-control",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[kube-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
                 }
             }
         ]


### PR DESCRIPTION
In ACI 6.1.1, the following restrictions are added:
* physDom cannot be deleted unless it is deassociated with the all EPGs
* physDom cannot be deleted unless it is deassociated with AEP

Changed the order of creation and deletion of resources based on above restrictions