### PR TITLE
Add details for user-<sysid>.crt/key filename information in the

### DIFF
--- a/doc/features/README.md
+++ b/doc/features/README.md
@@ -38,6 +38,7 @@
       + [Troubleshooting Pod Health Check](#troubleshooting-pod-health-check)
       + [Troubleshooting aci-containers-host](#troubleshooting-aci-containers-host)
       + [Datapath tracing with acikubectl](#datapath_tracing_with_acikubectl)
+      + [Proactive Configuration with acikubectl](#proactive-configuration-with-acikubectl)
 
 
 # Overview
@@ -1156,3 +1157,8 @@ Follow the instructions in this section if the mcast-daemon inside aci-container
 
 ### Datapath tracing with acikubectl
 Refer the [document](datapath_tracing_with_acikubectl.md) to perform OVS datapath packet trace.
+
+---
+
+### Proactive Configuration with acikubectl
+Refer the [document](proactive-configuration-with-acikubectl.md) to perform proactive configuration.

--- a/doc/features/proactive-configuration-with-acikubectl.md
+++ b/doc/features/proactive-configuration-with-acikubectl.md
@@ -55,7 +55,9 @@ Global Flags:
 # Examples
 If the kubconfig is not present in the default location, it can be explicilty specified using the --kubeconfig argument.
 
-If the acc-provision created certificate and key pair is not available in working directory, the username and password to access the APIC can be explicitly provided using the -u and -p arguments. The APIC user needs to have admin level access to the cluster's tenant.
+If the acc-provision created certificate (user-<sysid>.crt) and key (user-<sysid>.key) are not available in the working directory, 
+then the username and password to access the APIC can be explicitly provided using the -u and -p arguments. 
+The APIC user needs to have admin level access to the cluster's tenant.
 
 ## Create Proactive Policy
 


### PR DESCRIPTION
proactive readme document