### PR TITLE
Unit Test for deletion of APs and EPGs

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -2688,12 +2688,13 @@ def get_apic(config):
     apic_password = config["aci_config"]["apic_login"]["password"]
     timeout = config["aci_config"]["apic_login"]["timeout"]
     debug = config["provision"]["debug_apic"]
+    ssl = config["aci_config"].get("ssl", True)
 
     if config["aci_config"]["apic_proxy"]:
         apic_host = config["aci_config"]["apic_proxy"]
     apic = Apic(
         apic_host, apic_username, apic_password,
-        timeout=timeout, debug=debug)
+        timeout=timeout, debug=debug, ssl=ssl)
     if apic.cookies is None:
         return None
     return apic

--- a/provision/acc_provision/fake_apic.py
+++ b/provision/acc_provision/fake_apic.py
@@ -1,0 +1,64 @@
+import threading
+import sys
+import json
+if sys.version_info[0] == 3:
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+    import urllib.parse as urll
+else:
+    from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+    import urllib as urll
+
+fake_gets = {}
+fake_deletes = []
+fake_extra_deletes=[]
+login_data = {
+    "imdata": [{"aaaLogin": {"attributes": {"token": "testtoken"}}}]
+}
+empty_data = {
+    "imdata": []
+}
+
+class Serv(BaseHTTPRequestHandler):
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'application/json')
+        self.end_headers()
+
+    def do_GET(self):
+        pp = urll.unquote(self.path)
+        if pp in fake_gets.keys():
+            self._set_headers()
+            self.wfile.write(json.dumps(fake_gets[pp]).encode())
+        else:
+            print("Error: path {} not found".format(self.path))
+            self.send_response(404)
+
+    def do_POST(self):
+        if self.path == "/api/aaaLogin.json":
+            print("Login detected")
+            self._set_headers()
+            self.wfile.write(json.dumps(login_data).encode())
+            return
+        self._set_headers()
+        self.wfile.write(json.dumps(empty_data).encode())
+
+    def do_DELETE(self):
+        pp = urll.unquote(self.path)
+        try:
+            fake_deletes.remove(pp)
+        except ValueError:
+            fake_extra_deletes.append(pp)
+        self._set_headers()
+        self.wfile.write(json.dumps(empty_data).encode())
+
+
+def start_fake_apic(port, gets, deletes):
+    global fake_gets
+    global fake_deletes
+    fake_gets = gets
+    fake_deletes = deletes
+    httpd = HTTPServer(('localhost', port), Serv)
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.daemon = True
+    thread.start()
+    return httpd

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -10,13 +10,14 @@ import ssl
 import sys
 import tempfile
 import tarfile
-
+import json
 import base64
 import copy
 
 import yaml
 
 from . import acc_provision
+from . import fake_apic
 
 from ruamel.yaml import YAML
 yml = YAML()
@@ -39,6 +40,98 @@ def in_testdir(f):
             os.chdir("..")
         return ret
     return wrapper
+
+
+@in_testdir
+def test_unprovision_delete_tenant():
+     with open("test_unprovision_delete_tenant_data.json") as data_file:
+         data = json.loads(data_file.read())
+     apic = fake_apic.start_fake_apic(50001, data["gets"], data["deletes"])
+     def clean_apic():
+         apic.shutdown()
+         apic.server_close()
+         return False
+     assert (len(fake_apic.fake_deletes) != 0)
+     run_provision(
+         "test_unprovision_delete_tenant.inp.yaml",
+         None,
+         None,
+         None,
+         overrides={ "skip_app_profile_check": True, "apic": True, "password": "test", "delete": True}, cleanupFunc=clean_apic
+     )
+     apic.shutdown()
+     apic.server_close()
+     # verify all deletes were executed
+     assert( len(fake_apic.fake_deletes) == 0 and len(fake_apic.fake_extra_deletes) == 0 )
+
+
+@in_testdir
+def test_unprovision_custom_ap_without_annotation():
+     with open("test_unprovision_custom_ap_without_annotation_data.json") as data_file:
+         data = json.loads(data_file.read())
+     apic = fake_apic.start_fake_apic(50001, data["gets"], data["deletes"])
+     def clean_apic():
+         apic.shutdown()
+         apic.server_close()
+         return False
+     assert (len(fake_apic.fake_deletes) != 0)
+     run_provision(
+         "test_unprovision_custom_ap_without_annotation.inp.yaml",
+         None,
+         None,
+         None,
+         overrides={ "apic": True, "password": "test", "delete": True}, cleanupFunc=clean_apic
+     )
+     apic.shutdown()
+     apic.server_close()
+     # verify all deletes were executed
+     assert( len(fake_apic.fake_deletes) == 0 and len(fake_apic.fake_extra_deletes) == 0 )
+
+
+@in_testdir
+def test_unprovision_custom_ap_with_annotation():
+     with open("test_unprovision_custom_ap_with_annotation_data.json") as data_file:
+         data = json.loads(data_file.read())
+     apic = fake_apic.start_fake_apic(50001, data["gets"], data["deletes"])
+     def clean_apic():
+         apic.shutdown()
+         apic.server_close()
+         return False
+     assert (len(fake_apic.fake_deletes) != 0)
+     run_provision(
+         "test_unprovision_custom_ap_with_annotation.inp.yaml",
+         None,
+         None,
+         None,
+         overrides={ "apic": True, "password": "test", "delete": True}, cleanupFunc=clean_apic
+     )
+     apic.shutdown()
+     apic.server_close()
+     # verify all deletes were executed
+     assert( len(fake_apic.fake_deletes) == 0 and len(fake_apic.fake_extra_deletes) == 0 )
+
+
+@in_testdir
+def test_unprovision_custom_epg():
+     with open("test_unprovision_custom_epg_data.json") as data_file:
+         data = json.loads(data_file.read())
+     apic = fake_apic.start_fake_apic(50001, data["gets"], data["deletes"])
+     def clean_apic():
+         apic.shutdown()
+         apic.server_close()
+         return False
+     assert (len(fake_apic.fake_deletes) != 0)
+     run_provision(
+         "test_unprovision_custom_epg.inp.yaml",
+         None,
+         None,
+         None,
+         overrides={ "apic": True, "password": "test", "delete": True}, cleanupFunc=clean_apic
+     )
+     apic.shutdown()
+     apic.server_close()
+     # verify all deletes were executed
+     assert( len(fake_apic.fake_deletes) == 0 and len(fake_apic.fake_extra_deletes) == 0 )
 
 
 @in_testdir

--- a/provision/testdata/test_unprovision_custom_ap_with_annotation.inp.yaml
+++ b/provision/testdata/test_unprovision_custom_ap_with_annotation.inp.yaml
@@ -1,0 +1,135 @@
+aci_config:
+  system_id: kube
+  #use_legacy_kube_naming_convention: False
+  tenant:
+    name: test
+  apic_hosts:                   # List of cAPIC hosts to connect for APIC API
+  - localhost:50001
+  apic_version: "6.1"
+  apic_login:
+    username: admin
+    password: dummy
+    aep: kube-aep
+  vrf:
+    name: kube-vrf
+    tenant: common
+  aep: kube-aep
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+    - test_ext_net
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  apic_refreshticker_adjust: 1
+  apic_subscription_delay: 1
+  opflex_device_delete_timeout: 1
+  ssl: False
+
+net_config:
+  node_subnet:
+  - 10.1.0.1/16
+  - 11.1.0.1/16
+  pod_subnet:
+  - 10.2.0.1/16
+  - 12.3.0.1/16
+  extern_dynamic:
+  - 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+  disable_wait_for_network: True
+  duration_wait_for_network: 200
+  interface_mtu_headroom: 51
+
+kube_config:
+  aci_multipod: True
+  aci_multipod_ubuntu: True
+  dhcp_renew_max_retry_count: 12
+  dhcp_delay: 12
+  use_cluster_role: False
+  no_wait_for_service_ep_readiness: True
+  service_graph_endpoint_add_delay:
+    delay: 30 
+    services:
+    - name: "service-name-1"
+      namespace: "service-ns-1"
+    - name: "service-name-2"
+      namespace: "service-ns-2"
+      delay: 60
+  add_external_subnets_to_rdconfig: True
+  snat_operator:
+    disable_periodic_snat_global_info_sync: True
+    sleep_time_snat_global_info_sync: 60
+  hpp_optimization: True
+  opflex_agent_opflex_asyncjson_enabled: True
+  opflex_agent_ovs_asyncjson_enabled: True
+  opflex_agent_policy_retry_delay_timer: 90
+  opflex_device_reconnect_wait_timeout: 10
+  use_system_node_priority_class: False
+  aci_containers_controller_memory_limit: "5Gi"
+  aci_containers_controller_memory_request: "256Mi"
+  aci_containers_host_memory_limit: "5Gi"
+  aci_containers_host_memory_request: "256Mi"
+  mcast_daemon_memory_limit: "5Gi"
+  mcast_daemon_memory_request: "256Mi"
+  opflex_agent_memory_limit: "5Gi"
+  opflex_agent_memory_request: "256Mi"
+  aci_containers_memory_limit: "2Gi"
+  aci_containers_memory_request: "256Mi"
+  ovs_memory_limit: "2Gi"
+  ovs_memory_request: "256Mi"
+  opflex_agent_statistics: False
+  add_external_contract_to_default_epg: True
+  enable_opflex_agent_reconnect: True
+  opflex_openssl_compat: True
+  toleration_seconds: 100
+  node_snat_redirect_exclude:
+  - group: router
+    labels:
+    - worker
+    - router
+    - infra
+  - group: infra
+    labels:
+    - infra
+    - router
+  disable_hpp_rendering: True
+  apic_connection_retry_limit: 10
+  taint_not_ready_node: True
+  opflex_startup_enabled: True
+  opflex_startup_policy_duration: 80
+  opflex_startup_resolve_aft_conn: True
+  opflex_switch_sync_delay: 10
+  opflex_switch_sync_dynamic: 5
+
+registry:
+  image_prefix: quay.io/noiro
+  use_digest: True
+  aci_containers_controller_version: 375c61f113c207b152f70b4c1abc8390f23dedb73245e3d67b99c6a00dbd6bca
+  aci_containers_host_version: d37de5ac9093dff471c0602a79064a7cbac85f6513785ed86eb037ef8740ceed
+  cnideploy_version: 96f1df66843660905fa2cb07b058d8ecc5cb956c4799d661459cc0bfdfd291d2
+  opflex_agent_version: 6ae620eb8ba66a627a9c96b0e34b5d31b05aa22c9196b1885362c6273b0b76e4
+  openvswitch_version: 71d04aa713ff90ce26382bc234941beff9e51a365b3f85c76666a524b7384766
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info
+
+sriov_config:
+  enable: True
+
+nodepodif_config:
+  enable: True
+
+drop_log_config:
+  disable_events: True

--- a/provision/testdata/test_unprovision_custom_ap_with_annotation_data.json
+++ b/provision/testdata/test_unprovision_custom_ap_with_annotation_data.json
@@ -1,0 +1,461 @@
+{
+    "gets": {
+        "/api/node/mo/uni/tn-common.json?query-target=subtree&target-subtree-class=tagInst": {
+            "totalCount": "0",
+            "imdata": []
+        },
+        "/api/mo/uni/tn-test.json?query-target=children": {
+            "totalCount": "8",
+            "imdata": [
+                {
+                    "fvAp": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/ap-aci-containers-kube",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "fvBD": {
+                        "attributes": {
+                            "OptimizeWanBandwidth": "no",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "arpFlood": "no",
+                            "bcastP": "225.0.2.32",
+                            "childAction": "",
+                            "configIssues": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/BD-aci-containers-kube-pod-bd",
+                            "enableRogueExceptMac": "no",
+                            "epClear": "no",
+                            "epMoveDetectMode": "",
+                            "extMngdBy": "",
+                            "hostBasedRouting": "no",
+                            "intersiteBumTrafficAllow": "no",
+                            "intersiteL2Stretch": "no",
+                            "ipLearning": "yes",
+                            "ipv6McastAllow": "no",
+                            "lcOwn": "local",
+                            "limitIpLearnToSubnets": "yes",
+                            "llAddr": "::",
+                            "mac": "00:22:BD:F8:19:FF",
+                            "mcastARPDrop": "yes",
+                            "mcastAllow": "no",
+                            "modTs": "2025-02-27T14:43:21.537+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "mtu": "inherit",
+                            "multiDstPktAct": "bd-flood",
+                            "name": "aci-containers-kube-pod-bd",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "pcTag": "49164",
+                            "scope": "3047424",
+                            "seg": "16547722",
+                            "serviceBdRoutingDisable": "no",
+                            "status": "",
+                            "type": "regular",
+                            "uid": "15374",
+                            "unicastRoute": "yes",
+                            "unkMacUcastAct": "proxy",
+                            "unkMcastAct": "flood",
+                            "userdom": ":all:",
+                            "v6unkMcastAct": "flood",
+                            "vmac": "not-applicable"
+                        }
+                    }
+                },
+                {
+                    "fvBD": {
+                        "attributes": {
+                            "OptimizeWanBandwidth": "no",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "arpFlood": "yes",
+                            "bcastP": "225.1.43.192",
+                            "childAction": "",
+                            "configIssues": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/BD-aci-containers-kube-node-bd",
+                            "enableRogueExceptMac": "no",
+                            "epClear": "no",
+                            "epMoveDetectMode": "",
+                            "extMngdBy": "",
+                            "hostBasedRouting": "no",
+                            "intersiteBumTrafficAllow": "no",
+                            "intersiteL2Stretch": "no",
+                            "ipLearning": "yes",
+                            "ipv6McastAllow": "no",
+                            "lcOwn": "local",
+                            "limitIpLearnToSubnets": "yes",
+                            "llAddr": "::",
+                            "mac": "00:22:BD:F8:19:FF",
+                            "mcastARPDrop": "yes",
+                            "mcastAllow": "no",
+                            "modTs": "2025-02-27T14:43:21.537+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "mtu": "inherit",
+                            "multiDstPktAct": "bd-flood",
+                            "name": "aci-containers-kube-node-bd",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "pcTag": "16387",
+                            "scope": "3047424",
+                            "seg": "15728635",
+                            "serviceBdRoutingDisable": "no",
+                            "status": "",
+                            "type": "regular",
+                            "uid": "15374",
+                            "unicastRoute": "yes",
+                            "unkMacUcastAct": "proxy",
+                            "unkMcastAct": "flood",
+                            "userdom": ":all:",
+                            "v6unkMcastAct": "flood",
+                            "vmac": "not-applicable"
+                        }
+                    }
+                },
+                {
+                    "fvEpTags": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "dn": "uni/tn-test/eptags",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "status": "",
+                            "uid": "0",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "fvRsTenantMonPol": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "dn": "uni/tn-test/rsTenantMonPol",
+                            "extMngdBy": "",
+                            "forceResolve": "yes",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "",
+                            "rType": "mo",
+                            "state": "formed",
+                            "stateQual": "default-target",
+                            "status": "",
+                            "tCl": "monEPGPol",
+                            "tContextDn": "",
+                            "tDn": "uni/tn-common/monepg-default",
+                            "tRn": "monepg-default",
+                            "tType": "name",
+                            "tnMonEPGPolName": "",
+                            "uid": "0",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "vnsSvcCont": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "dn": "uni/tn-test/svcCont",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "status": "",
+                            "uid": "0",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "vzBrCP": {
+                        "attributes": {
+                            "accessPrivilege": "USER",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "configIssues": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/brc-aci-containers-kube-icmp",
+                            "extMngdBy": "",
+                            "intent": "install",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.532+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube-icmp",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "reevaluateAll": "no",
+                            "scope": "context",
+                            "status": "",
+                            "targetDscp": "unspecified",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "vzFilter": {
+                        "attributes": {
+                            "accessPrivilege": "USER",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/flt-aci-containers-kube-istio-filter",
+                            "extMngdBy": "",
+                            "fwdId": "4",
+                            "id": "implicit",
+                            "lcOwn": "local",
+                            "maxEntryCount": "500",
+                            "modTs": "2025-02-27T14:43:21.532+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube-istio-filter",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "revId": "6",
+                            "status": "",
+                            "txId": "14987979559920810987",
+                            "uid": "15374",
+                            "unsupportedEntries": "no",
+                            "unsupportedMgmtEntries": "no",
+                            "userdom": ":all:",
+                            "usesIds": "yes"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/mo/uni/tn-test/ap-aci-containers-kube.json": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvAp": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/ap-aci-containers-kube",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/mo/uni/tn-test/ap-aci-containers-kube1.json": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvAp": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/ap-aci-containers-kube1",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/mo/uni/tn-test/ap-aci-containers-kube.json?query-target=children": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvAEPg": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "configIssues": "",
+                            "configSt": "applied",
+                            "descr": "",
+                            "dn": "uni/tn-test/ap-aci-containers-kube/epg-aci-containers-nodes",
+                            "exceptionTag": "",
+                            "extMngdBy": "",
+                            "floodOnEncap": "disabled",
+                            "fwdCtrl": "",
+                            "hasMcastSource": "no",
+                            "isAttrBasedEPg": "no",
+                            "isSharedSrvMsiteEPg": "no",
+                            "lcOwn": "local",
+                            "matchT": "AtleastOne",
+                            "modTs": "2025-02-27T14:43:21.779+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-nodes",
+                            "nameAlias": "",
+                            "pcEnfPref": "unenforced",
+                            "pcTag": "32779",
+                            "pcTagAllocSrc": "idmanager",
+                            "prefGrMemb": "exclude",
+                            "prio": "unspecified",
+                            "scope": "3047424",
+                            "shutdown": "no",
+                            "status": "",
+                            "triggerSt": "triggerable",
+                            "txId": "14987979559920810987",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/node/class/firmwareCtrlrRunning.json": {
+            "totalCount": "3",
+            "imdata": [
+                {
+                    "firmwareCtrlrRunning": {
+                        "attributes": {
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "topology/pod-1/node-1/sys/ctrlrfwstatuscont/ctrlrrunning",
+                            "internalLabel": "a779e8156387a65a437b28e719dd8bda5774da0e",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-17T16:56:30.846+00:00",
+                            "mode": "normal",
+                            "status": "",
+                            "tpmInUse": "no",
+                            "ts": "2025-02-17T16:56:11.430+00:00",
+                            "type": "controller",
+                            "version": "6.1(2.115a)"
+                        }
+                    }
+                },
+                {
+                    "firmwareCtrlrRunning": {
+                        "attributes": {
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "topology/pod-1/node-3/sys/ctrlrfwstatuscont/ctrlrrunning",
+                            "internalLabel": "a779e8156387a65a437b28e719dd8bda5774da0e",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-17T17:49:53.268+00:00",
+                            "mode": "normal",
+                            "status": "",
+                            "tpmInUse": "no",
+                            "ts": "2025-02-17T17:49:33.904+00:00",
+                            "type": "controller",
+                            "version": "6.1(2.115a)"
+                        }
+                    }
+                },
+                {
+                    "firmwareCtrlrRunning": {
+                        "attributes": {
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "topology/pod-1/node-2/sys/ctrlrfwstatuscont/ctrlrrunning",
+                            "internalLabel": "a779e8156387a65a437b28e719dd8bda5774da0e",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-17T17:22:48.096+00:00",
+                            "mode": "normal",
+                            "status": "",
+                            "tpmInUse": "no",
+                            "ts": "2025-02-17T17:22:28.809+00:00",
+                            "type": "controller",
+                            "version": "6.1(2.115a)"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/node/mo/uni/tn-test.json?query-target=self": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvTenant": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-03-06T12:13:01.770+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "akhila2",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/node/mo/uni/tn-common.json?query-target=subtree&target-subtree-class=tagAnnotation": {
+            "totalCount": "0",
+            "imdata": []
+        }
+    },
+    
+    "deletes": [
+        
+        "/api/mo/uni/infra/vlanns-[kube-pool]-static.json" ,
+        "/api/mo/uni/infra/maddrns-kube-mpool.json",
+        "/api/mo/uni/vmmp-Kubernetes/dom-kube.json",
+        "/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/vmmp-Kubernetes/dom-kube].json",
+        "/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/phys-kube-pdom].json",
+        "/api/mo/uni/infra/attentp-kube-aep/gen-default/rsfuncToEpg-[uni/tn-test/ap-aci-containers-kube/epg-aci-containers-nodes].json",
+        "/api/mo/uni/tn-common/flt-kube-allow-all-filter.json",
+        "/api/mo/uni/tn-common/brc-kube-l3out-allow-all.json",   
+        "/api/node/mo/uni/userext/user-kube.json", 
+        "/api/node/mo/uni/userext/user-kube.json",             
+        "/api/node/mo/uni/tn-test/BD-aci-containers-kube-node-bd.json",
+        "/api/node/mo/uni/tn-test/BD-aci-containers-kube-pod-bd.json",
+        "/api/mo/uni/tn-test/ap-aci-containers-kube/epg-aci-containers-nodes.json",        
+        "/api/mo/uni/tn-common/out-l3out/instP-test_ext_net/rsprov-kube-l3out-allow-all.json",
+        "/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-kube-l3out-allow-all.json" ,
+        "/api/mo/uni/phys-kube-pdom.json" ,
+        "/api/node/mo/uni/tn-test/flt-aci-containers-kube-istio-filter.json" ,
+        "/api/node/mo/uni/tn-test/brc-aci-containers-kube-icmp.json" ,
+        "/api/node/mo/comp/prov-Kubernetes/ctrlr-[kube]-kube/injcont/info.json",
+        "/api/node/mo/uni/tn-test/ap-aci-containers-kube.json"
+    ]
+}
+    

--- a/provision/testdata/test_unprovision_custom_ap_without_annotation.inp.yaml
+++ b/provision/testdata/test_unprovision_custom_ap_without_annotation.inp.yaml
@@ -1,0 +1,135 @@
+aci_config:
+  system_id: kube
+  #use_legacy_kube_naming_convention: False
+  tenant:
+    name: test
+  apic_hosts:                   # List of cAPIC hosts to connect for APIC API
+  - localhost:50001
+  apic_version: "6.1"
+  apic_login:
+    username: admin
+    password: dummy
+    aep: kube-aep
+  vrf:
+    name: kube-vrf
+    tenant: common
+  aep: kube-aep
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+    - test_ext_net
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  apic_refreshticker_adjust: 1
+  apic_subscription_delay: 1
+  opflex_device_delete_timeout: 1
+  ssl: False
+
+net_config:
+  node_subnet:
+  - 10.1.0.1/16
+  - 11.1.0.1/16
+  pod_subnet:
+  - 10.2.0.1/16
+  - 12.3.0.1/16
+  extern_dynamic:
+  - 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+  disable_wait_for_network: True
+  duration_wait_for_network: 200
+  interface_mtu_headroom: 51
+
+kube_config:
+  aci_multipod: True
+  aci_multipod_ubuntu: True
+  dhcp_renew_max_retry_count: 12
+  dhcp_delay: 12
+  use_cluster_role: False
+  no_wait_for_service_ep_readiness: True
+  service_graph_endpoint_add_delay:
+    delay: 30 
+    services:
+    - name: "service-name-1"
+      namespace: "service-ns-1"
+    - name: "service-name-2"
+      namespace: "service-ns-2"
+      delay: 60
+  add_external_subnets_to_rdconfig: True
+  snat_operator:
+    disable_periodic_snat_global_info_sync: True
+    sleep_time_snat_global_info_sync: 60
+  hpp_optimization: True
+  opflex_agent_opflex_asyncjson_enabled: True
+  opflex_agent_ovs_asyncjson_enabled: True
+  opflex_agent_policy_retry_delay_timer: 90
+  opflex_device_reconnect_wait_timeout: 10
+  use_system_node_priority_class: False
+  aci_containers_controller_memory_limit: "5Gi"
+  aci_containers_controller_memory_request: "256Mi"
+  aci_containers_host_memory_limit: "5Gi"
+  aci_containers_host_memory_request: "256Mi"
+  mcast_daemon_memory_limit: "5Gi"
+  mcast_daemon_memory_request: "256Mi"
+  opflex_agent_memory_limit: "5Gi"
+  opflex_agent_memory_request: "256Mi"
+  aci_containers_memory_limit: "2Gi"
+  aci_containers_memory_request: "256Mi"
+  ovs_memory_limit: "2Gi"
+  ovs_memory_request: "256Mi"
+  opflex_agent_statistics: False
+  add_external_contract_to_default_epg: True
+  enable_opflex_agent_reconnect: True
+  opflex_openssl_compat: True
+  toleration_seconds: 100
+  node_snat_redirect_exclude:
+  - group: router
+    labels:
+    - worker
+    - router
+    - infra
+  - group: infra
+    labels:
+    - infra
+    - router
+  disable_hpp_rendering: True
+  apic_connection_retry_limit: 10
+  taint_not_ready_node: True
+  opflex_startup_enabled: True
+  opflex_startup_policy_duration: 80
+  opflex_startup_resolve_aft_conn: True
+  opflex_switch_sync_delay: 10
+  opflex_switch_sync_dynamic: 5
+
+registry:
+  image_prefix: quay.io/noiro
+  use_digest: True
+  aci_containers_controller_version: 375c61f113c207b152f70b4c1abc8390f23dedb73245e3d67b99c6a00dbd6bca
+  aci_containers_host_version: d37de5ac9093dff471c0602a79064a7cbac85f6513785ed86eb037ef8740ceed
+  cnideploy_version: 96f1df66843660905fa2cb07b058d8ecc5cb956c4799d661459cc0bfdfd291d2
+  opflex_agent_version: 6ae620eb8ba66a627a9c96b0e34b5d31b05aa22c9196b1885362c6273b0b76e4
+  openvswitch_version: 71d04aa713ff90ce26382bc234941beff9e51a365b3f85c76666a524b7384766
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info
+
+sriov_config:
+  enable: True
+
+nodepodif_config:
+  enable: True
+
+drop_log_config:
+  disable_events: True

--- a/provision/testdata/test_unprovision_custom_ap_without_annotation_data.json
+++ b/provision/testdata/test_unprovision_custom_ap_without_annotation_data.json
@@ -1,0 +1,459 @@
+{
+    "gets": {
+        "/api/node/mo/uni/tn-common.json?query-target=subtree&target-subtree-class=tagInst": {
+            "totalCount": "0",
+            "imdata": []
+        },
+        "/api/mo/uni/tn-test.json?query-target=children": {
+            "totalCount": "8",
+            "imdata": [
+                {
+                    "fvAp": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/ap-aci-containers-kube",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "fvBD": {
+                        "attributes": {
+                            "OptimizeWanBandwidth": "no",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "arpFlood": "no",
+                            "bcastP": "225.0.2.32",
+                            "childAction": "",
+                            "configIssues": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/BD-aci-containers-kube-pod-bd",
+                            "enableRogueExceptMac": "no",
+                            "epClear": "no",
+                            "epMoveDetectMode": "",
+                            "extMngdBy": "",
+                            "hostBasedRouting": "no",
+                            "intersiteBumTrafficAllow": "no",
+                            "intersiteL2Stretch": "no",
+                            "ipLearning": "yes",
+                            "ipv6McastAllow": "no",
+                            "lcOwn": "local",
+                            "limitIpLearnToSubnets": "yes",
+                            "llAddr": "::",
+                            "mac": "00:22:BD:F8:19:FF",
+                            "mcastARPDrop": "yes",
+                            "mcastAllow": "no",
+                            "modTs": "2025-02-27T14:43:21.537+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "mtu": "inherit",
+                            "multiDstPktAct": "bd-flood",
+                            "name": "aci-containers-kube-pod-bd",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "pcTag": "49164",
+                            "scope": "3047424",
+                            "seg": "16547722",
+                            "serviceBdRoutingDisable": "no",
+                            "status": "",
+                            "type": "regular",
+                            "uid": "15374",
+                            "unicastRoute": "yes",
+                            "unkMacUcastAct": "proxy",
+                            "unkMcastAct": "flood",
+                            "userdom": ":all:",
+                            "v6unkMcastAct": "flood",
+                            "vmac": "not-applicable"
+                        }
+                    }
+                },
+                {
+                    "fvBD": {
+                        "attributes": {
+                            "OptimizeWanBandwidth": "no",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "arpFlood": "yes",
+                            "bcastP": "225.1.43.192",
+                            "childAction": "",
+                            "configIssues": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/BD-aci-containers-kube-node-bd",
+                            "enableRogueExceptMac": "no",
+                            "epClear": "no",
+                            "epMoveDetectMode": "",
+                            "extMngdBy": "",
+                            "hostBasedRouting": "no",
+                            "intersiteBumTrafficAllow": "no",
+                            "intersiteL2Stretch": "no",
+                            "ipLearning": "yes",
+                            "ipv6McastAllow": "no",
+                            "lcOwn": "local",
+                            "limitIpLearnToSubnets": "yes",
+                            "llAddr": "::",
+                            "mac": "00:22:BD:F8:19:FF",
+                            "mcastARPDrop": "yes",
+                            "mcastAllow": "no",
+                            "modTs": "2025-02-27T14:43:21.537+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "mtu": "inherit",
+                            "multiDstPktAct": "bd-flood",
+                            "name": "aci-containers-kube-node-bd",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "pcTag": "16387",
+                            "scope": "3047424",
+                            "seg": "15728635",
+                            "serviceBdRoutingDisable": "no",
+                            "status": "",
+                            "type": "regular",
+                            "uid": "15374",
+                            "unicastRoute": "yes",
+                            "unkMacUcastAct": "proxy",
+                            "unkMcastAct": "flood",
+                            "userdom": ":all:",
+                            "v6unkMcastAct": "flood",
+                            "vmac": "not-applicable"
+                        }
+                    }
+                },
+                {
+                    "fvEpTags": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "dn": "uni/tn-test/eptags",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "status": "",
+                            "uid": "0",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "fvRsTenantMonPol": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "dn": "uni/tn-test/rsTenantMonPol",
+                            "extMngdBy": "",
+                            "forceResolve": "yes",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "",
+                            "rType": "mo",
+                            "state": "formed",
+                            "stateQual": "default-target",
+                            "status": "",
+                            "tCl": "monEPGPol",
+                            "tContextDn": "",
+                            "tDn": "uni/tn-common/monepg-default",
+                            "tRn": "monepg-default",
+                            "tType": "name",
+                            "tnMonEPGPolName": "",
+                            "uid": "0",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "vnsSvcCont": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "dn": "uni/tn-test/svcCont",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "status": "",
+                            "uid": "0",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "vzBrCP": {
+                        "attributes": {
+                            "accessPrivilege": "USER",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "configIssues": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/brc-aci-containers-kube-icmp",
+                            "extMngdBy": "",
+                            "intent": "install",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.532+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube-icmp",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "reevaluateAll": "no",
+                            "scope": "context",
+                            "status": "",
+                            "targetDscp": "unspecified",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "vzFilter": {
+                        "attributes": {
+                            "accessPrivilege": "USER",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/flt-aci-containers-kube-istio-filter",
+                            "extMngdBy": "",
+                            "fwdId": "4",
+                            "id": "implicit",
+                            "lcOwn": "local",
+                            "maxEntryCount": "500",
+                            "modTs": "2025-02-27T14:43:21.532+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube-istio-filter",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "revId": "6",
+                            "status": "",
+                            "txId": "14987979559920810987",
+                            "uid": "15374",
+                            "unsupportedEntries": "no",
+                            "unsupportedMgmtEntries": "no",
+                            "userdom": ":all:",
+                            "usesIds": "yes"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/mo/uni/tn-test/ap-aci-containers-kube.json": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvAp": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/ap-aci-containers-kube",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/mo/uni/tn-test/ap-aci-containers-kube1.json": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvAp": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/ap-aci-containers-kube1",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+       
+        "/api/mo/uni/tn-test/ap-aci-containers-kube.json?query-target=children": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvAEPg": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "configIssues": "",
+                            "configSt": "applied",
+                            "descr": "",
+                            "dn": "uni/tn-test/ap-aci-containers-kube/epg-aci-containers-nodes",
+                            "exceptionTag": "",
+                            "extMngdBy": "",
+                            "floodOnEncap": "disabled",
+                            "fwdCtrl": "",
+                            "hasMcastSource": "no",
+                            "isAttrBasedEPg": "no",
+                            "isSharedSrvMsiteEPg": "no",
+                            "lcOwn": "local",
+                            "matchT": "AtleastOne",
+                            "modTs": "2025-02-27T14:43:21.779+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-nodes",
+                            "nameAlias": "",
+                            "pcEnfPref": "unenforced",
+                            "pcTag": "32779",
+                            "pcTagAllocSrc": "idmanager",
+                            "prefGrMemb": "exclude",
+                            "prio": "unspecified",
+                            "scope": "3047424",
+                            "shutdown": "no",
+                            "status": "",
+                            "triggerSt": "triggerable",
+                            "txId": "14987979559920810987",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/node/class/firmwareCtrlrRunning.json": {
+            "totalCount": "3",
+            "imdata": [
+                {
+                    "firmwareCtrlrRunning": {
+                        "attributes": {
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "topology/pod-1/node-1/sys/ctrlrfwstatuscont/ctrlrrunning",
+                            "internalLabel": "a779e8156387a65a437b28e719dd8bda5774da0e",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-17T16:56:30.846+00:00",
+                            "mode": "normal",
+                            "status": "",
+                            "tpmInUse": "no",
+                            "ts": "2025-02-17T16:56:11.430+00:00",
+                            "type": "controller",
+                            "version": "6.1(2.115a)"
+                        }
+                    }
+                },
+                {
+                    "firmwareCtrlrRunning": {
+                        "attributes": {
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "topology/pod-1/node-3/sys/ctrlrfwstatuscont/ctrlrrunning",
+                            "internalLabel": "a779e8156387a65a437b28e719dd8bda5774da0e",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-17T17:49:53.268+00:00",
+                            "mode": "normal",
+                            "status": "",
+                            "tpmInUse": "no",
+                            "ts": "2025-02-17T17:49:33.904+00:00",
+                            "type": "controller",
+                            "version": "6.1(2.115a)"
+                        }
+                    }
+                },
+                {
+                    "firmwareCtrlrRunning": {
+                        "attributes": {
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "topology/pod-1/node-2/sys/ctrlrfwstatuscont/ctrlrrunning",
+                            "internalLabel": "a779e8156387a65a437b28e719dd8bda5774da0e",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-17T17:22:48.096+00:00",
+                            "mode": "normal",
+                            "status": "",
+                            "tpmInUse": "no",
+                            "ts": "2025-02-17T17:22:28.809+00:00",
+                            "type": "controller",
+                            "version": "6.1(2.115a)"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/node/mo/uni/tn-test.json?query-target=self": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvTenant": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-03-06T12:13:01.770+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "akhila2",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/node/mo/uni/tn-common.json?query-target=subtree&target-subtree-class=tagAnnotation": {
+            "totalCount": "0",
+            "imdata": []
+        }
+    },
+    "deletes":[
+        "/api/mo/uni/infra/vlanns-[kube-pool]-static.json" ,
+        "/api/mo/uni/infra/maddrns-kube-mpool.json",
+        "/api/mo/uni/vmmp-Kubernetes/dom-kube.json",
+        "/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/vmmp-Kubernetes/dom-kube].json",
+        "/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/phys-kube-pdom].json",
+        "/api/mo/uni/infra/attentp-kube-aep/gen-default/rsfuncToEpg-[uni/tn-test/ap-aci-containers-kube/epg-aci-containers-nodes].json",
+        "/api/mo/uni/tn-common/flt-kube-allow-all-filter.json",
+        "/api/mo/uni/tn-common/brc-kube-l3out-allow-all.json",   
+        "/api/node/mo/uni/userext/user-kube.json", 
+        "/api/node/mo/uni/userext/user-kube.json",             
+        "/api/node/mo/uni/tn-test/BD-aci-containers-kube-node-bd.json",
+        "/api/node/mo/uni/tn-test/BD-aci-containers-kube-pod-bd.json",
+        "/api/mo/uni/tn-test/ap-aci-containers-kube/epg-aci-containers-nodes.json",        
+        "/api/mo/uni/tn-common/out-l3out/instP-test_ext_net/rsprov-kube-l3out-allow-all.json",
+        "/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-kube-l3out-allow-all.json" ,
+        "/api/mo/uni/phys-kube-pdom.json" ,
+        "/api/node/mo/uni/tn-test/flt-aci-containers-kube-istio-filter.json" ,
+        "/api/node/mo/uni/tn-test/brc-aci-containers-kube-icmp.json" ,
+        "/api/node/mo/comp/prov-Kubernetes/ctrlr-[kube]-kube/injcont/info.json",
+        "/api/node/mo/uni/tn-test/ap-aci-containers-kube.json"
+    ] 
+}

--- a/provision/testdata/test_unprovision_custom_epg.inp.yaml
+++ b/provision/testdata/test_unprovision_custom_epg.inp.yaml
@@ -1,0 +1,135 @@
+aci_config:
+  system_id: kube
+  #use_legacy_kube_naming_convention: False
+  tenant:
+    name: test
+  apic_hosts:                   # List of cAPIC hosts to connect for APIC API
+  - localhost:50001
+  apic_version: "6.1"
+  apic_login:
+    username: admin
+    password: dummy
+    aep: kube-aep
+  vrf:
+    name: kube-vrf
+    tenant: common
+  aep: kube-aep
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+    - test_ext_net
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  apic_refreshticker_adjust: 1
+  apic_subscription_delay: 1
+  opflex_device_delete_timeout: 1
+  ssl: False
+
+net_config:
+  node_subnet:
+  - 10.1.0.1/16
+  - 11.1.0.1/16
+  pod_subnet:
+  - 10.2.0.1/16
+  - 12.3.0.1/16
+  extern_dynamic:
+  - 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+  disable_wait_for_network: True
+  duration_wait_for_network: 200
+  interface_mtu_headroom: 51
+
+kube_config:
+  aci_multipod: True
+  aci_multipod_ubuntu: True
+  dhcp_renew_max_retry_count: 12
+  dhcp_delay: 12
+  use_cluster_role: False
+  no_wait_for_service_ep_readiness: True
+  service_graph_endpoint_add_delay:
+    delay: 30 
+    services:
+    - name: "service-name-1"
+      namespace: "service-ns-1"
+    - name: "service-name-2"
+      namespace: "service-ns-2"
+      delay: 60
+  add_external_subnets_to_rdconfig: True
+  snat_operator:
+    disable_periodic_snat_global_info_sync: True
+    sleep_time_snat_global_info_sync: 60
+  hpp_optimization: True
+  opflex_agent_opflex_asyncjson_enabled: True
+  opflex_agent_ovs_asyncjson_enabled: True
+  opflex_agent_policy_retry_delay_timer: 90
+  opflex_device_reconnect_wait_timeout: 10
+  use_system_node_priority_class: False
+  aci_containers_controller_memory_limit: "5Gi"
+  aci_containers_controller_memory_request: "256Mi"
+  aci_containers_host_memory_limit: "5Gi"
+  aci_containers_host_memory_request: "256Mi"
+  mcast_daemon_memory_limit: "5Gi"
+  mcast_daemon_memory_request: "256Mi"
+  opflex_agent_memory_limit: "5Gi"
+  opflex_agent_memory_request: "256Mi"
+  aci_containers_memory_limit: "2Gi"
+  aci_containers_memory_request: "256Mi"
+  ovs_memory_limit: "2Gi"
+  ovs_memory_request: "256Mi"
+  opflex_agent_statistics: False
+  add_external_contract_to_default_epg: True
+  enable_opflex_agent_reconnect: True
+  opflex_openssl_compat: True
+  toleration_seconds: 100
+  node_snat_redirect_exclude:
+  - group: router
+    labels:
+    - worker
+    - router
+    - infra
+  - group: infra
+    labels:
+    - infra
+    - router
+  disable_hpp_rendering: True
+  apic_connection_retry_limit: 10
+  taint_not_ready_node: True
+  opflex_startup_enabled: True
+  opflex_startup_policy_duration: 80
+  opflex_startup_resolve_aft_conn: True
+  opflex_switch_sync_delay: 10
+  opflex_switch_sync_dynamic: 5
+
+registry:
+  image_prefix: quay.io/noiro
+  use_digest: True
+  aci_containers_controller_version: 375c61f113c207b152f70b4c1abc8390f23dedb73245e3d67b99c6a00dbd6bca
+  aci_containers_host_version: d37de5ac9093dff471c0602a79064a7cbac85f6513785ed86eb037ef8740ceed
+  cnideploy_version: 96f1df66843660905fa2cb07b058d8ecc5cb956c4799d661459cc0bfdfd291d2
+  opflex_agent_version: 6ae620eb8ba66a627a9c96b0e34b5d31b05aa22c9196b1885362c6273b0b76e4
+  openvswitch_version: 71d04aa713ff90ce26382bc234941beff9e51a365b3f85c76666a524b7384766
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info
+
+sriov_config:
+  enable: True
+
+nodepodif_config:
+  enable: True
+
+drop_log_config:
+  disable_events: True

--- a/provision/testdata/test_unprovision_custom_epg_data.json
+++ b/provision/testdata/test_unprovision_custom_epg_data.json
@@ -1,0 +1,495 @@
+{
+    "gets": {
+        "/api/node/mo/uni/tn-common.json?query-target=subtree&target-subtree-class=tagInst": {
+            "totalCount": "0",
+            "imdata": []
+        },
+        "/api/mo/uni/tn-test.json?query-target=children": {
+            "totalCount": "8",
+            "imdata": [
+                {
+                    "fvAp": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/ap-aci-containers-kube",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "fvBD": {
+                        "attributes": {
+                            "OptimizeWanBandwidth": "no",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "arpFlood": "no",
+                            "bcastP": "225.0.2.32",
+                            "childAction": "",
+                            "configIssues": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/BD-aci-containers-kube-pod-bd",
+                            "enableRogueExceptMac": "no",
+                            "epClear": "no",
+                            "epMoveDetectMode": "",
+                            "extMngdBy": "",
+                            "hostBasedRouting": "no",
+                            "intersiteBumTrafficAllow": "no",
+                            "intersiteL2Stretch": "no",
+                            "ipLearning": "yes",
+                            "ipv6McastAllow": "no",
+                            "lcOwn": "local",
+                            "limitIpLearnToSubnets": "yes",
+                            "llAddr": "::",
+                            "mac": "00:22:BD:F8:19:FF",
+                            "mcastARPDrop": "yes",
+                            "mcastAllow": "no",
+                            "modTs": "2025-02-27T14:43:21.537+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "mtu": "inherit",
+                            "multiDstPktAct": "bd-flood",
+                            "name": "aci-containers-kube-pod-bd",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "pcTag": "49164",
+                            "scope": "3047424",
+                            "seg": "16547722",
+                            "serviceBdRoutingDisable": "no",
+                            "status": "",
+                            "type": "regular",
+                            "uid": "15374",
+                            "unicastRoute": "yes",
+                            "unkMacUcastAct": "proxy",
+                            "unkMcastAct": "flood",
+                            "userdom": ":all:",
+                            "v6unkMcastAct": "flood",
+                            "vmac": "not-applicable"
+                        }
+                    }
+                },
+                {
+                    "fvBD": {
+                        "attributes": {
+                            "OptimizeWanBandwidth": "no",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "arpFlood": "yes",
+                            "bcastP": "225.1.43.192",
+                            "childAction": "",
+                            "configIssues": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/BD-aci-containers-kube-node-bd",
+                            "enableRogueExceptMac": "no",
+                            "epClear": "no",
+                            "epMoveDetectMode": "",
+                            "extMngdBy": "",
+                            "hostBasedRouting": "no",
+                            "intersiteBumTrafficAllow": "no",
+                            "intersiteL2Stretch": "no",
+                            "ipLearning": "yes",
+                            "ipv6McastAllow": "no",
+                            "lcOwn": "local",
+                            "limitIpLearnToSubnets": "yes",
+                            "llAddr": "::",
+                            "mac": "00:22:BD:F8:19:FF",
+                            "mcastARPDrop": "yes",
+                            "mcastAllow": "no",
+                            "modTs": "2025-02-27T14:43:21.537+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "mtu": "inherit",
+                            "multiDstPktAct": "bd-flood",
+                            "name": "aci-containers-kube-node-bd",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "pcTag": "16387",
+                            "scope": "3047424",
+                            "seg": "15728635",
+                            "serviceBdRoutingDisable": "no",
+                            "status": "",
+                            "type": "regular",
+                            "uid": "15374",
+                            "unicastRoute": "yes",
+                            "unkMacUcastAct": "proxy",
+                            "unkMcastAct": "flood",
+                            "userdom": ":all:",
+                            "v6unkMcastAct": "flood",
+                            "vmac": "not-applicable"
+                        }
+                    }
+                },
+                {
+                    "fvEpTags": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "dn": "uni/tn-test/eptags",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "status": "",
+                            "uid": "0",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "fvRsTenantMonPol": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "dn": "uni/tn-test/rsTenantMonPol",
+                            "extMngdBy": "",
+                            "forceResolve": "yes",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "",
+                            "rType": "mo",
+                            "state": "formed",
+                            "stateQual": "default-target",
+                            "status": "",
+                            "tCl": "monEPGPol",
+                            "tContextDn": "",
+                            "tDn": "uni/tn-common/monepg-default",
+                            "tRn": "monepg-default",
+                            "tType": "name",
+                            "tnMonEPGPolName": "",
+                            "uid": "0",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "vnsSvcCont": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "dn": "uni/tn-test/svcCont",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "status": "",
+                            "uid": "0",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "vzBrCP": {
+                        "attributes": {
+                            "accessPrivilege": "USER",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "configIssues": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/brc-aci-containers-kube-icmp",
+                            "extMngdBy": "",
+                            "intent": "install",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.532+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube-icmp",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "reevaluateAll": "no",
+                            "scope": "context",
+                            "status": "",
+                            "targetDscp": "unspecified",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "vzFilter": {
+                        "attributes": {
+                            "accessPrivilege": "USER",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/flt-aci-containers-kube-istio-filter",
+                            "extMngdBy": "",
+                            "fwdId": "4",
+                            "id": "implicit",
+                            "lcOwn": "local",
+                            "maxEntryCount": "500",
+                            "modTs": "2025-02-27T14:43:21.532+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube-istio-filter",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "revId": "6",
+                            "status": "",
+                            "txId": "14987979559920810987",
+                            "uid": "15374",
+                            "unsupportedEntries": "no",
+                            "unsupportedMgmtEntries": "no",
+                            "userdom": ":all:",
+                            "usesIds": "yes"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/mo/uni/tn-test/ap-aci-containers-kube.json": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvAp": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/ap-aci-containers-kube",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/mo/uni/tn-test/ap-aci-containers-kube1.json": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvAp": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test/ap-aci-containers-kube1",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+       
+        "/api/mo/uni/tn-test/ap-aci-containers-kube.json?query-target=children": {
+            "totalCount": "2",
+            "imdata": [
+                {
+                    "fvAEPg": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "configIssues": "",
+                            "configSt": "applied",
+                            "descr": "",
+                            "dn": "uni/tn-test/ap-aci-containers-kube/epg-aci-containers-nodes",
+                            "exceptionTag": "",
+                            "extMngdBy": "",
+                            "floodOnEncap": "disabled",
+                            "fwdCtrl": "",
+                            "hasMcastSource": "no",
+                            "isAttrBasedEPg": "no",
+                            "isSharedSrvMsiteEPg": "no",
+                            "lcOwn": "local",
+                            "matchT": "AtleastOne",
+                            "modTs": "2025-02-27T14:43:21.779+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-nodes",
+                            "nameAlias": "",
+                            "pcEnfPref": "unenforced",
+                            "pcTag": "32779",
+                            "pcTagAllocSrc": "idmanager",
+                            "prefGrMemb": "exclude",
+                            "prio": "unspecified",
+                            "scope": "3047424",
+                            "shutdown": "no",
+                            "status": "",
+                            "triggerSt": "triggerable",
+                            "txId": "14987979559920810987",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }, {
+                    "fvAEPg": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "configIssues": "",
+                            "configSt": "applied",
+                            "descr": "",
+                            "dn": "uni/tn-test/ap-aci-containers-kube/epg-testepg",
+                            "exceptionTag": "",
+                            "extMngdBy": "",
+                            "floodOnEncap": "disabled",
+                            "fwdCtrl": "",
+                            "hasMcastSource": "no",
+                            "isAttrBasedEPg": "no",
+                            "isSharedSrvMsiteEPg": "no",
+                            "lcOwn": "local",
+                            "matchT": "AtleastOne",
+                            "modTs": "2025-02-27T14:43:21.779+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-nodes",
+                            "nameAlias": "",
+                            "pcEnfPref": "unenforced",
+                            "pcTag": "32779",
+                            "pcTagAllocSrc": "idmanager",
+                            "prefGrMemb": "exclude",
+                            "prio": "unspecified",
+                            "scope": "3047424",
+                            "shutdown": "no",
+                            "status": "",
+                            "triggerSt": "triggerable",
+                            "txId": "14987979559920810987",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/node/class/firmwareCtrlrRunning.json": {
+            "totalCount": "3",
+            "imdata": [
+                {
+                    "firmwareCtrlrRunning": {
+                        "attributes": {
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "topology/pod-1/node-1/sys/ctrlrfwstatuscont/ctrlrrunning",
+                            "internalLabel": "a779e8156387a65a437b28e719dd8bda5774da0e",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-17T16:56:30.846+00:00",
+                            "mode": "normal",
+                            "status": "",
+                            "tpmInUse": "no",
+                            "ts": "2025-02-17T16:56:11.430+00:00",
+                            "type": "controller",
+                            "version": "6.1(2.115a)"
+                        }
+                    }
+                },
+                {
+                    "firmwareCtrlrRunning": {
+                        "attributes": {
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "topology/pod-1/node-3/sys/ctrlrfwstatuscont/ctrlrrunning",
+                            "internalLabel": "a779e8156387a65a437b28e719dd8bda5774da0e",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-17T17:49:53.268+00:00",
+                            "mode": "normal",
+                            "status": "",
+                            "tpmInUse": "no",
+                            "ts": "2025-02-17T17:49:33.904+00:00",
+                            "type": "controller",
+                            "version": "6.1(2.115a)"
+                        }
+                    }
+                },
+                {
+                    "firmwareCtrlrRunning": {
+                        "attributes": {
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "topology/pod-1/node-2/sys/ctrlrfwstatuscont/ctrlrrunning",
+                            "internalLabel": "a779e8156387a65a437b28e719dd8bda5774da0e",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-17T17:22:48.096+00:00",
+                            "mode": "normal",
+                            "status": "",
+                            "tpmInUse": "no",
+                            "ts": "2025-02-17T17:22:28.809+00:00",
+                            "type": "controller",
+                            "version": "6.1(2.115a)"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/node/mo/uni/tn-test.json?query-target=self": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvTenant": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-test",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-03-06T12:13:01.770+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "akhila2",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/node/mo/uni/tn-common.json?query-target=subtree&target-subtree-class=tagAnnotation": {
+            "totalCount": "0",
+            "imdata": []
+        }
+    },
+    "deletes":[
+        "/api/mo/uni/infra/vlanns-[kube-pool]-static.json" ,
+        "/api/mo/uni/infra/maddrns-kube-mpool.json",
+        "/api/mo/uni/vmmp-Kubernetes/dom-kube.json",
+        "/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/vmmp-Kubernetes/dom-kube].json",
+        "/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/phys-kube-pdom].json",
+        "/api/mo/uni/infra/attentp-kube-aep/gen-default/rsfuncToEpg-[uni/tn-test/ap-aci-containers-kube/epg-aci-containers-nodes].json",
+        "/api/mo/uni/tn-common/flt-kube-allow-all-filter.json",
+        "/api/mo/uni/tn-common/brc-kube-l3out-allow-all.json",   
+        "/api/node/mo/uni/userext/user-kube.json", 
+        "/api/node/mo/uni/userext/user-kube.json",             
+        "/api/node/mo/uni/tn-test/BD-aci-containers-kube-node-bd.json",
+        "/api/node/mo/uni/tn-test/BD-aci-containers-kube-pod-bd.json",
+        "/api/mo/uni/tn-test/ap-aci-containers-kube/epg-aci-containers-nodes.json",        
+        "/api/mo/uni/tn-common/out-l3out/instP-test_ext_net/rsprov-kube-l3out-allow-all.json",
+        "/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-kube-l3out-allow-all.json" ,
+        "/api/mo/uni/phys-kube-pdom.json" ,
+        "/api/node/mo/uni/tn-test/flt-aci-containers-kube-istio-filter.json" ,
+        "/api/node/mo/uni/tn-test/brc-aci-containers-kube-icmp.json" ,
+        "/api/node/mo/comp/prov-Kubernetes/ctrlr-[kube]-kube/injcont/info.json"
+        
+    ] 
+}

--- a/provision/testdata/test_unprovision_delete_tenant.inp.yaml
+++ b/provision/testdata/test_unprovision_delete_tenant.inp.yaml
@@ -1,0 +1,133 @@
+aci_config:
+  system_id: kube
+  #use_legacy_kube_naming_convention: False
+  apic_hosts:                   # List of cAPIC hosts to connect for APIC API
+  - localhost:50001
+  apic_version: "6.1"
+  apic_login:
+    username: admin
+    password: dummy
+    aep: kube-aep
+  vrf:
+    name: kube-vrf
+    tenant: common
+  aep: kube-aep
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+    - test_ext_net
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  apic_refreshticker_adjust: 1
+  apic_subscription_delay: 1
+  opflex_device_delete_timeout: 1
+  ssl: False
+
+net_config:
+  node_subnet:
+  - 10.1.0.1/16
+  - 11.1.0.1/16
+  pod_subnet:
+  - 10.2.0.1/16
+  - 12.3.0.1/16
+  extern_dynamic:
+  - 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+  disable_wait_for_network: True
+  duration_wait_for_network: 200
+  interface_mtu_headroom: 51
+
+kube_config:
+  aci_multipod: True
+  aci_multipod_ubuntu: True
+  dhcp_renew_max_retry_count: 12
+  dhcp_delay: 12
+  use_cluster_role: False
+  no_wait_for_service_ep_readiness: True
+  service_graph_endpoint_add_delay:
+    delay: 30 
+    services:
+    - name: "service-name-1"
+      namespace: "service-ns-1"
+    - name: "service-name-2"
+      namespace: "service-ns-2"
+      delay: 60
+  add_external_subnets_to_rdconfig: True
+  snat_operator:
+    disable_periodic_snat_global_info_sync: True
+    sleep_time_snat_global_info_sync: 60
+  hpp_optimization: True
+  opflex_agent_opflex_asyncjson_enabled: True
+  opflex_agent_ovs_asyncjson_enabled: True
+  opflex_agent_policy_retry_delay_timer: 90
+  opflex_device_reconnect_wait_timeout: 10
+  use_system_node_priority_class: False
+  aci_containers_controller_memory_limit: "5Gi"
+  aci_containers_controller_memory_request: "256Mi"
+  aci_containers_host_memory_limit: "5Gi"
+  aci_containers_host_memory_request: "256Mi"
+  mcast_daemon_memory_limit: "5Gi"
+  mcast_daemon_memory_request: "256Mi"
+  opflex_agent_memory_limit: "5Gi"
+  opflex_agent_memory_request: "256Mi"
+  aci_containers_memory_limit: "2Gi"
+  aci_containers_memory_request: "256Mi"
+  ovs_memory_limit: "2Gi"
+  ovs_memory_request: "256Mi"
+  opflex_agent_statistics: False
+  add_external_contract_to_default_epg: True
+  enable_opflex_agent_reconnect: True
+  opflex_openssl_compat: True
+  toleration_seconds: 100
+  node_snat_redirect_exclude:
+  - group: router
+    labels:
+    - worker
+    - router
+    - infra
+  - group: infra
+    labels:
+    - infra
+    - router
+  disable_hpp_rendering: True
+  apic_connection_retry_limit: 10
+  taint_not_ready_node: True
+  opflex_startup_enabled: True
+  opflex_startup_policy_duration: 80
+  opflex_startup_resolve_aft_conn: True
+  opflex_switch_sync_delay: 10
+  opflex_switch_sync_dynamic: 5
+
+registry:
+  image_prefix: quay.io/noiro
+  use_digest: True
+  aci_containers_controller_version: 375c61f113c207b152f70b4c1abc8390f23dedb73245e3d67b99c6a00dbd6bca
+  aci_containers_host_version: d37de5ac9093dff471c0602a79064a7cbac85f6513785ed86eb037ef8740ceed
+  cnideploy_version: 96f1df66843660905fa2cb07b058d8ecc5cb956c4799d661459cc0bfdfd291d2
+  opflex_agent_version: 6ae620eb8ba66a627a9c96b0e34b5d31b05aa22c9196b1885362c6273b0b76e4
+  openvswitch_version: 71d04aa713ff90ce26382bc234941beff9e51a365b3f85c76666a524b7384766
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info
+
+sriov_config:
+  enable: True
+
+nodepodif_config:
+  enable: True
+
+drop_log_config:
+  disable_events: True

--- a/provision/testdata/test_unprovision_delete_tenant_data.json
+++ b/provision/testdata/test_unprovision_delete_tenant_data.json
@@ -1,0 +1,564 @@
+{
+    "gets": {
+        "/api/node/mo/uni/tn-common.json?query-target=subtree&target-subtree-class=tagInst": {
+            "totalCount": "0",
+            "imdata": []
+        },
+        "/api/mo/uni/tn-kube.json?query-target=children": {
+            "totalCount": "8",
+            "imdata": [
+                {
+                    "fvAp": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-kube/ap-aci-containers-kube",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "fvBD": {
+                        "attributes": {
+                            "OptimizeWanBandwidth": "no",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "arpFlood": "no",
+                            "bcastP": "225.0.2.32",
+                            "childAction": "",
+                            "configIssues": "",
+                            "descr": "",
+                            "dn": "uni/tn-kube/BD-aci-containers-kube-pod-bd",
+                            "enableRogueExceptMac": "no",
+                            "epClear": "no",
+                            "epMoveDetectMode": "",
+                            "extMngdBy": "",
+                            "hostBasedRouting": "no",
+                            "intersiteBumTrafficAllow": "no",
+                            "intersiteL2Stretch": "no",
+                            "ipLearning": "yes",
+                            "ipv6McastAllow": "no",
+                            "lcOwn": "local",
+                            "limitIpLearnToSubnets": "yes",
+                            "llAddr": "::",
+                            "mac": "00:22:BD:F8:19:FF",
+                            "mcastARPDrop": "yes",
+                            "mcastAllow": "no",
+                            "modTs": "2025-02-27T14:43:21.537+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "mtu": "inherit",
+                            "multiDstPktAct": "bd-flood",
+                            "name": "aci-containers-kube-pod-bd",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "pcTag": "49164",
+                            "scope": "3047424",
+                            "seg": "16547722",
+                            "serviceBdRoutingDisable": "no",
+                            "status": "",
+                            "type": "regular",
+                            "uid": "15374",
+                            "unicastRoute": "yes",
+                            "unkMacUcastAct": "proxy",
+                            "unkMcastAct": "flood",
+                            "userdom": ":all:",
+                            "v6unkMcastAct": "flood",
+                            "vmac": "not-applicable"
+                        }
+                    }
+                },
+                {
+                    "fvBD": {
+                        "attributes": {
+                            "OptimizeWanBandwidth": "no",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "arpFlood": "yes",
+                            "bcastP": "225.1.43.192",
+                            "childAction": "",
+                            "configIssues": "",
+                            "descr": "",
+                            "dn": "uni/tn-kube/BD-aci-containers-kube-node-bd",
+                            "enableRogueExceptMac": "no",
+                            "epClear": "no",
+                            "epMoveDetectMode": "",
+                            "extMngdBy": "",
+                            "hostBasedRouting": "no",
+                            "intersiteBumTrafficAllow": "no",
+                            "intersiteL2Stretch": "no",
+                            "ipLearning": "yes",
+                            "ipv6McastAllow": "no",
+                            "lcOwn": "local",
+                            "limitIpLearnToSubnets": "yes",
+                            "llAddr": "::",
+                            "mac": "00:22:BD:F8:19:FF",
+                            "mcastARPDrop": "yes",
+                            "mcastAllow": "no",
+                            "modTs": "2025-02-27T14:43:21.537+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "mtu": "inherit",
+                            "multiDstPktAct": "bd-flood",
+                            "name": "aci-containers-kube-node-bd",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "pcTag": "16387",
+                            "scope": "3047424",
+                            "seg": "15728635",
+                            "serviceBdRoutingDisable": "no",
+                            "status": "",
+                            "type": "regular",
+                            "uid": "15374",
+                            "unicastRoute": "yes",
+                            "unkMacUcastAct": "proxy",
+                            "unkMcastAct": "flood",
+                            "userdom": ":all:",
+                            "v6unkMcastAct": "flood",
+                            "vmac": "not-applicable"
+                        }
+                    }
+                },
+                {
+                    "fvEpTags": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "dn": "uni/tn-kube/eptags",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "status": "",
+                            "uid": "0",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "fvRsTenantMonPol": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "dn": "uni/tn-kube/rsTenantMonPol",
+                            "extMngdBy": "",
+                            "forceResolve": "yes",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "",
+                            "rType": "mo",
+                            "state": "formed",
+                            "stateQual": "default-target",
+                            "status": "",
+                            "tCl": "monEPGPol",
+                            "tContextDn": "",
+                            "tDn": "uni/tn-common/monepg-default",
+                            "tRn": "monepg-default",
+                            "tType": "name",
+                            "tnMonEPGPolName": "",
+                            "uid": "0",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "vnsSvcCont": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "dn": "uni/tn-kube/svcCont",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "status": "",
+                            "uid": "0",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "vzBrCP": {
+                        "attributes": {
+                            "accessPrivilege": "USER",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "configIssues": "",
+                            "descr": "",
+                            "dn": "uni/tn-kube/brc-aci-containers-kube-icmp",
+                            "extMngdBy": "",
+                            "intent": "install",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.532+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube-icmp",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "reevaluateAll": "no",
+                            "scope": "context",
+                            "status": "",
+                            "targetDscp": "unspecified",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                },
+                {
+                    "vzFilter": {
+                        "attributes": {
+                            "accessPrivilege": "USER",
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-kube/flt-aci-containers-kube-istio-filter",
+                            "extMngdBy": "",
+                            "fwdId": "4",
+                            "id": "implicit",
+                            "lcOwn": "local",
+                            "maxEntryCount": "500",
+                            "modTs": "2025-02-27T14:43:21.532+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube-istio-filter",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "revId": "6",
+                            "status": "",
+                            "txId": "14987979559920810987",
+                            "uid": "15374",
+                            "unsupportedEntries": "no",
+                            "unsupportedMgmtEntries": "no",
+                            "userdom": ":all:",
+                            "usesIds": "yes"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/mo/uni/tn-kube/ap-aci-containers-kube.json": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvAp": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-kube/ap-aci-containers-kube",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-kube",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "prio": "unspecified",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        
+       
+        "/api/mo/uni/tn-kube/ap-aci-containers-kube.json?query-target=children": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvAEPg": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "configIssues": "",
+                            "configSt": "applied",
+                            "descr": "",
+                            "dn": "uni/tn-kube/ap-aci-containers-kube/epg-aci-containers-nodes",
+                            "exceptionTag": "",
+                            "extMngdBy": "",
+                            "floodOnEncap": "disabled",
+                            "fwdCtrl": "",
+                            "hasMcastSource": "no",
+                            "isAttrBasedEPg": "no",
+                            "isSharedSrvMsiteEPg": "no",
+                            "lcOwn": "local",
+                            "matchT": "AtleastOne",
+                            "modTs": "2025-02-27T14:43:21.779+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "aci-containers-nodes",
+                            "nameAlias": "",
+                            "pcEnfPref": "unenforced",
+                            "pcTag": "32779",
+                            "pcTagAllocSrc": "idmanager",
+                            "prefGrMemb": "exclude",
+                            "prio": "unspecified",
+                            "scope": "3047424",
+                            "shutdown": "no",
+                            "status": "",
+                            "triggerSt": "triggerable",
+                            "txId": "14987979559920810987",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/node/class/firmwareCtrlrRunning.json": {
+            "totalCount": "3",
+            "imdata": [
+                {
+                    "firmwareCtrlrRunning": {
+                        "attributes": {
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "topology/pod-1/node-1/sys/ctrlrfwstatuscont/ctrlrrunning",
+                            "internalLabel": "a779e8156387a65a437b28e719dd8bda5774da0e",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-17T16:56:30.846+00:00",
+                            "mode": "normal",
+                            "status": "",
+                            "tpmInUse": "no",
+                            "ts": "2025-02-17T16:56:11.430+00:00",
+                            "type": "controller",
+                            "version": "6.1(2.115a)"
+                        }
+                    }
+                },
+                {
+                    "firmwareCtrlrRunning": {
+                        "attributes": {
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "topology/pod-1/node-3/sys/ctrlrfwstatuscont/ctrlrrunning",
+                            "internalLabel": "a779e8156387a65a437b28e719dd8bda5774da0e",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-17T17:49:53.268+00:00",
+                            "mode": "normal",
+                            "status": "",
+                            "tpmInUse": "no",
+                            "ts": "2025-02-17T17:49:33.904+00:00",
+                            "type": "controller",
+                            "version": "6.1(2.115a)"
+                        }
+                    }
+                },
+                {
+                    "firmwareCtrlrRunning": {
+                        "attributes": {
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "topology/pod-1/node-2/sys/ctrlrfwstatuscont/ctrlrrunning",
+                            "internalLabel": "a779e8156387a65a437b28e719dd8bda5774da0e",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-17T17:22:48.096+00:00",
+                            "mode": "normal",
+                            "status": "",
+                            "tpmInUse": "no",
+                            "ts": "2025-02-17T17:22:28.809+00:00",
+                            "type": "controller",
+                            "version": "6.1(2.115a)"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/node/mo/uni/tn-kube.json?query-target=self": {
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvTenant": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-kube",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-03-06T12:13:01.770+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "akhila2",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/node/mo/uni/tn-common.json?query-target=subtree&target-subtree-class=tagAnnotation": {
+            "totalCount": "0",
+            "imdata": []
+        },
+        "/api/mo/uni/tn-kube.json":{
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvTenant": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-kube",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-02-27T14:43:21.255+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "kube",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/mo/uni/tn-common/out-l3out.json":{
+            "totalCount": "0",
+            "imdata": []
+        },
+        "/api/mo/uni/tn-common/ctx-kube-vrf.json":{
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "fvCtx": {
+                        "attributes": {
+                            "annotation": "orchestrator:terraform",
+                            "bdEnforcedEnable": "no",
+                            "childAction": "",
+                            "descr": "",
+                            "dn": "uni/tn-common/ctx-kube-vrf",
+                            "extMngdBy": "",
+                            "ipDataPlaneLearning": "enabled",
+                            "knwMcastAct": "permit",
+                            "lcOwn": "local",
+                            "modTs": "2024-06-19T08:18:21.128+00:00",
+                            "monPolDn": "uni/tn-common/monepg-default",
+                            "name": "kube-vrf",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "pcEnfDir": "ingress",
+                            "pcEnfDirUpdated": "yes",
+                            "pcEnfPref": "enforced",
+                            "pcTag": "49153",
+                            "scope": "3047424",
+                            "seg": "3047424",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:",
+                            "vrfId": "0",
+                            "vrfIndex": "0"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/mo/uni/infra/attentp-kube-aep.json":{
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "infraAttEntityP": {
+                        "attributes": {
+                            "annotation": "orchestrator:aci-containers-controller",
+                            "childAction": "",
+                            "configIssues": "",
+                            "creator": "USER",
+                            "descr": "",
+                            "dn": "uni/infra/attentp-kube-aep",
+                            "extMngdBy": "",
+                            "lcOwn": "local",
+                            "modTs": "2024-11-28T15:31:07.043+00:00",
+                            "monPolDn": "uni/fabric/monfab-default",
+                            "name": "kube-aep",
+                            "nameAlias": "",
+                            "ownerKey": "",
+                            "ownerTag": "",
+                            "status": "",
+                            "uid": "15374",
+                            "userdom": ":all:"
+                        }
+                    }
+                }
+            ]
+        },
+        "/api/node/mo/uni/infra/attentp-default/provacc/rsfuncToEpg-%5Buni/tn-infra/ap-access/epg-default%5D.json":{
+            "totalCount": "1",
+            "imdata": [
+                {
+                    "infraRsFuncToEpg": {
+                        "attributes": {
+                            "annotation": "",
+                            "childAction": "",
+                            "dn": "uni/infra/attentp-default/provacc/rsfuncToEpg-[uni/tn-infra/ap-access/epg-default]",
+                            "encap": "vlan-3301",
+                            "extMngdBy": "",
+                            "forceResolve": "yes",
+                            "instrImedcy": "lazy",
+                            "lcOwn": "local",
+                            "modTs": "2023-02-18T12:54:47.637+00:00",
+                            "mode": "regular",
+                            "monPolDn": "uni/fabric/monfab-default",
+                            "primaryEncap": "unknown",
+                            "rType": "mo",
+                            "state": "formed",
+                            "stateQual": "none",
+                            "status": "",
+                            "tCl": "fvAEPg",
+                            "tDn": "uni/tn-infra/ap-access/epg-default",
+                            "tType": "mo",
+                            "uid": "0",
+                            "userdom": "all"
+                        }
+                    }
+                }
+            ]
+        }
+
+    },
+    "deletes":[
+        "/api/mo/uni/infra/vlanns-[kube-pool]-static.json" ,
+        "/api/mo/uni/infra/maddrns-kube-mpool.json",
+        "/api/mo/uni/vmmp-Kubernetes/dom-kube.json",
+        "/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/vmmp-Kubernetes/dom-kube].json",
+        "/api/mo/uni/infra/attentp-kube-aep/rsdomP-[uni/phys-kube-pdom].json",
+        "/api/mo/uni/infra/attentp-kube-aep/gen-default/rsfuncToEpg-[uni/tn-kube/ap-aci-containers-kube/epg-aci-containers-nodes].json",
+        "/api/mo/uni/tn-common/flt-kube-allow-all-filter.json",
+        "/api/mo/uni/tn-common/brc-kube-l3out-allow-all.json",   
+        "/api/node/mo/uni/userext/user-kube.json", 
+        "/api/node/mo/uni/userext/user-kube.json",             
+        "/api/node/mo/uni/tn-kube/BD-aci-containers-kube-node-bd.json",
+        "/api/node/mo/uni/tn-kube/BD-aci-containers-kube-pod-bd.json",
+        "/api/mo/uni/tn-kube/ap-aci-containers-kube/epg-aci-containers-nodes.json",
+        "/api/mo/uni/tn-kube.json",
+        "/api/mo/uni/tn-common/out-l3out/instP-test_ext_net/rsprov-kube-l3out-allow-all.json",
+        "/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-kube-l3out-allow-all.json" ,
+        "/api/mo/uni/phys-kube-pdom.json" ,
+        "/api/node/mo/uni/tn-kube/flt-aci-containers-kube-istio-filter.json" ,
+        "/api/node/mo/uni/tn-kube/brc-aci-containers-kube-icmp.json" ,
+        "/api/node/mo/comp/prov-Kubernetes/ctrlr-[kube]-kube/injcont/info.json",
+        "/api/node/mo/uni/tn-kube/ap-aci-containers-kube.json"
+       
+        
+    ] 
+}


### PR DESCRIPTION
- Ensure deletion of APs and EPGs created by acc-provision for a specific system-id.
- Validate that APs and EPGs are deleted based on matching system-id and annotation.