### PR TITLE
Fix: Prevent stale APIC objects on deletion

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -3228,6 +3228,7 @@ def provision(args, apic_file, no_random):
     if 'aci_config' in user_config and 'use_legacy_kube_naming_convention' in user_config['aci_config'] and 'tenant' in user_config['aci_config']:
         err("Not allowed to set tenant and use_legacy_kube_naming_convention fields at the same time")
         return False
+    system_id = user_config["aci_config"]["system_id"]
 
     if flavor == "cloud" and 'use_legacy_kube_naming_convention' in user_config['aci_config']:
         err("use_legacy_kube_naming_convention not allowed in cloud flavor")
@@ -3259,6 +3260,9 @@ def provision(args, apic_file, no_random):
         info("Using configuration flavor " + flavor)
         deep_merge(config, {"flavor": flavor})
         if "config" in FLAVORS[flavor]:
+            if "items" in FLAVORS[flavor]["config"].get("aci_config", ""):
+                for item in FLAVORS[flavor]["config"]["aci_config"]["items"]:
+                    item['name'] = f"{Apic.ACI_PREFIX}{system_id}-{item['name']}"
             deep_merge(config, FLAVORS[flavor]["config"])
         if "default_version" in FLAVORS[flavor]:
             deep_merge(config, {

--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -163,7 +163,7 @@ class Apic(object):
         return resp
     
     def is_system_id_matching(self, system_id, resource_name):
-        contains_match_pattern = rf".*-\b{system_id}\b-.*"
+        contains_match_pattern = rf".*-\b{system_id}\d*-.*"
         ends_with_pattern = rf".*-\b{system_id}\b$"
         if(re.match(contains_match_pattern, resource_name) or re.match(ends_with_pattern, resource_name)):
             return True


### PR DESCRIPTION
Stale APIC resources, particularly contracts (`brc-`) specific to OpenShift flavors, were not being removed during unprovisioning.

This issue was most apparent when multiple OCP clusters shared a pre-existing tenant, as the flavor-defined resources were created without a unique, cluster-specific prefix, making them impossible to distinguish and safely delete.

This commit fixes the issue by prefixing these OpenShift resources with `ocp-{system_id}-` during provisioning, ensuring they are uniquely identifiable.

As a secondary improvement, the name-matching regex was also updated to robustly handle system_ids with appended digits.