### PR TITLE
[mmr-6.1.1] Fix: Prevent stale APIC objects on deletion

### DIFF
--- a/provision/testdata/flavor_RKE2_kubernetes_1_24.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_24.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke2-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke2-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke2-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke2-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE2_kubernetes_1_25.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_25.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke2-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke2-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke2-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke2-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE2_kubernetes_1_26.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_26.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke2-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke2-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke2-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke2-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE2_kubernetes_1_27.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_27.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke2-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke2-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke2-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke2-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE2_kubernetes_1_28.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_28.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke2-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke2-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke2-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke2-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE2_kubernetes_1_29.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_29.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke2-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke2-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke2-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke2-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE2_kubernetes_1_30.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_30.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke2-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke2-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke2-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke2-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE2_kubernetes_1_31.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_31.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke2-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke2-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke2-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke2-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE2_kubernetes_1_32.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_32.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke2-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke2-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke2-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke2-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE2_kubernetes_1_33.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_33.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke2-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke2-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke2-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke2-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_2_3.apic.txt
+++ b/provision/testdata/flavor_RKE_1_2_3.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_3_13.apic.txt
+++ b/provision/testdata/flavor_RKE_1_3_13.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_3_17.apic.txt
+++ b/provision/testdata/flavor_RKE_1_3_17.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_3_18.apic.txt
+++ b/provision/testdata/flavor_RKE_1_3_18.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_3_20.apic.txt
+++ b/provision/testdata/flavor_RKE_1_3_20.apic.txt
@@ -829,7 +829,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -843,7 +843,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -857,7 +857,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -871,7 +871,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_3_21.apic.txt
+++ b/provision/testdata/flavor_RKE_1_3_21.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_3_24.apic.txt
+++ b/provision/testdata/flavor_RKE_1_3_24.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_4_13.apic.txt
+++ b/provision/testdata/flavor_RKE_1_4_13.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_4_16.apic.txt
+++ b/provision/testdata/flavor_RKE_1_4_16.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_4_20.apic.txt
+++ b/provision/testdata/flavor_RKE_1_4_20.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_4_6.apic.txt
+++ b/provision/testdata/flavor_RKE_1_4_6.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_4_9.apic.txt
+++ b/provision/testdata/flavor_RKE_1_4_9.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_5_11.apic.txt
+++ b/provision/testdata/flavor_RKE_1_5_11.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_5_13.apic.txt
+++ b/provision/testdata/flavor_RKE_1_5_13.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_5_14.apic.txt
+++ b/provision/testdata/flavor_RKE_1_5_14.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_5_3.apic.txt
+++ b/provision/testdata/flavor_RKE_1_5_3.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_5_6.apic.txt
+++ b/provision/testdata/flavor_RKE_1_5_6.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_6_0.apic.txt
+++ b/provision/testdata/flavor_RKE_1_6_0.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_6_10.apic.txt
+++ b/provision/testdata/flavor_RKE_1_6_10.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_6_2.apic.txt
+++ b/provision/testdata/flavor_RKE_1_6_2.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_6_3.apic.txt
+++ b/provision/testdata/flavor_RKE_1_6_3.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_6_5.apic.txt
+++ b/provision/testdata/flavor_RKE_1_6_5.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_6_6.apic.txt
+++ b/provision/testdata/flavor_RKE_1_6_6.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_7_1.apic.txt
+++ b/provision/testdata/flavor_RKE_1_7_1.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_7_2.apic.txt
+++ b/provision/testdata/flavor_RKE_1_7_2.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_7_7.apic.txt
+++ b/provision/testdata/flavor_RKE_1_7_7.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_RKE_1_8_3.apic.txt
+++ b/provision/testdata/flavor_RKE_1_8_3.apic.txt
@@ -846,7 +846,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metrics-kubelet",
+                                    "name": "aci-containers-rke-metrics-kubelet",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -860,7 +860,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-node",
+                                    "name": "aci-containers-rke-monitoring-node",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9796",
@@ -874,7 +874,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "monitoring-ingress",
+                                    "name": "aci-containers-rke-monitoring-ingress",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10254",
@@ -888,7 +888,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "rancher-ui",
+                                    "name": "aci-containers-rke-rancher-ui",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",

--- a/provision/testdata/flavor_dockerucp.apic.txt
+++ b/provision/testdata/flavor_dockerucp.apic.txt
@@ -897,7 +897,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "ucp-ui-port",
+                                    "name": "aci-containers-kube-ucp-ui-port",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",
@@ -911,7 +911,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "ucp-tls-port",
+                                    "name": "aci-containers-kube-ucp-tls-port",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "12376",
@@ -925,7 +925,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "ucp-kubelet-port",
+                                    "name": "aci-containers-kube-ucp-kubelet-port",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -939,7 +939,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "ucp-misc-ports",
+                                    "name": "aci-containers-kube-ucp-misc-ports",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "12378",

--- a/provision/testdata/flavor_openshift_310.apic.txt
+++ b/provision/testdata/flavor_openshift_310.apic.txt
@@ -322,7 +322,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -330,7 +330,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -436,7 +436,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -444,7 +444,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -551,7 +551,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -559,7 +559,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -707,7 +707,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -715,7 +715,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -797,7 +797,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -805,7 +805,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1295,14 +1295,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1311,7 +1311,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1325,14 +1325,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1341,7 +1341,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1355,14 +1355,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1379,14 +1379,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1400,7 +1400,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",

--- a/provision/testdata/flavor_openshift_311.apic.txt
+++ b/provision/testdata/flavor_openshift_311.apic.txt
@@ -322,7 +322,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -330,7 +330,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -436,7 +436,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -444,7 +444,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -551,7 +551,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -559,7 +559,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -707,7 +707,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -715,7 +715,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -797,7 +797,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -805,7 +805,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1295,14 +1295,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1311,7 +1311,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1325,14 +1325,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1341,7 +1341,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1355,14 +1355,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1379,14 +1379,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1400,7 +1400,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",

--- a/provision/testdata/flavor_openshift_410_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_410_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -755,7 +755,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -861,7 +861,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1473,14 +1473,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1489,7 +1489,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1503,14 +1503,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1519,7 +1519,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1533,14 +1533,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1557,14 +1557,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1788,7 +1788,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1802,7 +1802,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1816,7 +1816,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1830,7 +1830,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_410_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_410_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1320,14 +1320,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1336,7 +1336,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1350,14 +1350,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1366,7 +1366,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1380,14 +1380,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1404,14 +1404,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1425,7 +1425,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1439,7 +1439,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1453,7 +1453,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1467,7 +1467,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1481,7 +1481,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1495,7 +1495,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1509,7 +1509,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1523,7 +1523,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1537,7 +1537,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1551,7 +1551,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1565,7 +1565,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1579,7 +1579,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1593,7 +1593,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1607,7 +1607,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1621,7 +1621,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1635,7 +1635,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1649,7 +1649,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1663,7 +1663,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1677,7 +1677,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_410_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_410_esx_vDS_6_6_above.apic.txt
@@ -415,7 +415,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -423,7 +423,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -529,7 +529,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -537,7 +537,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -545,7 +545,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -635,7 +635,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -643,7 +643,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1329,14 +1329,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1345,7 +1345,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1359,14 +1359,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1375,7 +1375,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1389,14 +1389,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1413,14 +1413,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1434,7 +1434,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1448,7 +1448,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1462,7 +1462,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1476,7 +1476,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1490,7 +1490,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1504,7 +1504,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1518,7 +1518,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1532,7 +1532,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1546,7 +1546,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1560,7 +1560,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1574,7 +1574,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1588,7 +1588,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1602,7 +1602,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1616,7 +1616,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1630,7 +1630,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1644,7 +1644,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1658,7 +1658,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1672,7 +1672,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1686,7 +1686,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_410_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_410_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -716,7 +716,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -822,7 +822,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1425,14 +1425,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1441,7 +1441,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1455,14 +1455,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1471,7 +1471,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1485,14 +1485,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1509,14 +1509,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1530,7 +1530,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1544,7 +1544,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1558,7 +1558,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1572,7 +1572,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1586,7 +1586,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1600,7 +1600,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1614,7 +1614,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1628,7 +1628,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1642,7 +1642,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1656,7 +1656,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1670,7 +1670,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1684,7 +1684,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1698,7 +1698,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1712,7 +1712,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1726,7 +1726,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1740,7 +1740,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1754,7 +1754,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1768,7 +1768,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1782,7 +1782,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_411_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_411_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -755,7 +755,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -861,7 +861,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1473,14 +1473,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1489,7 +1489,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1503,14 +1503,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1519,7 +1519,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1533,14 +1533,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1557,14 +1557,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1788,7 +1788,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1802,7 +1802,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1816,7 +1816,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1830,7 +1830,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_411_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_411_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1320,14 +1320,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1336,7 +1336,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1350,14 +1350,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1366,7 +1366,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1380,14 +1380,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1404,14 +1404,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1425,7 +1425,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1439,7 +1439,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1453,7 +1453,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1467,7 +1467,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1481,7 +1481,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1495,7 +1495,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1509,7 +1509,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1523,7 +1523,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1537,7 +1537,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1551,7 +1551,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1565,7 +1565,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1579,7 +1579,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1593,7 +1593,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1607,7 +1607,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1621,7 +1621,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1635,7 +1635,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1649,7 +1649,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1663,7 +1663,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1677,7 +1677,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_411_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_411_esx_vDS_6_6_above.apic.txt
@@ -415,7 +415,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -423,7 +423,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -529,7 +529,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -537,7 +537,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -545,7 +545,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -635,7 +635,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -643,7 +643,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1329,14 +1329,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1345,7 +1345,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1359,14 +1359,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1375,7 +1375,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1389,14 +1389,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1413,14 +1413,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1434,7 +1434,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1448,7 +1448,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1462,7 +1462,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1476,7 +1476,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1490,7 +1490,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1504,7 +1504,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1518,7 +1518,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1532,7 +1532,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1546,7 +1546,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1560,7 +1560,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1574,7 +1574,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1588,7 +1588,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1602,7 +1602,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1616,7 +1616,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1630,7 +1630,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1644,7 +1644,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1658,7 +1658,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1672,7 +1672,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1686,7 +1686,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_411_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_411_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -716,7 +716,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -822,7 +822,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1425,14 +1425,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1441,7 +1441,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1455,14 +1455,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1471,7 +1471,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1485,14 +1485,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1509,14 +1509,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1530,7 +1530,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1544,7 +1544,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1558,7 +1558,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1572,7 +1572,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1586,7 +1586,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1600,7 +1600,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1614,7 +1614,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1628,7 +1628,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1642,7 +1642,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1656,7 +1656,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1670,7 +1670,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1684,7 +1684,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1698,7 +1698,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1712,7 +1712,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1726,7 +1726,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1740,7 +1740,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1754,7 +1754,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1768,7 +1768,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1782,7 +1782,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_412_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_412_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -755,7 +755,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -861,7 +861,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1473,14 +1473,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1489,7 +1489,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1503,14 +1503,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1519,7 +1519,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1533,14 +1533,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1557,14 +1557,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1788,7 +1788,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1802,7 +1802,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1816,7 +1816,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1830,7 +1830,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_412_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_412_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1320,14 +1320,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1336,7 +1336,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1350,14 +1350,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1366,7 +1366,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1380,14 +1380,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1404,14 +1404,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1425,7 +1425,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1439,7 +1439,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1453,7 +1453,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1467,7 +1467,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1481,7 +1481,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1495,7 +1495,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1509,7 +1509,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1523,7 +1523,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1537,7 +1537,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1551,7 +1551,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1565,7 +1565,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1579,7 +1579,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1593,7 +1593,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1607,7 +1607,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1621,7 +1621,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1635,7 +1635,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1649,7 +1649,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1663,7 +1663,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1677,7 +1677,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_412_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_412_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -716,7 +716,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -822,7 +822,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1425,14 +1425,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1441,7 +1441,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1455,14 +1455,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1471,7 +1471,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1485,14 +1485,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1509,14 +1509,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1530,7 +1530,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1544,7 +1544,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1558,7 +1558,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1572,7 +1572,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1586,7 +1586,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1600,7 +1600,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1614,7 +1614,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1628,7 +1628,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1642,7 +1642,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1656,7 +1656,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1670,7 +1670,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1684,7 +1684,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1698,7 +1698,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1712,7 +1712,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1726,7 +1726,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1740,7 +1740,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1754,7 +1754,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1768,7 +1768,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1782,7 +1782,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_413_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_413_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -755,7 +755,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -861,7 +861,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1473,14 +1473,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1489,7 +1489,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1503,14 +1503,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1519,7 +1519,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1533,14 +1533,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1557,14 +1557,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1788,7 +1788,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1802,7 +1802,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1816,7 +1816,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1830,7 +1830,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_413_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_413_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1320,14 +1320,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1336,7 +1336,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1350,14 +1350,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1366,7 +1366,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1380,14 +1380,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1404,14 +1404,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1425,7 +1425,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1439,7 +1439,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1453,7 +1453,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1467,7 +1467,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1481,7 +1481,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1495,7 +1495,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1509,7 +1509,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1523,7 +1523,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1537,7 +1537,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1551,7 +1551,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1565,7 +1565,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1579,7 +1579,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1593,7 +1593,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1607,7 +1607,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1621,7 +1621,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1635,7 +1635,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1649,7 +1649,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1663,7 +1663,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1677,7 +1677,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_413_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_413_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -716,7 +716,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -822,7 +822,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1425,14 +1425,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1441,7 +1441,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1455,14 +1455,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1471,7 +1471,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1485,14 +1485,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1509,14 +1509,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1530,7 +1530,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1544,7 +1544,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1558,7 +1558,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1572,7 +1572,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1586,7 +1586,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1600,7 +1600,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1614,7 +1614,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1628,7 +1628,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1642,7 +1642,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1656,7 +1656,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1670,7 +1670,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1684,7 +1684,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1698,7 +1698,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1712,7 +1712,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1726,7 +1726,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1740,7 +1740,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1754,7 +1754,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1768,7 +1768,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1782,7 +1782,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_414_aci_cilium_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_414_aci_cilium_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -642,7 +642,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1336,14 +1336,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1352,7 +1352,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1366,14 +1366,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1382,7 +1382,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1396,14 +1396,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1420,14 +1420,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1441,7 +1441,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1455,7 +1455,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1469,7 +1469,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1483,7 +1483,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1497,7 +1497,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1511,7 +1511,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1525,7 +1525,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1539,7 +1539,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1553,7 +1553,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1567,7 +1567,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1581,7 +1581,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1595,7 +1595,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1609,7 +1609,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1623,7 +1623,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1637,7 +1637,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1651,7 +1651,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1665,7 +1665,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1679,7 +1679,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1693,7 +1693,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_414_agent_based_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_414_agent_based_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -354,7 +354,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -362,7 +362,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -476,7 +476,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -484,7 +484,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -492,7 +492,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -500,7 +500,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -599,7 +599,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -607,7 +607,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -615,7 +615,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -623,7 +623,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -795,7 +795,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -803,7 +803,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -811,7 +811,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -819,7 +819,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -917,7 +917,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -925,7 +925,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -933,7 +933,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -941,7 +941,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1553,14 +1553,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1569,7 +1569,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1583,14 +1583,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1599,7 +1599,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1613,14 +1613,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "metal3-provisioning",
+                        "name": "aci-containers-kube-metal3-provisioning",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-subj",
+                                    "name": "aci-containers-kube-metal3-provisioning-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1629,7 +1629,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "metal3-provisioning-filter",
+                                                "tnVzFilterName": "aci-containers-kube-metal3-provisioning-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1643,14 +1643,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1667,14 +1667,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1688,7 +1688,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1702,7 +1702,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1716,7 +1716,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1730,7 +1730,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1744,7 +1744,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1758,7 +1758,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1772,7 +1772,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1786,7 +1786,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1800,7 +1800,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1814,7 +1814,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1828,7 +1828,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1842,7 +1842,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9102",
+                                    "name": "aci-containers-kube-openshift-monitoring-9102",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9102",
@@ -1856,7 +1856,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9104",
+                                    "name": "aci-containers-kube-openshift-monitoring-9104",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9104",
@@ -1870,7 +1870,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1884,7 +1884,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1898,7 +1898,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1912,7 +1912,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1926,7 +1926,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1940,7 +1940,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1954,7 +1954,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1968,7 +1968,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",
@@ -1985,14 +1985,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "metal3-provisioning-filter",
+                        "name": "aci-containers-kube-metal3-provisioning-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-4343",
+                                    "name": "aci-containers-kube-metal3-provisioning-4343",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "4343",
@@ -2006,7 +2006,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5050",
+                                    "name": "aci-containers-kube-metal3-provisioning-5050",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5050",
@@ -2020,7 +2020,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5051",
+                                    "name": "aci-containers-kube-metal3-provisioning-5051",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5051",
@@ -2034,7 +2034,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6180",
+                                    "name": "aci-containers-kube-metal3-provisioning-6180",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6180",
@@ -2048,7 +2048,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6183",
+                                    "name": "aci-containers-kube-metal3-provisioning-6183",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6183",
@@ -2062,7 +2062,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6385",
+                                    "name": "aci-containers-kube-metal3-provisioning-6385",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6385",
@@ -2076,7 +2076,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6388",
+                                    "name": "aci-containers-kube-metal3-provisioning-6388",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6388",
@@ -2090,7 +2090,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-9443",
+                                    "name": "aci-containers-kube-metal3-provisioning-9443",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9443",

--- a/provision/testdata/flavor_openshift_414_agent_based_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_414_agent_based_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -544,7 +544,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -552,7 +552,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -560,7 +560,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -568,7 +568,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -658,7 +658,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -666,7 +666,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -674,7 +674,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -682,7 +682,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1368,14 +1368,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1384,7 +1384,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1398,14 +1398,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1414,7 +1414,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1428,14 +1428,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "metal3-provisioning",
+                        "name": "aci-containers-kube-metal3-provisioning",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-subj",
+                                    "name": "aci-containers-kube-metal3-provisioning-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1444,7 +1444,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "metal3-provisioning-filter",
+                                                "tnVzFilterName": "aci-containers-kube-metal3-provisioning-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1458,14 +1458,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1482,14 +1482,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1503,7 +1503,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1517,7 +1517,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1531,7 +1531,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1545,7 +1545,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1559,7 +1559,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1573,7 +1573,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1587,7 +1587,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1601,7 +1601,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1615,7 +1615,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1629,7 +1629,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1643,7 +1643,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1657,7 +1657,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9102",
+                                    "name": "aci-containers-kube-openshift-monitoring-9102",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9102",
@@ -1671,7 +1671,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9104",
+                                    "name": "aci-containers-kube-openshift-monitoring-9104",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9104",
@@ -1685,7 +1685,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1699,7 +1699,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1713,7 +1713,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1727,7 +1727,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1741,7 +1741,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1755,7 +1755,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1769,7 +1769,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1783,7 +1783,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",
@@ -1800,14 +1800,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "metal3-provisioning-filter",
+                        "name": "aci-containers-kube-metal3-provisioning-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-4343",
+                                    "name": "aci-containers-kube-metal3-provisioning-4343",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "4343",
@@ -1821,7 +1821,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5050",
+                                    "name": "aci-containers-kube-metal3-provisioning-5050",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5050",
@@ -1835,7 +1835,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5051",
+                                    "name": "aci-containers-kube-metal3-provisioning-5051",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5051",
@@ -1849,7 +1849,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6180",
+                                    "name": "aci-containers-kube-metal3-provisioning-6180",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6180",
@@ -1863,7 +1863,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6183",
+                                    "name": "aci-containers-kube-metal3-provisioning-6183",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6183",
@@ -1877,7 +1877,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6385",
+                                    "name": "aci-containers-kube-metal3-provisioning-6385",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6385",
@@ -1891,7 +1891,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6388",
+                                    "name": "aci-containers-kube-metal3-provisioning-6388",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6388",
@@ -1905,7 +1905,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-9443",
+                                    "name": "aci-containers-kube-metal3-provisioning-9443",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9443",

--- a/provision/testdata/flavor_openshift_414_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_414_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -755,7 +755,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -861,7 +861,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1473,14 +1473,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1489,7 +1489,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1503,14 +1503,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1519,7 +1519,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1533,14 +1533,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1557,14 +1557,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1788,7 +1788,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1802,7 +1802,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1816,7 +1816,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1830,7 +1830,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_414_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_414_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1320,14 +1320,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1336,7 +1336,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1350,14 +1350,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1366,7 +1366,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1380,14 +1380,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1404,14 +1404,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1425,7 +1425,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1439,7 +1439,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1453,7 +1453,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1467,7 +1467,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1481,7 +1481,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1495,7 +1495,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1509,7 +1509,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1523,7 +1523,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1537,7 +1537,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1551,7 +1551,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1565,7 +1565,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1579,7 +1579,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1593,7 +1593,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1607,7 +1607,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1621,7 +1621,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1635,7 +1635,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1649,7 +1649,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1663,7 +1663,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1677,7 +1677,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_414_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_414_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -716,7 +716,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -822,7 +822,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1425,14 +1425,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1441,7 +1441,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1455,14 +1455,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1471,7 +1471,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1485,14 +1485,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1509,14 +1509,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1530,7 +1530,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1544,7 +1544,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1558,7 +1558,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1572,7 +1572,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1586,7 +1586,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1600,7 +1600,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1614,7 +1614,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1628,7 +1628,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1642,7 +1642,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1656,7 +1656,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1670,7 +1670,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1684,7 +1684,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1698,7 +1698,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1712,7 +1712,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1726,7 +1726,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1740,7 +1740,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1754,7 +1754,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1768,7 +1768,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1782,7 +1782,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_415_agent_based_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_415_agent_based_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -354,7 +354,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -362,7 +362,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -476,7 +476,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -484,7 +484,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -492,7 +492,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -500,7 +500,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -599,7 +599,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -607,7 +607,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -615,7 +615,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -623,7 +623,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -795,7 +795,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -803,7 +803,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -811,7 +811,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -819,7 +819,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -917,7 +917,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -925,7 +925,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -933,7 +933,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -941,7 +941,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1553,14 +1553,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1569,7 +1569,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1583,14 +1583,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1599,7 +1599,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1613,14 +1613,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "metal3-provisioning",
+                        "name": "aci-containers-kube-metal3-provisioning",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-subj",
+                                    "name": "aci-containers-kube-metal3-provisioning-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1629,7 +1629,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "metal3-provisioning-filter",
+                                                "tnVzFilterName": "aci-containers-kube-metal3-provisioning-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1643,14 +1643,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1667,14 +1667,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1688,7 +1688,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1702,7 +1702,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1716,7 +1716,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1730,7 +1730,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1744,7 +1744,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1758,7 +1758,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1772,7 +1772,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1786,7 +1786,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1800,7 +1800,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1814,7 +1814,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1828,7 +1828,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1842,7 +1842,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9102",
+                                    "name": "aci-containers-kube-openshift-monitoring-9102",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9102",
@@ -1856,7 +1856,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9104",
+                                    "name": "aci-containers-kube-openshift-monitoring-9104",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9104",
@@ -1870,7 +1870,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1884,7 +1884,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1898,7 +1898,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1912,7 +1912,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1926,7 +1926,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1940,7 +1940,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1954,7 +1954,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1968,7 +1968,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",
@@ -1985,14 +1985,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "metal3-provisioning-filter",
+                        "name": "aci-containers-kube-metal3-provisioning-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-4343",
+                                    "name": "aci-containers-kube-metal3-provisioning-4343",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "4343",
@@ -2006,7 +2006,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5050",
+                                    "name": "aci-containers-kube-metal3-provisioning-5050",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5050",
@@ -2020,7 +2020,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5051",
+                                    "name": "aci-containers-kube-metal3-provisioning-5051",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5051",
@@ -2034,7 +2034,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6180",
+                                    "name": "aci-containers-kube-metal3-provisioning-6180",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6180",
@@ -2048,7 +2048,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6183",
+                                    "name": "aci-containers-kube-metal3-provisioning-6183",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6183",
@@ -2062,7 +2062,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6385",
+                                    "name": "aci-containers-kube-metal3-provisioning-6385",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6385",
@@ -2076,7 +2076,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6388",
+                                    "name": "aci-containers-kube-metal3-provisioning-6388",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6388",
@@ -2090,7 +2090,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-9443",
+                                    "name": "aci-containers-kube-metal3-provisioning-9443",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9443",

--- a/provision/testdata/flavor_openshift_415_agent_based_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_415_agent_based_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -544,7 +544,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -552,7 +552,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -560,7 +560,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -568,7 +568,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -658,7 +658,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -666,7 +666,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -674,7 +674,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -682,7 +682,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1368,14 +1368,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1384,7 +1384,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1398,14 +1398,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1414,7 +1414,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1428,14 +1428,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "metal3-provisioning",
+                        "name": "aci-containers-kube-metal3-provisioning",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-subj",
+                                    "name": "aci-containers-kube-metal3-provisioning-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1444,7 +1444,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "metal3-provisioning-filter",
+                                                "tnVzFilterName": "aci-containers-kube-metal3-provisioning-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1458,14 +1458,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1482,14 +1482,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1503,7 +1503,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1517,7 +1517,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1531,7 +1531,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1545,7 +1545,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1559,7 +1559,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1573,7 +1573,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1587,7 +1587,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1601,7 +1601,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1615,7 +1615,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1629,7 +1629,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1643,7 +1643,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1657,7 +1657,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9102",
+                                    "name": "aci-containers-kube-openshift-monitoring-9102",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9102",
@@ -1671,7 +1671,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9104",
+                                    "name": "aci-containers-kube-openshift-monitoring-9104",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9104",
@@ -1685,7 +1685,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1699,7 +1699,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1713,7 +1713,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1727,7 +1727,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1741,7 +1741,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1755,7 +1755,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1769,7 +1769,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1783,7 +1783,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",
@@ -1800,14 +1800,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "metal3-provisioning-filter",
+                        "name": "aci-containers-kube-metal3-provisioning-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-4343",
+                                    "name": "aci-containers-kube-metal3-provisioning-4343",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "4343",
@@ -1821,7 +1821,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5050",
+                                    "name": "aci-containers-kube-metal3-provisioning-5050",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5050",
@@ -1835,7 +1835,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5051",
+                                    "name": "aci-containers-kube-metal3-provisioning-5051",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5051",
@@ -1849,7 +1849,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6180",
+                                    "name": "aci-containers-kube-metal3-provisioning-6180",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6180",
@@ -1863,7 +1863,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6183",
+                                    "name": "aci-containers-kube-metal3-provisioning-6183",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6183",
@@ -1877,7 +1877,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6385",
+                                    "name": "aci-containers-kube-metal3-provisioning-6385",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6385",
@@ -1891,7 +1891,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6388",
+                                    "name": "aci-containers-kube-metal3-provisioning-6388",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6388",
@@ -1905,7 +1905,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-9443",
+                                    "name": "aci-containers-kube-metal3-provisioning-9443",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9443",

--- a/provision/testdata/flavor_openshift_415_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_415_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -755,7 +755,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -861,7 +861,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1473,14 +1473,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1489,7 +1489,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1503,14 +1503,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1519,7 +1519,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1533,14 +1533,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1557,14 +1557,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1788,7 +1788,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1802,7 +1802,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1816,7 +1816,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1830,7 +1830,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_415_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_415_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1320,14 +1320,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1336,7 +1336,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1350,14 +1350,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1366,7 +1366,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1380,14 +1380,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1404,14 +1404,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1425,7 +1425,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1439,7 +1439,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1453,7 +1453,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1467,7 +1467,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1481,7 +1481,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1495,7 +1495,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1509,7 +1509,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1523,7 +1523,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1537,7 +1537,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1551,7 +1551,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1565,7 +1565,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1579,7 +1579,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1593,7 +1593,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1607,7 +1607,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1621,7 +1621,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1635,7 +1635,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1649,7 +1649,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1663,7 +1663,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1677,7 +1677,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_415_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_415_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -716,7 +716,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -822,7 +822,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1425,14 +1425,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1441,7 +1441,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1455,14 +1455,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1471,7 +1471,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1485,14 +1485,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1509,14 +1509,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1530,7 +1530,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1544,7 +1544,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1558,7 +1558,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1572,7 +1572,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1586,7 +1586,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1600,7 +1600,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1614,7 +1614,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1628,7 +1628,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1642,7 +1642,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1656,7 +1656,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1670,7 +1670,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1684,7 +1684,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1698,7 +1698,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1712,7 +1712,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1726,7 +1726,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1740,7 +1740,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1754,7 +1754,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1768,7 +1768,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1782,7 +1782,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_416_agent_based_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_416_agent_based_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -354,7 +354,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -362,7 +362,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -476,7 +476,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -484,7 +484,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -492,7 +492,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -500,7 +500,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -599,7 +599,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -607,7 +607,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -615,7 +615,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -623,7 +623,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -795,7 +795,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -803,7 +803,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -811,7 +811,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -819,7 +819,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -917,7 +917,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -925,7 +925,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -933,7 +933,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -941,7 +941,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1553,14 +1553,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1569,7 +1569,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1583,14 +1583,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1599,7 +1599,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1613,14 +1613,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "metal3-provisioning",
+                        "name": "aci-containers-kube-metal3-provisioning",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-subj",
+                                    "name": "aci-containers-kube-metal3-provisioning-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1629,7 +1629,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "metal3-provisioning-filter",
+                                                "tnVzFilterName": "aci-containers-kube-metal3-provisioning-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1643,14 +1643,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1667,14 +1667,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1688,7 +1688,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1702,7 +1702,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1716,7 +1716,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1730,7 +1730,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1744,7 +1744,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1758,7 +1758,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1772,7 +1772,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1786,7 +1786,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1800,7 +1800,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1814,7 +1814,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1828,7 +1828,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1842,7 +1842,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9102",
+                                    "name": "aci-containers-kube-openshift-monitoring-9102",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9102",
@@ -1856,7 +1856,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9104",
+                                    "name": "aci-containers-kube-openshift-monitoring-9104",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9104",
@@ -1870,7 +1870,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1884,7 +1884,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1898,7 +1898,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1912,7 +1912,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1926,7 +1926,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1940,7 +1940,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1954,7 +1954,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1968,7 +1968,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",
@@ -1985,14 +1985,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "metal3-provisioning-filter",
+                        "name": "aci-containers-kube-metal3-provisioning-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-4343",
+                                    "name": "aci-containers-kube-metal3-provisioning-4343",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "4343",
@@ -2006,7 +2006,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5050",
+                                    "name": "aci-containers-kube-metal3-provisioning-5050",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5050",
@@ -2020,7 +2020,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5051",
+                                    "name": "aci-containers-kube-metal3-provisioning-5051",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5051",
@@ -2034,7 +2034,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6180",
+                                    "name": "aci-containers-kube-metal3-provisioning-6180",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6180",
@@ -2048,7 +2048,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6183",
+                                    "name": "aci-containers-kube-metal3-provisioning-6183",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6183",
@@ -2062,7 +2062,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6385",
+                                    "name": "aci-containers-kube-metal3-provisioning-6385",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6385",
@@ -2076,7 +2076,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6388",
+                                    "name": "aci-containers-kube-metal3-provisioning-6388",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6388",
@@ -2090,7 +2090,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-9443",
+                                    "name": "aci-containers-kube-metal3-provisioning-9443",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9443",

--- a/provision/testdata/flavor_openshift_416_agent_based_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_416_agent_based_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -544,7 +544,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -552,7 +552,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -560,7 +560,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -568,7 +568,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -658,7 +658,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -666,7 +666,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -674,7 +674,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -682,7 +682,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1368,14 +1368,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1384,7 +1384,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1398,14 +1398,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1414,7 +1414,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1428,14 +1428,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "metal3-provisioning",
+                        "name": "aci-containers-kube-metal3-provisioning",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-subj",
+                                    "name": "aci-containers-kube-metal3-provisioning-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1444,7 +1444,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "metal3-provisioning-filter",
+                                                "tnVzFilterName": "aci-containers-kube-metal3-provisioning-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1458,14 +1458,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1482,14 +1482,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1503,7 +1503,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1517,7 +1517,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1531,7 +1531,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1545,7 +1545,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1559,7 +1559,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1573,7 +1573,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1587,7 +1587,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1601,7 +1601,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1615,7 +1615,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1629,7 +1629,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1643,7 +1643,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1657,7 +1657,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9102",
+                                    "name": "aci-containers-kube-openshift-monitoring-9102",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9102",
@@ -1671,7 +1671,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9104",
+                                    "name": "aci-containers-kube-openshift-monitoring-9104",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9104",
@@ -1685,7 +1685,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1699,7 +1699,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1713,7 +1713,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1727,7 +1727,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1741,7 +1741,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1755,7 +1755,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1769,7 +1769,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1783,7 +1783,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",
@@ -1800,14 +1800,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "metal3-provisioning-filter",
+                        "name": "aci-containers-kube-metal3-provisioning-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-4343",
+                                    "name": "aci-containers-kube-metal3-provisioning-4343",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "4343",
@@ -1821,7 +1821,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5050",
+                                    "name": "aci-containers-kube-metal3-provisioning-5050",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5050",
@@ -1835,7 +1835,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5051",
+                                    "name": "aci-containers-kube-metal3-provisioning-5051",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5051",
@@ -1849,7 +1849,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6180",
+                                    "name": "aci-containers-kube-metal3-provisioning-6180",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6180",
@@ -1863,7 +1863,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6183",
+                                    "name": "aci-containers-kube-metal3-provisioning-6183",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6183",
@@ -1877,7 +1877,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6385",
+                                    "name": "aci-containers-kube-metal3-provisioning-6385",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6385",
@@ -1891,7 +1891,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6388",
+                                    "name": "aci-containers-kube-metal3-provisioning-6388",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6388",
@@ -1905,7 +1905,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-9443",
+                                    "name": "aci-containers-kube-metal3-provisioning-9443",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9443",

--- a/provision/testdata/flavor_openshift_416_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_416_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -755,7 +755,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -861,7 +861,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1473,14 +1473,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1489,7 +1489,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1503,14 +1503,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1519,7 +1519,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1533,14 +1533,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1557,14 +1557,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1788,7 +1788,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1802,7 +1802,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1816,7 +1816,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1830,7 +1830,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_416_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_416_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1320,14 +1320,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1336,7 +1336,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1350,14 +1350,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1366,7 +1366,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1380,14 +1380,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1404,14 +1404,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1425,7 +1425,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1439,7 +1439,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1453,7 +1453,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1467,7 +1467,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1481,7 +1481,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1495,7 +1495,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1509,7 +1509,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1523,7 +1523,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1537,7 +1537,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1551,7 +1551,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1565,7 +1565,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1579,7 +1579,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1593,7 +1593,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1607,7 +1607,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1621,7 +1621,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1635,7 +1635,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1649,7 +1649,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1663,7 +1663,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1677,7 +1677,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_416_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_416_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -716,7 +716,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -822,7 +822,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1425,14 +1425,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1441,7 +1441,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1455,14 +1455,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1471,7 +1471,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1485,14 +1485,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1509,14 +1509,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1530,7 +1530,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1544,7 +1544,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1558,7 +1558,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1572,7 +1572,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1586,7 +1586,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1600,7 +1600,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1614,7 +1614,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1628,7 +1628,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1642,7 +1642,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1656,7 +1656,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1670,7 +1670,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1684,7 +1684,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1698,7 +1698,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1712,7 +1712,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1726,7 +1726,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1740,7 +1740,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1754,7 +1754,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1768,7 +1768,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1782,7 +1782,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_417_agent_based_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_417_agent_based_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -354,7 +354,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -362,7 +362,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -476,7 +476,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -484,7 +484,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -492,7 +492,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -500,7 +500,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -599,7 +599,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -607,7 +607,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -615,7 +615,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -623,7 +623,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -795,7 +795,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -803,7 +803,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -811,7 +811,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -819,7 +819,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -917,7 +917,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -925,7 +925,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -933,7 +933,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -941,7 +941,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1553,14 +1553,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1569,7 +1569,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1583,14 +1583,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1599,7 +1599,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1613,14 +1613,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "metal3-provisioning",
+                        "name": "aci-containers-kube-metal3-provisioning",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-subj",
+                                    "name": "aci-containers-kube-metal3-provisioning-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1629,7 +1629,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "metal3-provisioning-filter",
+                                                "tnVzFilterName": "aci-containers-kube-metal3-provisioning-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1643,14 +1643,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1667,14 +1667,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1688,7 +1688,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1702,7 +1702,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1716,7 +1716,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1730,7 +1730,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1744,7 +1744,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1758,7 +1758,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1772,7 +1772,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1786,7 +1786,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1800,7 +1800,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1814,7 +1814,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1828,7 +1828,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1842,7 +1842,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9102",
+                                    "name": "aci-containers-kube-openshift-monitoring-9102",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9102",
@@ -1856,7 +1856,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9104",
+                                    "name": "aci-containers-kube-openshift-monitoring-9104",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9104",
@@ -1870,7 +1870,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1884,7 +1884,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1898,7 +1898,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1912,7 +1912,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1926,7 +1926,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1940,7 +1940,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1954,7 +1954,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1968,7 +1968,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",
@@ -1985,14 +1985,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "metal3-provisioning-filter",
+                        "name": "aci-containers-kube-metal3-provisioning-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-4343",
+                                    "name": "aci-containers-kube-metal3-provisioning-4343",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "4343",
@@ -2006,7 +2006,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5050",
+                                    "name": "aci-containers-kube-metal3-provisioning-5050",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5050",
@@ -2020,7 +2020,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5051",
+                                    "name": "aci-containers-kube-metal3-provisioning-5051",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5051",
@@ -2034,7 +2034,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6180",
+                                    "name": "aci-containers-kube-metal3-provisioning-6180",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6180",
@@ -2048,7 +2048,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6183",
+                                    "name": "aci-containers-kube-metal3-provisioning-6183",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6183",
@@ -2062,7 +2062,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6385",
+                                    "name": "aci-containers-kube-metal3-provisioning-6385",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6385",
@@ -2076,7 +2076,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6388",
+                                    "name": "aci-containers-kube-metal3-provisioning-6388",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6388",
@@ -2090,7 +2090,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-9443",
+                                    "name": "aci-containers-kube-metal3-provisioning-9443",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9443",

--- a/provision/testdata/flavor_openshift_417_agent_based_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_417_agent_based_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -544,7 +544,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -552,7 +552,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -560,7 +560,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -568,7 +568,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -658,7 +658,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -666,7 +666,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -674,7 +674,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -682,7 +682,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1368,14 +1368,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1384,7 +1384,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1398,14 +1398,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1414,7 +1414,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1428,14 +1428,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "metal3-provisioning",
+                        "name": "aci-containers-kube-metal3-provisioning",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-subj",
+                                    "name": "aci-containers-kube-metal3-provisioning-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1444,7 +1444,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "metal3-provisioning-filter",
+                                                "tnVzFilterName": "aci-containers-kube-metal3-provisioning-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1458,14 +1458,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1482,14 +1482,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1503,7 +1503,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1517,7 +1517,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1531,7 +1531,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1545,7 +1545,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1559,7 +1559,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1573,7 +1573,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1587,7 +1587,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1601,7 +1601,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1615,7 +1615,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1629,7 +1629,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1643,7 +1643,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1657,7 +1657,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9102",
+                                    "name": "aci-containers-kube-openshift-monitoring-9102",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9102",
@@ -1671,7 +1671,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9104",
+                                    "name": "aci-containers-kube-openshift-monitoring-9104",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9104",
@@ -1685,7 +1685,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1699,7 +1699,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1713,7 +1713,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1727,7 +1727,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1741,7 +1741,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1755,7 +1755,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1769,7 +1769,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1783,7 +1783,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",
@@ -1800,14 +1800,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "metal3-provisioning-filter",
+                        "name": "aci-containers-kube-metal3-provisioning-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-4343",
+                                    "name": "aci-containers-kube-metal3-provisioning-4343",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "4343",
@@ -1821,7 +1821,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5050",
+                                    "name": "aci-containers-kube-metal3-provisioning-5050",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5050",
@@ -1835,7 +1835,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5051",
+                                    "name": "aci-containers-kube-metal3-provisioning-5051",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5051",
@@ -1849,7 +1849,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6180",
+                                    "name": "aci-containers-kube-metal3-provisioning-6180",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6180",
@@ -1863,7 +1863,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6183",
+                                    "name": "aci-containers-kube-metal3-provisioning-6183",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6183",
@@ -1877,7 +1877,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6385",
+                                    "name": "aci-containers-kube-metal3-provisioning-6385",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6385",
@@ -1891,7 +1891,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6388",
+                                    "name": "aci-containers-kube-metal3-provisioning-6388",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6388",
@@ -1905,7 +1905,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-9443",
+                                    "name": "aci-containers-kube-metal3-provisioning-9443",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9443",

--- a/provision/testdata/flavor_openshift_417_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_417_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -755,7 +755,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -861,7 +861,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1473,14 +1473,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1489,7 +1489,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1503,14 +1503,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1519,7 +1519,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1533,14 +1533,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1557,14 +1557,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1788,7 +1788,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1802,7 +1802,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1816,7 +1816,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1830,7 +1830,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_417_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_417_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1320,14 +1320,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1336,7 +1336,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1350,14 +1350,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1366,7 +1366,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1380,14 +1380,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1404,14 +1404,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1425,7 +1425,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1439,7 +1439,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1453,7 +1453,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1467,7 +1467,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1481,7 +1481,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1495,7 +1495,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1509,7 +1509,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1523,7 +1523,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1537,7 +1537,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1551,7 +1551,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1565,7 +1565,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1579,7 +1579,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1593,7 +1593,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1607,7 +1607,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1621,7 +1621,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1635,7 +1635,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1649,7 +1649,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1663,7 +1663,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1677,7 +1677,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_417_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_417_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -716,7 +716,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -822,7 +822,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1425,14 +1425,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1441,7 +1441,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1455,14 +1455,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1471,7 +1471,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1485,14 +1485,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1509,14 +1509,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1530,7 +1530,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1544,7 +1544,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1558,7 +1558,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1572,7 +1572,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1586,7 +1586,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1600,7 +1600,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1614,7 +1614,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1628,7 +1628,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1642,7 +1642,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1656,7 +1656,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1670,7 +1670,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1684,7 +1684,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1698,7 +1698,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1712,7 +1712,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1726,7 +1726,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1740,7 +1740,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1754,7 +1754,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1768,7 +1768,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1782,7 +1782,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_418_agent_based_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_418_agent_based_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -354,7 +354,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -362,7 +362,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -476,7 +476,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -484,7 +484,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -492,7 +492,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -500,7 +500,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -599,7 +599,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -607,7 +607,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -615,7 +615,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -623,7 +623,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -795,7 +795,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -803,7 +803,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -811,7 +811,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -819,7 +819,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -917,7 +917,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -925,7 +925,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -933,7 +933,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -941,7 +941,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1553,14 +1553,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1569,7 +1569,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1583,14 +1583,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1599,7 +1599,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1613,14 +1613,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "metal3-provisioning",
+                        "name": "aci-containers-kube-metal3-provisioning",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-subj",
+                                    "name": "aci-containers-kube-metal3-provisioning-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1629,7 +1629,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "metal3-provisioning-filter",
+                                                "tnVzFilterName": "aci-containers-kube-metal3-provisioning-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1643,14 +1643,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1667,14 +1667,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1688,7 +1688,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1702,7 +1702,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1716,7 +1716,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1730,7 +1730,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1744,7 +1744,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1758,7 +1758,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1772,7 +1772,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1786,7 +1786,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1800,7 +1800,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1814,7 +1814,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1828,7 +1828,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1842,7 +1842,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9102",
+                                    "name": "aci-containers-kube-openshift-monitoring-9102",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9102",
@@ -1856,7 +1856,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9104",
+                                    "name": "aci-containers-kube-openshift-monitoring-9104",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9104",
@@ -1870,7 +1870,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1884,7 +1884,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1898,7 +1898,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1912,7 +1912,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1926,7 +1926,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1940,7 +1940,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1954,7 +1954,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1968,7 +1968,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",
@@ -1985,14 +1985,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "metal3-provisioning-filter",
+                        "name": "aci-containers-kube-metal3-provisioning-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-4343",
+                                    "name": "aci-containers-kube-metal3-provisioning-4343",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "4343",
@@ -2006,7 +2006,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5050",
+                                    "name": "aci-containers-kube-metal3-provisioning-5050",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5050",
@@ -2020,7 +2020,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5051",
+                                    "name": "aci-containers-kube-metal3-provisioning-5051",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5051",
@@ -2034,7 +2034,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6180",
+                                    "name": "aci-containers-kube-metal3-provisioning-6180",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6180",
@@ -2048,7 +2048,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6183",
+                                    "name": "aci-containers-kube-metal3-provisioning-6183",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6183",
@@ -2062,7 +2062,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6385",
+                                    "name": "aci-containers-kube-metal3-provisioning-6385",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6385",
@@ -2076,7 +2076,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6388",
+                                    "name": "aci-containers-kube-metal3-provisioning-6388",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6388",
@@ -2090,7 +2090,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-9443",
+                                    "name": "aci-containers-kube-metal3-provisioning-9443",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9443",

--- a/provision/testdata/flavor_openshift_418_agent_based_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_418_agent_based_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -544,7 +544,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -552,7 +552,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -560,7 +560,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -568,7 +568,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -658,7 +658,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -666,7 +666,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -674,7 +674,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -682,7 +682,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1368,14 +1368,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1384,7 +1384,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1398,14 +1398,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1414,7 +1414,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1428,14 +1428,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "metal3-provisioning",
+                        "name": "aci-containers-kube-metal3-provisioning",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-subj",
+                                    "name": "aci-containers-kube-metal3-provisioning-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1444,7 +1444,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "metal3-provisioning-filter",
+                                                "tnVzFilterName": "aci-containers-kube-metal3-provisioning-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1458,14 +1458,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1482,14 +1482,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1503,7 +1503,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1517,7 +1517,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1531,7 +1531,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1545,7 +1545,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1559,7 +1559,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1573,7 +1573,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1587,7 +1587,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1601,7 +1601,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1615,7 +1615,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1629,7 +1629,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1643,7 +1643,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1657,7 +1657,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9102",
+                                    "name": "aci-containers-kube-openshift-monitoring-9102",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9102",
@@ -1671,7 +1671,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9104",
+                                    "name": "aci-containers-kube-openshift-monitoring-9104",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9104",
@@ -1685,7 +1685,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1699,7 +1699,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1713,7 +1713,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1727,7 +1727,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1741,7 +1741,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1755,7 +1755,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1769,7 +1769,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1783,7 +1783,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",
@@ -1800,14 +1800,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "metal3-provisioning-filter",
+                        "name": "aci-containers-kube-metal3-provisioning-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-4343",
+                                    "name": "aci-containers-kube-metal3-provisioning-4343",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "4343",
@@ -1821,7 +1821,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5050",
+                                    "name": "aci-containers-kube-metal3-provisioning-5050",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5050",
@@ -1835,7 +1835,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5051",
+                                    "name": "aci-containers-kube-metal3-provisioning-5051",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5051",
@@ -1849,7 +1849,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6180",
+                                    "name": "aci-containers-kube-metal3-provisioning-6180",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6180",
@@ -1863,7 +1863,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6183",
+                                    "name": "aci-containers-kube-metal3-provisioning-6183",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6183",
@@ -1877,7 +1877,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6385",
+                                    "name": "aci-containers-kube-metal3-provisioning-6385",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6385",
@@ -1891,7 +1891,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6388",
+                                    "name": "aci-containers-kube-metal3-provisioning-6388",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6388",
@@ -1905,7 +1905,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-9443",
+                                    "name": "aci-containers-kube-metal3-provisioning-9443",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9443",

--- a/provision/testdata/flavor_openshift_418_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_418_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -755,7 +755,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -861,7 +861,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1473,14 +1473,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1489,7 +1489,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1503,14 +1503,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1519,7 +1519,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1533,14 +1533,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1557,14 +1557,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1788,7 +1788,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1802,7 +1802,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1816,7 +1816,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1830,7 +1830,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_418_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_418_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1320,14 +1320,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1336,7 +1336,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1350,14 +1350,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1366,7 +1366,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1380,14 +1380,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1404,14 +1404,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1425,7 +1425,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1439,7 +1439,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1453,7 +1453,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1467,7 +1467,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1481,7 +1481,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1495,7 +1495,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1509,7 +1509,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1523,7 +1523,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1537,7 +1537,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1551,7 +1551,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1565,7 +1565,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1579,7 +1579,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1593,7 +1593,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1607,7 +1607,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1621,7 +1621,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1635,7 +1635,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1649,7 +1649,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1663,7 +1663,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1677,7 +1677,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_418_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_418_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -716,7 +716,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -822,7 +822,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1425,14 +1425,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1441,7 +1441,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1455,14 +1455,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1471,7 +1471,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1485,14 +1485,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1509,14 +1509,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1530,7 +1530,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1544,7 +1544,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1558,7 +1558,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1572,7 +1572,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1586,7 +1586,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1600,7 +1600,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1614,7 +1614,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1628,7 +1628,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1642,7 +1642,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1656,7 +1656,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1670,7 +1670,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1684,7 +1684,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1698,7 +1698,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1712,7 +1712,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1726,7 +1726,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1740,7 +1740,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1754,7 +1754,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1768,7 +1768,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1782,7 +1782,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_419_agent_based_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_419_agent_based_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -354,7 +354,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -362,7 +362,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -476,7 +476,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -484,7 +484,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -492,7 +492,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -500,7 +500,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -599,7 +599,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -607,7 +607,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -615,7 +615,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -623,7 +623,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -795,7 +795,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -803,7 +803,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -811,7 +811,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -819,7 +819,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -917,7 +917,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -925,7 +925,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -933,7 +933,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -941,7 +941,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1553,14 +1553,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1569,7 +1569,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1583,14 +1583,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1599,7 +1599,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1613,14 +1613,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "metal3-provisioning",
+                        "name": "aci-containers-kube-metal3-provisioning",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-subj",
+                                    "name": "aci-containers-kube-metal3-provisioning-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1629,7 +1629,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "metal3-provisioning-filter",
+                                                "tnVzFilterName": "aci-containers-kube-metal3-provisioning-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1643,14 +1643,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1667,14 +1667,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1688,7 +1688,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1702,7 +1702,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1716,7 +1716,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1730,7 +1730,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1744,7 +1744,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1758,7 +1758,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1772,7 +1772,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1786,7 +1786,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1800,7 +1800,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1814,7 +1814,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1828,7 +1828,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1842,7 +1842,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9102",
+                                    "name": "aci-containers-kube-openshift-monitoring-9102",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9102",
@@ -1856,7 +1856,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9104",
+                                    "name": "aci-containers-kube-openshift-monitoring-9104",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9104",
@@ -1870,7 +1870,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1884,7 +1884,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1898,7 +1898,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1912,7 +1912,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1926,7 +1926,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1940,7 +1940,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1954,7 +1954,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1968,7 +1968,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",
@@ -1985,14 +1985,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "metal3-provisioning-filter",
+                        "name": "aci-containers-kube-metal3-provisioning-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-4343",
+                                    "name": "aci-containers-kube-metal3-provisioning-4343",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "4343",
@@ -2006,7 +2006,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5050",
+                                    "name": "aci-containers-kube-metal3-provisioning-5050",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5050",
@@ -2020,7 +2020,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5051",
+                                    "name": "aci-containers-kube-metal3-provisioning-5051",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5051",
@@ -2034,7 +2034,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6180",
+                                    "name": "aci-containers-kube-metal3-provisioning-6180",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6180",
@@ -2048,7 +2048,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6183",
+                                    "name": "aci-containers-kube-metal3-provisioning-6183",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6183",
@@ -2062,7 +2062,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6385",
+                                    "name": "aci-containers-kube-metal3-provisioning-6385",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6385",
@@ -2076,7 +2076,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6388",
+                                    "name": "aci-containers-kube-metal3-provisioning-6388",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6388",
@@ -2090,7 +2090,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-9443",
+                                    "name": "aci-containers-kube-metal3-provisioning-9443",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9443",

--- a/provision/testdata/flavor_openshift_419_agent_based_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_419_agent_based_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -544,7 +544,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -552,7 +552,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -560,7 +560,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -568,7 +568,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -658,7 +658,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -666,7 +666,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -674,7 +674,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -682,7 +682,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "metal3-provisioning",
+                                                "tnVzBrCPName": "aci-containers-kube-metal3-provisioning",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1368,14 +1368,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1384,7 +1384,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1398,14 +1398,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1414,7 +1414,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1428,14 +1428,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "metal3-provisioning",
+                        "name": "aci-containers-kube-metal3-provisioning",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-subj",
+                                    "name": "aci-containers-kube-metal3-provisioning-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1444,7 +1444,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "metal3-provisioning-filter",
+                                                "tnVzFilterName": "aci-containers-kube-metal3-provisioning-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1458,14 +1458,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1482,14 +1482,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1503,7 +1503,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1517,7 +1517,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1531,7 +1531,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1545,7 +1545,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1559,7 +1559,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1573,7 +1573,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1587,7 +1587,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1601,7 +1601,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1615,7 +1615,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1629,7 +1629,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1643,7 +1643,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1657,7 +1657,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9102",
+                                    "name": "aci-containers-kube-openshift-monitoring-9102",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9102",
@@ -1671,7 +1671,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9104",
+                                    "name": "aci-containers-kube-openshift-monitoring-9104",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9104",
@@ -1685,7 +1685,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1699,7 +1699,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1713,7 +1713,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1727,7 +1727,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1741,7 +1741,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1755,7 +1755,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1769,7 +1769,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1783,7 +1783,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",
@@ -1800,14 +1800,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "metal3-provisioning-filter",
+                        "name": "aci-containers-kube-metal3-provisioning-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-4343",
+                                    "name": "aci-containers-kube-metal3-provisioning-4343",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "4343",
@@ -1821,7 +1821,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5050",
+                                    "name": "aci-containers-kube-metal3-provisioning-5050",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5050",
@@ -1835,7 +1835,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-5051",
+                                    "name": "aci-containers-kube-metal3-provisioning-5051",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "5051",
@@ -1849,7 +1849,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6180",
+                                    "name": "aci-containers-kube-metal3-provisioning-6180",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6180",
@@ -1863,7 +1863,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6183",
+                                    "name": "aci-containers-kube-metal3-provisioning-6183",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6183",
@@ -1877,7 +1877,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6385",
+                                    "name": "aci-containers-kube-metal3-provisioning-6385",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6385",
@@ -1891,7 +1891,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-6388",
+                                    "name": "aci-containers-kube-metal3-provisioning-6388",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "6388",
@@ -1905,7 +1905,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "metal3-provisioning-9443",
+                                    "name": "aci-containers-kube-metal3-provisioning-9443",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9443",

--- a/provision/testdata/flavor_openshift_419_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_419_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -755,7 +755,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -861,7 +861,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1473,14 +1473,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1489,7 +1489,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1503,14 +1503,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1519,7 +1519,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1533,14 +1533,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1557,14 +1557,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1788,7 +1788,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1802,7 +1802,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1816,7 +1816,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1830,7 +1830,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_419_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_419_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1320,14 +1320,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1336,7 +1336,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1350,14 +1350,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1366,7 +1366,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1380,14 +1380,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1404,14 +1404,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1425,7 +1425,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1439,7 +1439,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1453,7 +1453,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1467,7 +1467,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1481,7 +1481,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1495,7 +1495,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1509,7 +1509,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1523,7 +1523,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1537,7 +1537,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1551,7 +1551,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1565,7 +1565,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1579,7 +1579,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1593,7 +1593,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1607,7 +1607,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1621,7 +1621,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1635,7 +1635,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1649,7 +1649,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1663,7 +1663,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1677,7 +1677,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_419_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_419_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -716,7 +716,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -822,7 +822,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1425,14 +1425,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1441,7 +1441,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1455,14 +1455,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1471,7 +1471,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1485,14 +1485,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1509,14 +1509,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1530,7 +1530,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1544,7 +1544,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1558,7 +1558,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1572,7 +1572,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1586,7 +1586,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1600,7 +1600,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1614,7 +1614,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1628,7 +1628,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1642,7 +1642,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1656,7 +1656,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1670,7 +1670,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1684,7 +1684,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1698,7 +1698,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1712,7 +1712,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1726,7 +1726,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1740,7 +1740,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1754,7 +1754,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1768,7 +1768,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1782,7 +1782,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_43.apic.txt
+++ b/provision/testdata/flavor_openshift_43.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -739,7 +739,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -845,7 +845,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1465,14 +1465,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1481,7 +1481,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1495,14 +1495,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1511,7 +1511,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1525,14 +1525,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1549,14 +1549,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1570,7 +1570,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1584,7 +1584,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1598,7 +1598,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1612,7 +1612,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",

--- a/provision/testdata/flavor_openshift_44_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_44_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1312,14 +1312,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1328,7 +1328,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1342,14 +1342,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1358,7 +1358,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1372,14 +1372,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1396,14 +1396,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1417,7 +1417,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1431,7 +1431,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1445,7 +1445,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1459,7 +1459,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1473,7 +1473,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1487,7 +1487,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1501,7 +1501,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1515,7 +1515,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1529,7 +1529,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1543,7 +1543,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1557,7 +1557,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1571,7 +1571,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1585,7 +1585,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1599,7 +1599,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1613,7 +1613,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_44_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_44_esx_vDS_6_6_above.apic.txt
@@ -415,7 +415,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -423,7 +423,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -529,7 +529,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -537,7 +537,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -545,7 +545,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -635,7 +635,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -643,7 +643,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1321,14 +1321,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1337,7 +1337,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1351,14 +1351,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1367,7 +1367,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1381,14 +1381,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1405,14 +1405,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1426,7 +1426,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1440,7 +1440,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1454,7 +1454,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1468,7 +1468,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1482,7 +1482,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1496,7 +1496,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1510,7 +1510,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1524,7 +1524,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1538,7 +1538,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1552,7 +1552,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1566,7 +1566,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1580,7 +1580,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1594,7 +1594,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1608,7 +1608,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1622,7 +1622,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_44_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_44_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -700,7 +700,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -806,7 +806,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1417,14 +1417,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1433,7 +1433,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1447,14 +1447,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1463,7 +1463,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1477,14 +1477,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1501,14 +1501,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1522,7 +1522,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1536,7 +1536,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1550,7 +1550,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1564,7 +1564,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_45_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_45_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1312,14 +1312,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1328,7 +1328,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1342,14 +1342,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1358,7 +1358,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1372,14 +1372,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1396,14 +1396,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1417,7 +1417,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1431,7 +1431,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1445,7 +1445,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1459,7 +1459,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1473,7 +1473,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1487,7 +1487,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1501,7 +1501,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1515,7 +1515,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1529,7 +1529,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1543,7 +1543,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1557,7 +1557,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1571,7 +1571,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1585,7 +1585,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1599,7 +1599,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1613,7 +1613,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_45_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_45_esx_vDS_6_6_above.apic.txt
@@ -415,7 +415,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -423,7 +423,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -529,7 +529,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -537,7 +537,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -545,7 +545,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -635,7 +635,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -643,7 +643,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1321,14 +1321,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1337,7 +1337,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1351,14 +1351,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1367,7 +1367,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1381,14 +1381,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1405,14 +1405,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1426,7 +1426,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1440,7 +1440,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1454,7 +1454,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1468,7 +1468,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1482,7 +1482,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1496,7 +1496,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1510,7 +1510,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1524,7 +1524,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1538,7 +1538,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1552,7 +1552,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1566,7 +1566,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1580,7 +1580,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1594,7 +1594,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1608,7 +1608,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1622,7 +1622,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_45_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_45_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -700,7 +700,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -806,7 +806,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1417,14 +1417,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1433,7 +1433,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1447,14 +1447,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1463,7 +1463,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1477,14 +1477,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1501,14 +1501,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1522,7 +1522,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1536,7 +1536,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1550,7 +1550,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1564,7 +1564,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_46_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_46_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -739,7 +739,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -845,7 +845,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1465,14 +1465,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1481,7 +1481,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1495,14 +1495,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1511,7 +1511,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1525,14 +1525,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1549,14 +1549,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1570,7 +1570,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1584,7 +1584,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1598,7 +1598,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1612,7 +1612,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1626,7 +1626,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1640,7 +1640,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1654,7 +1654,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1668,7 +1668,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1682,7 +1682,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1696,7 +1696,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1710,7 +1710,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1724,7 +1724,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1738,7 +1738,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1752,7 +1752,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1766,7 +1766,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1780,7 +1780,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1794,7 +1794,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1808,7 +1808,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1822,7 +1822,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_46_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_46_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1312,14 +1312,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1328,7 +1328,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1342,14 +1342,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1358,7 +1358,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1372,14 +1372,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1396,14 +1396,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1417,7 +1417,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1431,7 +1431,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1445,7 +1445,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1459,7 +1459,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1473,7 +1473,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1487,7 +1487,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1501,7 +1501,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1515,7 +1515,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1529,7 +1529,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1543,7 +1543,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1557,7 +1557,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1571,7 +1571,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1585,7 +1585,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1599,7 +1599,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1613,7 +1613,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1627,7 +1627,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1641,7 +1641,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1655,7 +1655,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1669,7 +1669,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_46_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_46_esx_vDS_6_6_above.apic.txt
@@ -415,7 +415,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -423,7 +423,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -529,7 +529,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -537,7 +537,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -545,7 +545,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -635,7 +635,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -643,7 +643,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1321,14 +1321,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1337,7 +1337,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1351,14 +1351,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1367,7 +1367,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1381,14 +1381,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1405,14 +1405,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1426,7 +1426,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1440,7 +1440,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1454,7 +1454,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1468,7 +1468,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1482,7 +1482,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1496,7 +1496,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1510,7 +1510,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1524,7 +1524,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1538,7 +1538,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1552,7 +1552,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1566,7 +1566,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1580,7 +1580,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1594,7 +1594,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1608,7 +1608,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1622,7 +1622,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1636,7 +1636,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1650,7 +1650,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1664,7 +1664,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1678,7 +1678,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_46_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_46_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -700,7 +700,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -806,7 +806,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1417,14 +1417,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1433,7 +1433,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1447,14 +1447,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1463,7 +1463,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1477,14 +1477,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1501,14 +1501,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1522,7 +1522,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1536,7 +1536,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1550,7 +1550,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1564,7 +1564,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_47_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_47_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -739,7 +739,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -845,7 +845,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1465,14 +1465,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1481,7 +1481,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1495,14 +1495,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1511,7 +1511,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1525,14 +1525,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1549,14 +1549,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1570,7 +1570,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1584,7 +1584,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1598,7 +1598,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1612,7 +1612,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1626,7 +1626,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1640,7 +1640,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1654,7 +1654,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1668,7 +1668,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1682,7 +1682,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1696,7 +1696,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1710,7 +1710,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1724,7 +1724,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1738,7 +1738,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1752,7 +1752,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1766,7 +1766,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1780,7 +1780,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1794,7 +1794,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1808,7 +1808,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1822,7 +1822,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_47_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_47_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1312,14 +1312,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1328,7 +1328,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1342,14 +1342,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1358,7 +1358,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1372,14 +1372,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1396,14 +1396,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1417,7 +1417,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1431,7 +1431,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1445,7 +1445,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1459,7 +1459,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1473,7 +1473,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1487,7 +1487,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1501,7 +1501,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1515,7 +1515,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1529,7 +1529,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1543,7 +1543,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1557,7 +1557,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1571,7 +1571,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1585,7 +1585,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1599,7 +1599,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1613,7 +1613,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1627,7 +1627,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1641,7 +1641,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1655,7 +1655,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1669,7 +1669,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_47_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_47_esx_vDS_6_6_above.apic.txt
@@ -415,7 +415,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -423,7 +423,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -529,7 +529,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -537,7 +537,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -545,7 +545,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -635,7 +635,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -643,7 +643,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1321,14 +1321,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1337,7 +1337,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1351,14 +1351,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1367,7 +1367,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1381,14 +1381,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1405,14 +1405,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1426,7 +1426,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1440,7 +1440,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1454,7 +1454,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1468,7 +1468,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1482,7 +1482,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1496,7 +1496,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1510,7 +1510,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1524,7 +1524,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1538,7 +1538,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1552,7 +1552,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1566,7 +1566,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1580,7 +1580,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1594,7 +1594,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1608,7 +1608,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1622,7 +1622,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1636,7 +1636,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1650,7 +1650,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1664,7 +1664,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1678,7 +1678,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_47_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_47_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -700,7 +700,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -806,7 +806,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1417,14 +1417,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1433,7 +1433,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1447,14 +1447,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1463,7 +1463,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1477,14 +1477,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1501,14 +1501,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1522,7 +1522,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1536,7 +1536,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1550,7 +1550,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1564,7 +1564,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_48_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_48_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -755,7 +755,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -861,7 +861,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1473,14 +1473,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1489,7 +1489,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1503,14 +1503,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1519,7 +1519,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1533,14 +1533,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1557,14 +1557,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1788,7 +1788,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1802,7 +1802,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1816,7 +1816,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1830,7 +1830,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_48_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_48_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1320,14 +1320,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1336,7 +1336,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1350,14 +1350,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1366,7 +1366,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1380,14 +1380,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1404,14 +1404,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1425,7 +1425,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1439,7 +1439,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1453,7 +1453,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1467,7 +1467,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1481,7 +1481,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1495,7 +1495,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1509,7 +1509,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1523,7 +1523,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1537,7 +1537,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1551,7 +1551,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1565,7 +1565,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1579,7 +1579,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1593,7 +1593,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1607,7 +1607,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1621,7 +1621,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1635,7 +1635,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1649,7 +1649,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1663,7 +1663,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1677,7 +1677,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_48_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_48_esx_vDS_6_6_above.apic.txt
@@ -415,7 +415,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -423,7 +423,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -529,7 +529,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -537,7 +537,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -545,7 +545,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -635,7 +635,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -643,7 +643,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1329,14 +1329,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1345,7 +1345,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1359,14 +1359,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1375,7 +1375,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1389,14 +1389,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1413,14 +1413,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1434,7 +1434,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1448,7 +1448,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1462,7 +1462,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1476,7 +1476,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1490,7 +1490,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1504,7 +1504,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1518,7 +1518,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1532,7 +1532,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1546,7 +1546,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1560,7 +1560,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1574,7 +1574,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1588,7 +1588,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1602,7 +1602,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1616,7 +1616,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1630,7 +1630,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1644,7 +1644,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1658,7 +1658,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1672,7 +1672,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1686,7 +1686,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_48_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_48_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -716,7 +716,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -822,7 +822,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1425,14 +1425,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1441,7 +1441,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1455,14 +1455,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1471,7 +1471,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1485,14 +1485,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1509,14 +1509,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1530,7 +1530,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1544,7 +1544,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1558,7 +1558,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1572,7 +1572,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1586,7 +1586,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1600,7 +1600,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1614,7 +1614,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1628,7 +1628,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1642,7 +1642,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1656,7 +1656,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1670,7 +1670,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1684,7 +1684,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1698,7 +1698,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1712,7 +1712,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1726,7 +1726,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1740,7 +1740,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1754,7 +1754,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1768,7 +1768,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1782,7 +1782,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_49_baremetal.apic.txt
+++ b/provision/testdata/flavor_openshift_49_baremetal.apic.txt
@@ -338,7 +338,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -346,7 +346,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -460,7 +460,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -468,7 +468,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -567,7 +567,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -575,7 +575,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -747,7 +747,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -755,7 +755,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -853,7 +853,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -861,7 +861,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1473,14 +1473,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1489,7 +1489,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1503,14 +1503,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1519,7 +1519,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1533,14 +1533,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1557,14 +1557,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1578,7 +1578,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1592,7 +1592,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1606,7 +1606,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1620,7 +1620,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1634,7 +1634,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1648,7 +1648,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1662,7 +1662,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1676,7 +1676,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1690,7 +1690,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1704,7 +1704,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1718,7 +1718,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1732,7 +1732,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1746,7 +1746,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1760,7 +1760,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1774,7 +1774,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1788,7 +1788,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1802,7 +1802,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1816,7 +1816,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1830,7 +1830,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_49_esx.apic.txt
+++ b/provision/testdata/flavor_openshift_49_esx.apic.txt
@@ -406,7 +406,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -414,7 +414,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -520,7 +520,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -626,7 +626,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -634,7 +634,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1320,14 +1320,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1336,7 +1336,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1350,14 +1350,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1366,7 +1366,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1380,14 +1380,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1404,14 +1404,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1425,7 +1425,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1439,7 +1439,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1453,7 +1453,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1467,7 +1467,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1481,7 +1481,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1495,7 +1495,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1509,7 +1509,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1523,7 +1523,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1537,7 +1537,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1551,7 +1551,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1565,7 +1565,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1579,7 +1579,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1593,7 +1593,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1607,7 +1607,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1621,7 +1621,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1635,7 +1635,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1649,7 +1649,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1663,7 +1663,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1677,7 +1677,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_49_esx_vDS_6_6_above.apic.txt
+++ b/provision/testdata/flavor_openshift_49_esx_vDS_6_6_above.apic.txt
@@ -415,7 +415,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -423,7 +423,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -529,7 +529,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -537,7 +537,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -545,7 +545,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -635,7 +635,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -643,7 +643,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1329,14 +1329,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1345,7 +1345,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1359,14 +1359,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1375,7 +1375,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1389,14 +1389,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1413,14 +1413,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1434,7 +1434,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1448,7 +1448,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1462,7 +1462,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1476,7 +1476,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1490,7 +1490,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1504,7 +1504,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1518,7 +1518,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1532,7 +1532,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1546,7 +1546,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1560,7 +1560,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1574,7 +1574,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1588,7 +1588,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1602,7 +1602,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1616,7 +1616,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1630,7 +1630,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1644,7 +1644,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1658,7 +1658,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1672,7 +1672,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1686,7 +1686,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/flavor_openshift_49_openstack.apic.txt
+++ b/provision/testdata/flavor_openshift_49_openstack.apic.txt
@@ -308,7 +308,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -316,7 +316,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -422,7 +422,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -430,7 +430,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -438,7 +438,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -528,7 +528,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -536,7 +536,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -708,7 +708,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -716,7 +716,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -814,7 +814,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -822,7 +822,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1425,14 +1425,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1441,7 +1441,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1455,14 +1455,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1471,7 +1471,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1485,14 +1485,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1509,14 +1509,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-1936",
+                                    "name": "aci-containers-kube-openshift-monitoring-1936",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "1936",
@@ -1530,7 +1530,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-2112",
+                                    "name": "aci-containers-kube-openshift-monitoring-2112",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2112",
@@ -1544,7 +1544,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-3000",
+                                    "name": "aci-containers-kube-openshift-monitoring-3000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "3000",
@@ -1558,7 +1558,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8080",
+                                    "name": "aci-containers-kube-openshift-monitoring-8080",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8080",
@@ -1572,7 +1572,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8383",
+                                    "name": "aci-containers-kube-openshift-monitoring-8383",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8383",
@@ -1586,7 +1586,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8441",
+                                    "name": "aci-containers-kube-openshift-monitoring-8441",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8441",
@@ -1600,7 +1600,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-8686",
+                                    "name": "aci-containers-kube-openshift-monitoring-8686",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "8686",
@@ -1614,7 +1614,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9001",
+                                    "name": "aci-containers-kube-openshift-monitoring-9001",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9001",
@@ -1628,7 +1628,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1642,7 +1642,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",
@@ -1656,7 +1656,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9095",
+                                    "name": "aci-containers-kube-openshift-monitoring-9095",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9095",
@@ -1670,7 +1670,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9099",
+                                    "name": "aci-containers-kube-openshift-monitoring-9099",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9099",
@@ -1684,7 +1684,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9192",
+                                    "name": "aci-containers-kube-openshift-monitoring-9192",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9192",
@@ -1698,7 +1698,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9393",
+                                    "name": "aci-containers-kube-openshift-monitoring-9393",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9393",
@@ -1712,7 +1712,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9537",
+                                    "name": "aci-containers-kube-openshift-monitoring-9537",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9537",
@@ -1726,7 +1726,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10250",
+                                    "name": "aci-containers-kube-openshift-monitoring-10250",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -1740,7 +1740,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10257",
+                                    "name": "aci-containers-kube-openshift-monitoring-10257",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10257",
@@ -1754,7 +1754,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-10259",
+                                    "name": "aci-containers-kube-openshift-monitoring-10259",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10259",
@@ -1768,7 +1768,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-17698",
+                                    "name": "aci-containers-kube-openshift-monitoring-17698",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "17698",
@@ -1782,7 +1782,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-60000",
+                                    "name": "aci-containers-kube-openshift-monitoring-60000",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "60000",

--- a/provision/testdata/test_unprovision_multi_cluster_cluster1.inp.yaml
+++ b/provision/testdata/test_unprovision_multi_cluster_cluster1.inp.yaml
@@ -1,0 +1,32 @@
+aci_config:
+  system_id: cluster1
+  tenant:
+    name: shared-tenant
+  apic_hosts:
+  - localhost:50001
+  apic_version: "6.1"
+  ssl: False
+  aep: test-aep
+  vrf:
+    name: test-vrf
+    tenant: common
+  l3out:
+    name: test-l3out
+    external_networks:
+    - default
+  vmm_domain:
+    encap_type: vxlan
+    nested_inside:
+      type: vmware
+      name: test-vmm
+      installer_provisioned_lb_ip: "1.1.1.1"
+
+net_config:
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093

--- a/provision/testdata/test_unprovision_multi_cluster_data.json
+++ b/provision/testdata/test_unprovision_multi_cluster_data.json
@@ -1,0 +1,41 @@
+{
+    "gets": {
+        "/api/mo/uni/tn-shared-tenant.json?query-target=children": {
+            "imdata": [
+                { "vzBrCP": { "attributes": { "dn": "uni/tn-shared-tenant/brc-aci-containers-cluster1-openshift-monitoring", "name": "aci-containers-cluster1-openshift-monitoring", "annotation": "orchestrator:aci-containers-controller" } } },
+                { "vzBrCP": { "attributes": { "dn": "uni/tn-shared-tenant/brc-aci-containers-cluster1-openshift-svc-catalog", "name": "aci-containers-cluster1-openshift-svc-catalog", "annotation": "orchestrator:aci-containers-controller" } } },
+                { "vzBrCP": { "attributes": { "dn": "uni/tn-shared-tenant/brc-aci-containers-cluster2-openshift-monitoring", "name": "aci-containers-cluster2-openshift-monitoring", "annotation": "orchestrator:aci-containers-controller" } } },
+                { "vzBrCP": { "attributes": { "dn": "uni/tn-shared-tenant/brc-aci-containers-cluster2-openshift-svc-catalog", "name": "aci-containers-cluster2-openshift-svc-catalog", "annotation": "orchestrator:aci-containers-controller" } } }
+            ]
+        },
+        "/api/mo/uni/tn-shared-tenant.json": { "imdata": [ { "fvTenant": { "attributes": { "dn": "uni/tn-shared-tenant", "name": "shared-tenant" } } } ] },
+        "/api/node/mo/uni/vmmp-VMware/dom-test-vmm.json?query-target=children&target-subtree-class=infraRsVlanNs": { "imdata": [ { "infraRsVlanNs": { "attributes": { "tDn": "uni/infra/vlanns-[test-pool]-static" } } } ] },
+        "/api/node/class/firmwareCtrlrRunning.json": { "imdata": [ { "firmwareCtrlrRunning": { "attributes": { "version": "6.1(1.1)" } } } ] },
+        "/api/node/mo/uni/infra/attentp-default/provacc/rsfuncToEpg-[uni/tn-infra/ap-access/epg-default].json": { "imdata": [] },
+        "/api/mo/uni/infra/attentp-test-aep.json": { "imdata": [] },
+        "/api/mo/uni/tn-common/ctx-test-vrf.json": { "imdata": [] },
+        "/api/mo/uni/tn-common/out-test-l3out.json": { "imdata": [] },
+        "/api/node/mo/uni/tn-common.json?query-target=subtree&target-subtree-class=tagInst": { "imdata": [] },
+        "/api/node/mo/uni/tn-common.json?query-target=subtree&target-subtree-class=tagAnnotation": { "imdata": [] }
+    },
+    "deletes": [
+        "/api/mo/uni/infra/vlanns-[cluster1-pool]-static.json",
+        "/api/mo/uni/vmmp-OpenShift/dom-cluster1.json",
+        "/api/mo/uni/vmmp-VMware/dom-test-vmm/usrcustomaggr-cluster1.json",
+        "/api/mo/uni/infra/attentp-test-aep/rsdomP-[uni/vmmp-OpenShift/dom-cluster1].json",
+        "/api/mo/uni/infra/attentp-test-aep/rsdomP-[uni/phys-cluster1-pdom].json",
+        "/api/mo/uni/infra/attentp-test-aep/gen-default/rsfuncToEpg-[uni/tn-shared-tenant/ap-aci-containers-cluster1/epg-aci-containers-nodes].json",
+        "/api/mo/uni/tn-common/flt-cluster1-allow-all-filter.json",
+        "/api/mo/uni/tn-common/brc-cluster1-l3out-allow-all.json",
+        "/api/node/mo/uni/userext/user-cluster1.json",
+        "/api/node/mo/uni/userext/user-cluster1.json",
+        "/api/node/mo/uni/tn-shared-tenant/brc-aci-containers-cluster1-openshift-monitoring.json",
+        "/api/node/mo/uni/tn-shared-tenant/brc-aci-containers-cluster1-openshift-svc-catalog.json",
+        "/api/node/mo/uni/infra/vlanns-[test-pool]-static/from-[vlan-4001]-to-[vlan-4001].json",
+        "/api/node/mo/uni/tn-shared-tenant/ap-aci-containers-cluster1/epg-aci-containers-nodes.json",
+        "/api/mo/uni/phys-cluster1-pdom.json",
+        "/api/mo/uni/tn-common/out-test-l3out/instP-default/rsprov-cluster1-l3out-allow-all.json",
+        "/api/mo/uni/infra/maddrns-cluster1-mpool.json",
+        "/api/node/mo/comp/prov-OpenShift/ctrlr-[cluster1]-cluster1/injcont/info.json"
+    ]
+}

--- a/provision/testdata/test_unprovision_shared_tenant_for_old_acc_provision.json
+++ b/provision/testdata/test_unprovision_shared_tenant_for_old_acc_provision.json
@@ -1,0 +1,37 @@
+{
+    "gets": {
+        "/api/mo/uni/tn-shared-tenant.json?query-target=children": {
+            "imdata": [
+                { "vzBrCP": { "attributes": { "dn": "uni/tn-shared-tenant/brc-openshift-monitoring", "name": "openshift-monitoring", "annotation": "orchestrator:aci-containers-controller" } } },
+                { "vzBrCP": { "attributes": { "dn": "uni/tn-shared-tenant/brc-openshift-svc-catalog", "name": "openshift-svc-catalog", "annotation": "orchestrator:aci-containers-controller" } } }
+            ]
+        },
+        "/api/mo/uni/tn-shared-tenant.json": { "imdata": [ { "fvTenant": { "attributes": { "dn": "uni/tn-shared-tenant", "name": "shared-tenant" } } } ] },
+        "/api/node/mo/uni/vmmp-VMware/dom-test-vmm.json?query-target=children&target-subtree-class=infraRsVlanNs": { "imdata": [ { "infraRsVlanNs": { "attributes": { "tDn": "uni/infra/vlanns-[test-pool]-static" } } } ] },
+        "/api/node/class/firmwareCtrlrRunning.json": { "imdata": [ { "firmwareCtrlrRunning": { "attributes": { "version": "6.1(1.1)" } } } ] },
+        "/api/node/mo/uni/infra/attentp-default/provacc/rsfuncToEpg-[uni/tn-infra/ap-access/epg-default].json": { "imdata": [] },
+        "/api/mo/uni/infra/attentp-test-aep.json": { "imdata": [] },
+        "/api/mo/uni/tn-common/ctx-test-vrf.json": { "imdata": [] },
+        "/api/mo/uni/tn-common/out-test-l3out.json": { "imdata": [] },
+        "/api/node/mo/uni/tn-common.json?query-target=subtree&target-subtree-class=tagInst": { "imdata": [] },
+        "/api/node/mo/uni/tn-common.json?query-target=subtree&target-subtree-class=tagAnnotation": { "imdata": [] }
+    },
+    "deletes": [
+        "/api/mo/uni/infra/vlanns-[cluster1-pool]-static.json",
+        "/api/mo/uni/vmmp-OpenShift/dom-cluster1.json",
+        "/api/mo/uni/vmmp-VMware/dom-test-vmm/usrcustomaggr-cluster1.json",
+        "/api/mo/uni/infra/attentp-test-aep/rsdomP-[uni/vmmp-OpenShift/dom-cluster1].json",
+        "/api/mo/uni/infra/attentp-test-aep/rsdomP-[uni/phys-cluster1-pdom].json",
+        "/api/mo/uni/infra/attentp-test-aep/gen-default/rsfuncToEpg-[uni/tn-shared-tenant/ap-aci-containers-cluster1/epg-aci-containers-nodes].json",
+        "/api/mo/uni/tn-common/flt-cluster1-allow-all-filter.json",
+        "/api/mo/uni/tn-common/brc-cluster1-l3out-allow-all.json",
+        "/api/node/mo/uni/userext/user-cluster1.json",
+        "/api/node/mo/uni/userext/user-cluster1.json",
+        "/api/node/mo/uni/infra/vlanns-[test-pool]-static/from-[vlan-4001]-to-[vlan-4001].json",
+        "/api/node/mo/uni/tn-shared-tenant/ap-aci-containers-cluster1/epg-aci-containers-nodes.json",
+        "/api/mo/uni/phys-cluster1-pdom.json",
+        "/api/mo/uni/tn-common/out-test-l3out/instP-default/rsprov-cluster1-l3out-allow-all.json",
+        "/api/mo/uni/infra/maddrns-cluster1-mpool.json",
+        "/api/node/mo/comp/prov-OpenShift/ctrlr-[cluster1]-cluster1/injcont/info.json"
+    ]
+}

--- a/provision/testdata/with_new_naming_convention_dockerucp.apic.txt
+++ b/provision/testdata/with_new_naming_convention_dockerucp.apic.txt
@@ -897,7 +897,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "ucp-ui-port",
+                                    "name": "aci-containers-kube-ucp-ui-port",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "443",
@@ -911,7 +911,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "ucp-tls-port",
+                                    "name": "aci-containers-kube-ucp-tls-port",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "12376",
@@ -925,7 +925,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "ucp-kubelet-port",
+                                    "name": "aci-containers-kube-ucp-kubelet-port",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "10250",
@@ -939,7 +939,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "ucp-misc-ports",
+                                    "name": "aci-containers-kube-ucp-misc-ports",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "12378",

--- a/provision/testdata/with_new_naming_convention_openshift.apic.txt
+++ b/provision/testdata/with_new_naming_convention_openshift.apic.txt
@@ -322,7 +322,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -330,7 +330,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -436,7 +436,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -444,7 +444,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -452,7 +452,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -551,7 +551,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-svc-catalog",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-svc-catalog",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -559,7 +559,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -707,7 +707,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -715,7 +715,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -797,7 +797,7 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -805,7 +805,7 @@ None
                                     {
                                         "fvRsProv": {
                                             "attributes": {
-                                                "tnVzBrCPName": "openshift-monitoring",
+                                                "tnVzBrCPName": "aci-containers-kube-openshift-monitoring",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1295,14 +1295,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-svc-catalog",
+                        "name": "aci-containers-kube-openshift-svc-catalog",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-subj",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1311,7 +1311,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-svc-catalog-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-svc-catalog-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1325,14 +1325,14 @@ None
             {
                 "vzBrCP": {
                     "attributes": {
-                        "name": "openshift-monitoring",
+                        "name": "aci-containers-kube-openshift-monitoring",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-subj",
+                                    "name": "aci-containers-kube-openshift-monitoring-subj",
                                     "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne",
                                     "annotation": "orchestrator:aci-containers-controller"
@@ -1341,7 +1341,7 @@ None
                                     {
                                         "vzRsSubjFiltAtt": {
                                             "attributes": {
-                                                "tnVzFilterName": "openshift-monitoring-filter",
+                                                "tnVzFilterName": "aci-containers-kube-openshift-monitoring-filter",
                                                 "annotation": "orchestrator:aci-containers-controller"
                                             }
                                         }
@@ -1355,14 +1355,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-svc-catalog-filter",
+                        "name": "aci-containers-kube-openshift-svc-catalog-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-svc-catalog-2379",
+                                    "name": "aci-containers-kube-openshift-svc-catalog-2379",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "2379",
@@ -1379,14 +1379,14 @@ None
             {
                 "vzFilter": {
                     "attributes": {
-                        "name": "openshift-monitoring-filter",
+                        "name": "aci-containers-kube-openshift-monitoring-filter",
                         "annotation": "orchestrator:aci-containers-controller"
                     },
                     "children": [
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9091",
+                                    "name": "aci-containers-kube-openshift-monitoring-9091",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9091",
@@ -1400,7 +1400,7 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "name": "openshift-monitoring-9094",
+                                    "name": "aci-containers-kube-openshift-monitoring-9094",
                                     "etherT": "ip",
                                     "prot": "tcp",
                                     "dFromPort": "9094",


### PR DESCRIPTION
Stale APIC resources, particularly contracts (`brc-`) specific to OpenShift flavors, were not being removed during unprovisioning.

This issue was most apparent when multiple OCP clusters shared a pre-existing tenant, as the flavor-defined resources were created without a unique, cluster-specific prefix, making them impossible to distinguish and safely delete.

This commit fixes the issue by prefixing these OpenShift resources with `ocp-{system_id}-` during provisioning, ensuring they are uniquely identifiable.

Two unit tests for these changes are also added.

(cherry picked from commit 622577842e27462ab842211ce2210f217873d86c)