### PR TITLE
[mmr-6.1.1] [Backport] Add support for RKE2-kubernetes-1.34 flavor

### DIFF
--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -7620,6 +7620,60 @@ flavors:
             prot: tcp
             stateful: "no"
     order: 63
+  RKE2-kubernetes-1.34:
+    desc: Rancher Kubernetes Engine Government kubernetes version 1.34
+    default_version: 6.1
+    config:
+      rke_config:
+        contracts:
+          - name: prometheus-monitoring
+            provided: ["aci-containers-system"]
+            consumed: ["aci-containers-istio"]
+            filter: "access-prometheus"
+        filters:
+          - name: access-prometheus
+            items:
+              - name: http
+                range: [8080, 8080]
+                etherT: ip
+                prot: tcp
+                stateful: "no"
+      kube_config:
+        allow_kube_api_default_epg: True
+        use_host_netns_volume: True
+        allow_pods_external_access: True
+        use_cnideploy_initcontainer: True
+      aci_config:
+        items:
+          - name: metrics-kubelet
+            range: [10250, 10250]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+          - name: monitoring-node
+            range: [9796, 9796]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+          - name: monitoring-ingress
+            range: [10254, 10254]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+          - name: rancher-ui
+            range: [443, 443]
+            etherT: ip
+            prot: tcp
+            stateful: "no"
+        vmm_domain:
+          type: Kubernetes
+          injected_cluster_type: RKE2
+          injected_cluster_provider: Rancher
+      istio_config:
+        install_istio: False
+    status: null
+    hidden: false
+    order: 88
   RKE2-kubernetes-1.33:
     desc: Rancher Kubernetes Engine Government kubernetes version 1.33
     default_version: 6.1
@@ -7673,7 +7727,7 @@ flavors:
         install_istio: False
     status: null
     hidden: false
-    order: 88
+    order: 89
   RKE2-kubernetes-1.32:
     desc: Rancher Kubernetes Engine Government kubernetes version 1.32
     default_version: 6.1
@@ -7727,7 +7781,7 @@ flavors:
         install_istio: False
     status: null
     hidden: false
-    order: 89
+    order: 90
   RKE2-kubernetes-1.31:
     desc: Rancher Kubernetes Engine Government kubernetes version 1.31
     default_version: 6.1
@@ -7780,8 +7834,8 @@ flavors:
       istio_config:
         install_istio: False
     status: null
-    hidden: false
-    order: 90
+    hidden: true
+    order: 91
   RKE2-kubernetes-1.30:
     desc: Rancher Kubernetes Engine Government kubernetes version 1.30
     default_version: 6.1
@@ -7835,7 +7889,7 @@ flavors:
         install_istio: False
     status: null
     hidden: true
-    order: 91
+    order: 92
   RKE2-kubernetes-1.29:
     desc: Rancher Kubernetes Engine Government kubernetes version 1.29
     default_version: 6.1
@@ -7889,7 +7943,7 @@ flavors:
         install_istio: False
     status: null
     hidden: true
-    order: 92
+    order: 93
   RKE2-kubernetes-1.28:
     desc: Rancher Kubernetes Engine Government kubernetes version 1.28
     default_version: 6.1
@@ -7943,7 +7997,7 @@ flavors:
         install_istio: False
     status: null
     hidden: true
-    order: 93
+    order: 94
   RKE2-kubernetes-1.27:
     desc: Rancher Kubernetes Engine Government kubernetes version 1.27
     default_version: 6.1
@@ -7997,7 +8051,7 @@ flavors:
         install_istio: False
     status: null
     hidden: true
-    order: 94
+    order: 95
   RKE2-kubernetes-1.26:
     desc: Rancher Kubernetes Engine Government kubernetes version 1.26
     default_version: 6.1
@@ -8051,7 +8105,7 @@ flavors:
         install_istio: False
     status: null
     hidden: true
-    order: 95
+    order: 96
   RKE2-kubernetes-1.25:
     desc: Rancher Kubernetes Engine Government kubernetes version 1.25
     default_version: 6.1
@@ -8105,7 +8159,7 @@ flavors:
         install_istio: False
     status: null
     hidden: true
-    order: 96
+    order: 97
   RKE2-kubernetes-1.24:
     desc: Rancher Kubernetes Engine Government kubernetes version 1.24
     default_version: 6.1
@@ -8159,7 +8213,7 @@ flavors:
         install_istio: False
     status: null
     hidden: true
-    order: 97
+    order: 98
   RKE-1.8.3:
     desc: Rancher Kubernetes Engine min version 1.8.3
     default_version: 6.1
@@ -8215,7 +8269,7 @@ flavors:
         disable: False
     hidden: False
     status: Experimental
-    order: 98
+    order: 99
   RKE-1.7.7:
     desc: Rancher Kubernetes Engine min version 1.7.7
     default_version: 6.1
@@ -8271,7 +8325,7 @@ flavors:
         disable: False
     hidden: False
     status: Experimental
-    order: 99
+    order: 100
   RKE-1.7.2:
     desc: Rancher Kubernetes Engine min version 1.7.2
     default_version: 6.1
@@ -8327,7 +8381,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 100
+    order: 101
   RKE-1.7.1:
     desc: Rancher Kubernetes Engine min version 1.7.1
     default_version: 6.1
@@ -8383,7 +8437,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 101
+    order: 102
   RKE-1.6.10:
     desc: Rancher Kubernetes Engine min version 1.6.10
     default_version: 6.1
@@ -8439,7 +8493,7 @@ flavors:
         disable: False
     hidden: False
     status: Experimental
-    order: 102
+    order: 103
   RKE-1.6.6:
     desc: Rancher Kubernetes Engine min version 1.6.6
     default_version: 6.1
@@ -8495,7 +8549,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 103
+    order: 104
   RKE-1.6.5:
     desc: Rancher Kubernetes Engine min version 1.6.5
     default_version: 6.1
@@ -8551,7 +8605,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 104
+    order: 105
   RKE-1.6.3:
     desc: Rancher Kubernetes Engine min version 1.6.3
     default_version: 6.1
@@ -8607,7 +8661,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 105
+    order: 106
   RKE-1.6.2:
     desc: Rancher Kubernetes Engine min version 1.6.2
     default_version: 6.1
@@ -8663,7 +8717,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 106
+    order: 107
   RKE-1.6.0:
     desc: Rancher Kubernetes Engine min version 1.6.0
     default_version: 6.1
@@ -8719,7 +8773,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 107
+    order: 108
   RKE-1.5.14:
     desc: Rancher Kubernetes Engine min version 1.5.14
     default_version: 6.1
@@ -8775,7 +8829,7 @@ flavors:
         disable: False
     hidden: False
     status: null
-    order: 108
+    order: 109
   RKE-1.5.13:
     desc: Rancher Kubernetes Engine min version 1.5.13
     default_version: 6.1
@@ -8831,7 +8885,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 109
+    order: 110
   RKE-1.5.11:
     desc: Rancher Kubernetes Engine min version 1.5.11
     default_version: 6.1
@@ -8887,7 +8941,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 110
+    order: 111
   RKE-1.5.6:
     desc: Rancher Kubernetes Engine min version 1.5.6
     default_version: 6.1
@@ -8943,7 +8997,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 111
+    order: 112
   RKE-1.5.3:
     desc: Rancher Kubernetes Engine min version 1.5.3
     default_version: 6.1
@@ -8999,7 +9053,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 112
+    order: 113
   RKE-1.4.20:
     desc: Rancher Kubernetes Engine min version 1.4.20
     default_version: 6.1
@@ -9055,7 +9109,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 113
+    order: 114
   RKE-1.4.16:
     desc: Rancher Kubernetes Engine min version 1.4.16
     default_version: 6.1
@@ -9111,7 +9165,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 114
+    order: 115
   RKE-1.4.13:
     desc: Rancher Kubernetes Engine min version 1.4.13
     default_version: 6.1
@@ -9167,7 +9221,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 115
+    order: 116
   RKE-1.4.9:
     desc: Rancher Kubernetes Engine min version 1.4.9
     default_version: 6.1
@@ -9223,7 +9277,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 116
+    order: 117
   RKE-1.4.6:
     desc: Rancher Kubernetes Engine min version 1.4.6
     default_version: 6.1
@@ -9279,7 +9333,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 117
+    order: 118
   RKE-1.3.24:
     desc: Rancher Kubernetes Engine min version 1.3.24
     default_version: 6.1
@@ -9335,7 +9389,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 118
+    order: 119
   RKE-1.3.21:
     desc: Rancher Kubernetes Engine min version 1.3.21
     default_version: 6.1
@@ -9391,7 +9445,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 119
+    order: 120
   RKE-1.3.20:
     desc: Rancher Kubernetes Engine min version 1.3.20
     default_version: 6.1
@@ -9447,7 +9501,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 120
+    order: 121
   RKE-1.3.18:
     desc: Rancher Kubernetes Engine min version 1.3.18
     default_version: 6.1
@@ -9503,7 +9557,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 121
+    order: 122
   RKE-1.3.17:
     desc: Rancher Kubernetes Engine min version 1.3.17
     default_version: 6.1
@@ -9559,7 +9613,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 122
+    order: 123
   RKE-1.3.13:
     desc: Rancher Kubernetes Engine min version 1.3.13
     default_version: 6.1
@@ -9615,7 +9669,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 123
+    order: 124
   RKE-1.2.3:
     desc: Rancher Kubernetes Engine min version 1.2.3
     default_version: 6.1
@@ -9671,7 +9725,7 @@ flavors:
         disable: False
     hidden: True
     status: null
-    order: 124
+    order: 125
   k8s-overlay:
     desc: Kubernetes basic overlay
     default_version: 6.1
@@ -9717,7 +9771,7 @@ flavors:
         enable: true
     status: Experimental
     hidden: true
-    order: 125
+    order: 126
   calico-3.26.3:
     desc: calico-3.26.3
     default_version: 6.1.3.3
@@ -9726,7 +9780,7 @@ flavors:
       template_generator: generate_calico_deployment_files
     hidden: False
     status: null
-    order: 126
+    order: 127
   openshift-sdn-ovn-baremetal:
     desc: Chained CNI for Red Hat OpenShift Container Platform 4.12 on Baremetal
     default_version: 6.1
@@ -9755,7 +9809,7 @@ flavors:
         kube_default_provide_kube_api: True
     status: null
     hidden: false
-    order: 127
+    order: 128
   openshift-vmm-lite-baremetal:
     desc: VMM lite for Red Hat OpenShift Container Platform 4.18 on Baremetal
     default_version: 6.1
@@ -9772,7 +9826,7 @@ flavors:
         kube_default_provide_kube_api: True
     status: null
     hidden: false
-    order: 128
+    order: 129
   k8s-aci-cilium:
     desc: Chained CNI for Kubernertes
     default_version: 6.1
@@ -9784,7 +9838,7 @@ flavors:
         disable: False
     hidden: False
     status: Experimental
-    order: 129
+    order: 130
   openshift-4.14-aci-cilium-esx:
     desc: Chained CNI for Red Hat OpenShift Container Platform 4.14 on ESX
     default_version: 6.1
@@ -9901,4 +9955,4 @@ flavors:
         disable: True
     status: Experimental
     hidden: false
-    order: 130
+    order: 131

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -1895,6 +1895,18 @@ def test_flavor_RKE2_kubernetes_1_33_base():
 
 
 @in_testdir
+def test_flavor_RKE2_kubernetes_1_34_base():
+    run_provision(
+        "flavor_RKE2_kubernetes_1_34.inp.yaml",
+        "flavor_RKE2_kubernetes_1_34.kube.yaml",
+        None,
+        None,
+        "flavor_RKE2_kubernetes_1_34.apic.txt",
+        overrides={"flavor": "RKE2-kubernetes-1.34"}
+    )
+
+
+@in_testdir
 def test_flavor_RKE_1_2_3_base():
     run_provision(
         "flavor_RKE_1_2_3.inp.yaml",

--- a/provision/testdata/flavor_RKE2_kubernetes_1_34.apic.txt
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_34.apic.txt
@@ -1,0 +1,1353 @@
+/api/mo/uni/infra/vlanns-[rke2-pool]-static.json
+{
+    "fvnsVlanInstP": {
+        "attributes": {
+            "name": "rke2-pool",
+            "allocMode": "static",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvnsEncapBlk": {
+                    "attributes": {
+                        "allocMode": "static",
+                        "from": "vlan-4001",
+                        "to": "vlan-4001",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "fvnsEncapBlk": {
+                    "attributes": {
+                        "allocMode": "static",
+                        "from": "vlan-4003",
+                        "to": "vlan-4003",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra/maddrns-rke2-mpool.json
+{
+    "fvnsMcastAddrInstP": {
+        "attributes": {
+            "name": "rke2-mpool",
+            "dn": "uni/infra/maddrns-rke2-mpool",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvnsMcastAddrBlk": {
+                    "attributes": {
+                        "from": "225.2.1.1",
+                        "to": "225.2.255.255",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/vmmp-Kubernetes/dom-rke2.json
+{
+    "vmmDomP": {
+        "attributes": {
+            "name": "rke2",
+            "mode": "rancher",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "vmmCtrlrP": {
+                    "attributes": {
+                        "name": "rke2",
+                        "mode": "rancher",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "vmmRsDomMcastAddrNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/maddrns-rke2-mpool",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra.json
+{
+    "infraAttEntityP": {
+        "attributes": {
+            "name": "rke2-aep",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsDomP": {
+                    "attributes": {
+                        "tDn": "uni/vmmp-Kubernetes/dom-rke2",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "infraRsDomP": {
+                    "attributes": {
+                        "tDn": "uni/phys-rke2-pdom",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            },
+            {
+                "infraProvAcc": {
+                    "attributes": {
+                        "name": "provacc",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "infraRsFuncToEpg": {
+                                "attributes": {
+                                    "encap": "vlan-4093",
+                                    "mode": "regular",
+                                    "tDn": "uni/tn-infra/ap-access/epg-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "dhcpInfraProvP": {
+                                "attributes": {
+                                    "mode": "controller",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "infraGeneric": {
+                    "attributes": {
+                        "name": "default",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "infraRsFuncToEpg": {
+                                "attributes": {
+                                    "tDn": "uni/tn-rke2/ap-aci-containers-rke2/epg-aci-containers-nodes",
+                                    "encap": "vlan-4001",
+                                    "mode": "regular",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/infra/attentp-rke2-aep/rsdomP-[uni/vmmp-Kubernetes/dom-rke2].json
+None
+/api/mo/uni/infra/attentp-rke2-aep/rsdomP-[uni/phys-rke2-pdom].json
+None
+/api/mo/uni/infra/attentp-rke2-aep/gen-default/rsfuncToEpg-[uni/tn-rke2/ap-aci-containers-rke2/epg-aci-containers-nodes].json
+None
+/api/mo/uni/infra.json
+{
+    "infraSetPol": {
+        "attributes": {
+            "opflexpAuthenticateClients": "no",
+            "opflexpUseSsl": "yes",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/node/mo/comp/prov-Kubernetes/ctrlr-[rke2]-rke2/injcont/info.json
+{
+    "vmmInjectedClusterInfo": {
+        "attributes": {
+            "name": "rke2",
+            "accountName": "rke2",
+            "type": "RKE2",
+            "provider": "Rancher"
+        },
+        "children": [
+            {
+                "vmmInjectedClusterDetails": {
+                    "attributes": {
+                        "accProvisionInput": "aci_config:\n  system_id: rke2\n  use_legacy_kube_naming_convention: false\n  apic_hosts:\n  - 10.30.120.100\n  - 10.30.120.101\n  - 10.30.120.102\n  apic_login:\n    username: admin\n  apic_version: '5.1'\n  aep: rke2-aep\n  vrf:\n    name: rke2\n    tenant: common\n  l3out:\n    name: l3out\n    external_networks:\n    - default\n    - test_ext_net\n  sync_login:\n    certfile: user.crt\n    keyfile: user.key\n  vmm_domain:\n    encap_type: vxlan\n    mcast_range:\n      start: 225.2.1.1\n      end: 225.2.255.255\n  opflex_device_reconnect_wait_timeout: 10\nnet_config:\n  node_subnet: 10.1.0.1/16\n  pod_subnet: 10.2.0.1/16\n  extern_dynamic: 10.3.0.1/24\n  extern_static: 10.4.0.1/24\n  node_svc_subnet: 10.5.0.1/24\n  pod_subnet_chunk_size: 256\n  kubeapi_vlan: 4001\n  service_vlan: 4003\n  infra_vlan: 4093\nlogging:\n  controller_log_level: info\n  hostagent_log_level: info\n  opflexagent_log_level: info\nrke2_config:\n  logging_namespace: cattle-logging-system\n  monitoring_namespace: cattle-monitoring-system\nregistry:\n  image_prefix: quay.io/noiro\nkube_config:\n  use_system_node_priority_class: true\n  aci_containers_controller_memory_request: 256Mi\n  aci_containers_controller_memory_limit: 2Gi\n  aci_containers_host_memory_request: 200Mi\n  aci_containers_host_memory_limit: 2Gi\n  mcast_daemon_memory_request: 300Mi\n  mcast_daemon_memory_limit: 1Gi\n  opflex_agent_memory_request: 256Mi\n  opflex_agent_memory_limit: 2Gi\n  acc_provision_operator_memory_request: 256Mi\n  acc_provision_operator_memory_limit: 1Gi\n  aci_containers_operator_memory_request: 256Mi\n  aci_containers_operator_memory_limit: 3Gi\n  ovs_memory_request: 256Mi\n  ovs_memory_limit: 2Gi\n",
+                        "userKey": "dummy\n",
+                        "userCert": "dummy\n"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common.json
+{
+    "fvTenant": {
+        "attributes": {
+            "name": "common",
+            "dn": "uni/tn-common"
+        },
+        "children": [
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "rke2-allow-all-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "allow-all",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "rke2-l3out-allow-all",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "rke2-allow-all-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common/flt-rke2-allow-all-filter.json
+None
+/api/mo/uni/tn-common/brc-rke2-l3out-allow-all.json
+None
+/api/mo/uni/tn-rke2.json
+{
+    "fvTenant": {
+        "attributes": {
+            "name": "rke2",
+            "dn": "uni/tn-rke2",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "fvAp": {
+                    "attributes": {
+                        "name": "aci-containers-rke2",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-default",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke2",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-istio",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke2-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "rke2-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-prometheus-opflex-agent",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-system",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "rke2-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke2",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke2-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-prometheus-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-prometheus-opflex-agent",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-nodes",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "rke2-l3out-allow-all",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke2",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke2-node-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "encap": "vlan-4001",
+                                                "tDn": "uni/phys-rke2-pdom",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-prometheus-opflex-agent",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "fvAEPg": {
+                                "attributes": {
+                                    "name": "aci-containers-istio",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-istio",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-api",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-icmp",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsProv": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-health-check",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-dns",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsDomAtt": {
+                                            "attributes": {
+                                                "tDn": "uni/vmmp-Kubernetes/dom-rke2",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsBd": {
+                                            "attributes": {
+                                                "tnFvBDName": "aci-containers-rke2-pod-bd",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "fvRsCons": {
+                                            "attributes": {
+                                                "tnVzBrCPName": "aci-containers-rke2-prometheus-monitoring",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "fvBD": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-node-bd",
+                        "arpFlood": "yes",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvRsCtx": {
+                                "attributes": {
+                                    "tnFvCtxName": "rke2",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsBDToOut": {
+                                "attributes": {
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "10.1.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "fvBD": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-pod-bd",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "fvRsCtx": {
+                                "attributes": {
+                                    "tnFvCtxName": "rke2",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvRsBDToOut": {
+                                "attributes": {
+                                    "tnL3extOutName": "l3out",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "fvSubnet": {
+                                "attributes": {
+                                    "ip": "10.2.0.1/16",
+                                    "scope": "public",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-icmp-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "icmp",
+                                    "etherT": "ipv4",
+                                    "prot": "icmp",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "icmp6",
+                                    "etherT": "ipv6",
+                                    "prot": "icmpv6",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-health-check-filter-in",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "health-check",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-health-check-filter-out",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "health-check",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "stateful": "no",
+                                    "tcpRules": "est",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-dns-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "dns-udp",
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-api-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "6443",
+                                    "dToPort": "6443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "8443",
+                                    "dToPort": "8443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-rke2-metrics-kubelet",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "10250",
+                                    "dToPort": "10250",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-rke2-monitoring-node",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9796",
+                                    "dToPort": "9796",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-rke2-monitoring-ingress",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "10254",
+                                    "dToPort": "10254",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "aci-containers-rke2-rancher-ui",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "443",
+                                    "dToPort": "443",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-istio-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-9080",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "sFromPort": "9080",
+                                    "sToPort": "9080",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-mixer-9090:91",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9090",
+                                    "dToPort": "9091",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-prometheus-15090",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "sFromPort": "15090",
+                                    "sToPort": "15090",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot-15010:12",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15010",
+                                    "dToPort": "15012",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        },
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "istio-pilot2-15014",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "15014",
+                                    "dToPort": "15014",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-api",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "aci-containers-api-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke2-api-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-health-check",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "health-check-subj",
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzOutTerm": {
+                                            "attributes": {
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            },
+                                            "children": [
+                                                {
+                                                    "vzRsFiltAtt": {
+                                                        "attributes": {
+                                                            "tnVzFilterName": "aci-containers-rke2-health-check-filter-out",
+                                                            "annotation": "orchestrator:aci-containers-controller"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "vzInTerm": {
+                                            "attributes": {
+                                                "name": "",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            },
+                                            "children": [
+                                                {
+                                                    "vzRsFiltAtt": {
+                                                        "attributes": {
+                                                            "tnVzFilterName": "aci-containers-rke2-health-check-filter-in",
+                                                            "annotation": "orchestrator:aci-containers-controller"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-dns",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke2-dns-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-icmp",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke2-icmp-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-istio",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "istio-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke2-istio-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-prometheus-monitoring",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "aci-containers-rke2-prometheus-monitoring-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke2-access-prometheus",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-access-prometheus",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "http",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "8080",
+                                    "dToPort": "8080",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzFilter": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-prometheus-opflex-agent-filter",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzEntry": {
+                                "attributes": {
+                                    "name": "prometheus-opflex-agent",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
+                                    "dFromPort": "9612",
+                                    "dToPort": "9612",
+                                    "stateful": "no",
+                                    "tcpRules": "",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "vzBrCP": {
+                    "attributes": {
+                        "name": "aci-containers-rke2-prometheus-opflex-agent",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "vzSubj": {
+                                "attributes": {
+                                    "name": "prometheus-opflex-agent-subj",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                },
+                                "children": [
+                                    {
+                                        "vzRsSubjFiltAtt": {
+                                            "attributes": {
+                                                "tnVzFilterName": "aci-containers-rke2-prometheus-opflex-agent-filter",
+                                                "annotation": "orchestrator:aci-containers-controller"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/phys-rke2-pdom.json
+{
+    "physDomP": {
+        "attributes": {
+            "dn": "uni/phys-rke2-pdom",
+            "name": "rke2-pdom",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "infraRsVlanNs": {
+                    "attributes": {
+                        "tDn": "uni/infra/vlanns-[rke2-pool]-static",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-default.json
+{
+    "fvRsProv": {
+        "attributes": {
+            "matchT": "AtleastOne",
+            "tnVzBrCPName": "rke2-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-default/rsprov-rke2-l3out-allow-all.json
+None
+/api/mo/uni/tn-common/out-l3out/instP-test_ext_net.json
+{
+    "fvRsProv": {
+        "attributes": {
+            "matchT": "AtleastOne",
+            "tnVzBrCPName": "rke2-l3out-allow-all",
+            "annotation": "orchestrator:aci-containers-controller"
+        }
+    }
+}
+/api/mo/uni/tn-common/out-l3out/instP-test_ext_net/rsprov-rke2-l3out-allow-all.json
+None
+/api/node/mo/uni/userext/user-rke2.json
+{
+    "aaaUser": {
+        "attributes": {
+            "name": "rke2",
+            "accountStatus": "active",
+            "pwd": "NotRandom!",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "aaaUserDomain": {
+                    "attributes": {
+                        "name": "all",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    },
+                    "children": [
+                        {
+                            "aaaUserRole": {
+                                "attributes": {
+                                    "name": "admin",
+                                    "privType": "writePriv",
+                                    "annotation": "orchestrator:aci-containers-controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+/api/node/mo/uni/userext/user-rke2.json
+{
+    "aaaUser": {
+        "attributes": {
+            "name": "rke2",
+            "annotation": "orchestrator:aci-containers-controller"
+        },
+        "children": [
+            {
+                "aaaUserCert": {
+                    "attributes": {
+                        "name": "rke2.crt",
+                        "data": "dummy\n",
+                        "annotation": "orchestrator:aci-containers-controller"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/provision/testdata/flavor_RKE2_kubernetes_1_34.inp.yaml
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_34.inp.yaml
@@ -1,0 +1,69 @@
+aci_config:
+  system_id: rke2
+  use_legacy_kube_naming_convention: False
+  apic_hosts:
+    - 10.30.120.100
+    - 10.30.120.101
+    - 10.30.120.102
+  apic_login:
+    username: admin
+    password: dummy
+  apic_version: "5.1"
+  aep: rke2-aep
+  vrf:
+    name: rke2
+    tenant: common
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+    - test_ext_net
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  opflex_device_reconnect_wait_timeout: 10
+
+net_config:
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  pod_subnet_chunk_size: 256
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info
+
+rke2_config:
+  logging_namespace: "cattle-logging-system"
+  monitoring_namespace: "cattle-monitoring-system"
+
+registry:
+  image_prefix: quay.io/noiro
+
+kube_config:
+  use_system_node_priority_class: true
+  aci_containers_controller_memory_request: "256Mi"
+  aci_containers_controller_memory_limit: "2Gi"
+  aci_containers_host_memory_request: "200Mi"
+  aci_containers_host_memory_limit: "2Gi"
+  mcast_daemon_memory_request: "300Mi"
+  mcast_daemon_memory_limit: "1Gi"
+  opflex_agent_memory_request: "256Mi"
+  opflex_agent_memory_limit: "2Gi"
+  acc_provision_operator_memory_request: "256Mi"
+  acc_provision_operator_memory_limit: "1Gi"
+  aci_containers_operator_memory_request: "256Mi"
+  aci_containers_operator_memory_limit: "3Gi"
+  ovs_memory_request: "256Mi"
+  ovs_memory_limit: "2Gi"

--- a/provision/testdata/flavor_RKE2_kubernetes_1_34.kube.yaml
+++ b/provision/testdata/flavor_RKE2_kubernetes_1_34.kube.yaml
@@ -1,0 +1,2837 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: acicontainersoperators.aci.ctrl
+spec:
+  group: aci.ctrl
+  names:
+    kind: AciContainersOperator
+    listKind: AciContainersOperatorList
+    plural: acicontainersoperators
+    singular: acicontainersoperator
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: acicontainersoperator owns the lifecycle of ACI objects in the cluster
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AciContainersOperatorSpec defines the desired spec for ACI Objects
+            properties:
+              flavor:
+                type: string
+              config:
+                type: string
+            type: object
+          status:
+            description: AciContainersOperatorStatus defines the successful completion of AciContainersOperator
+            properties:
+              status:
+                type: boolean
+            type: object
+        required:
+        - spec
+        type: object
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  annotations:
+    openshift.io/node-selector: ''
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nodepodifs.aci.aw
+spec:
+  group: aci.aw
+  names:
+    kind: NodePodIF
+    listKind: NodePodIFList
+    plural: nodepodifs
+    singular: nodepodif
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            properties:
+              podifs:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    containerID:
+                      type: string
+                    epg:
+                      type: string
+                    ifname:
+                      type: string
+                    ipaddr:
+                      type: string
+                    macaddr:
+                      type: string
+                    podname:
+                      type: string
+                    podns:
+                      type: string
+                    vtep:
+                      type: string
+        required:
+        - spec
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatglobalinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatGlobalInfo
+    listKind: SnatGlobalInfoList
+    plural: snatglobalinfos
+    singular: snatglobalinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: SnatGlobalInfo is the Schema for the snatglobalinfos API
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              globalInfos:
+                additionalProperties:
+                  items:
+                    properties:
+                      macAddress:
+                        type: string
+                      portRanges:
+                        items:
+                          properties:
+                            end:
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            start:
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          type: object
+                        type: array
+                      snatIp:
+                        type: string
+                      snatIpUid:
+                        type: string
+                      snatPolicyName:
+                        type: string
+                    required:
+                    - macAddress
+                    - portRanges
+                    - snatIp
+                    - snatIpUid
+                    - snatPolicyName
+                    type: object
+                  type: array
+                type: object
+            required:
+            - globalInfos
+            type: object
+          status:
+            description: SnatGlobalInfoStatus defines the observed state of SnatGlobalInfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatlocalinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatLocalInfo
+    listKind: SnatLocalInfoList
+    plural: snatlocalinfos
+    singular: snatlocalinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SnatLocalInfoSpec defines the desired state of SnatLocalInfo
+            properties:
+              localInfos:
+                items:
+                  properties:
+                    podName:
+                      type: string
+                    podNamespace:
+                      type: string
+                    podUid:
+                      type: string
+                    snatPolicies:
+                      items:
+                        properties:
+                          destIp:
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            type: string
+                          snatIp:
+                            type: string
+                        required:
+                        - destIp
+                        - name
+                        - snatIp
+                        type: object
+                      type: array
+                  required:
+                  - podName
+                  - podNamespace
+                  - podUid
+                  - snatPolicies
+                  type: object
+                type: array
+            required:
+            - localInfos
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: snatpolicies.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: SnatPolicy
+    listKind: SnatPolicyList
+    plural: snatpolicies
+    singular: snatpolicy
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            properties:
+              selector:
+                type: object
+                properties:
+                  labels:
+                    type: object
+                    description: 'Selection of Pods'
+                    properties:
+                    additionalProperties:
+                      type: string
+                  namespace:
+                    type: string
+              snatIp:
+                type: array
+                items:
+                  type: string
+              destIp:
+                type: array
+                items:
+                  type: string
+          status:
+            type: object
+            properties:
+            additionalProperties:
+              type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nodeinfos.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: NodeInfo
+    listKind: NodeInfoList
+    plural: nodeinfos
+    singular: nodeinfo
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              macaddress:
+                type: string
+              snatpolicynames:
+                additionalProperties:
+                  type: boolean
+                type: object
+            type: object
+          status:
+            description: NodeinfoStatus defines the observed state of Nodeinfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rdconfigs.aci.snat
+spec:
+  group: aci.snat
+  names:
+    kind: RdConfig
+    listKind: RdConfigList
+    plural: rdconfigs
+    singular: rdconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              discoveredsubnets:
+                items:
+                  type: string
+                type: array
+              usersubnets:
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: NodeinfoStatus defines the observed state of Nodeinfo
+            type: object
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.aci.netpol
+spec:
+  group: aci.netpol
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Network Policy describes traffic flow at IP address or port level
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              appliedTo:
+                properties:
+                  namespaceSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  podSelector:
+                    description: allow ingress from the same namespace
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+              egress:
+                description: Set of egress rules evaluated based on the order in which they are set.
+                items:
+                  properties:
+                    action:
+                      description: Action specifies the action to be applied on the rule.
+                      type: string
+                    enableLogging:
+                      description: EnableLogging is used to indicate if agent should generate logs default to false.
+                      type: boolean
+                    ports:
+                      description: Set of port and protocol allowed/denied by the rule. If this field is unset or empty, this rule matches all ports.
+                      items:
+                        description: NetworkPolicyPort describes the port and protocol to match in a rule.
+                        properties:
+                          endPort:
+                            description: EndPort defines the end of the port range, being the end included within the range. It can only be specified when a numerical `port` is specified.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can be either a numerical or named port on a Pod. If this field is not provided, this matches all port names and numbers.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            default: TCP
+                            description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      description: Rule is matched if traffic is intended for workloads selected by this field. If this field is empty or missing, this rule matches all destinations.
+                      items:
+                        properties:
+                          ipBlock:
+                            description: IPBlock describes the IPAddresses/IPBlocks that is matched in to/from. IPBlock cannot be set as part of the AppliedTo field. Cannot be set with any other selector.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            description: Select all Pods from Namespaces matched by this selector, as workloads in To/From fields. If set with PodSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except PodSelector or ExternalEntitySelector.
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          podSelector:
+                            description: Select Pods from NetworkPolicy's Namespace as workloads in AppliedTo/To/From fields. If set with NamespaceSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    toFqDn:
+                      properties:
+                        matchNames:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - matchNames
+                      type: object
+                  required:
+                  - enableLogging
+                  - toFqDn
+                  type: object
+                type: array
+              ingress:
+                description: Set of ingress rules evaluated based on the order in which they are set.
+                items:
+                  properties:
+                    action:
+                      description: Action specifies the action to be applied on the rule.
+                      type: string
+                    enableLogging:
+                      description: EnableLogging is used to indicate if agent should generate logs when rules are matched. Should be default to false.
+                      type: boolean
+                    from:
+                      description: Rule is matched if traffic originates from workloads selected by this field. If this field is empty, this rule matches all sources.
+                      items:
+                        properties:
+                          ipBlock:
+                            description: IPBlock describes the IPAddresses/IPBlocks that is matched in to/from. IPBlock cannot be set as part of the AppliedTo field. Cannot be set with any other selector.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          podSelector:
+                            description: Select Pods from NetworkPolicy's Namespace as workloads in AppliedTo/To/From fields. If set with NamespaceSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    ports:
+                      description: Set of port and protocol allowed/denied by the rule. If this field is unset or empty, this rule matches all ports.
+                      items:
+                        description: NetworkPolicyPort describes the port and protocol to match in a rule.
+                        properties:
+                          endPort:
+                            description: EndPort defines the end of the port range, being the end included within the range. It can only be specified when a numerical `port` is specified.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can be either a numerical or named port on a Pod. If this field is not provided, this matches all port names and numbers.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            default: TCP
+                            description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              policyTypes:
+                items:
+                  description: Policy Type string describes the NetworkPolicy type This type is beta-level in 1.8
+                  type: string
+                type: array
+              priority:
+                description: Priority specfies the order of the NetworkPolicy relative to other NetworkPolicies.
+                type: integer
+              type:
+                description: type of the policy.
+                type: string
+            required:
+            - type
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dnsnetworkpolicies.aci.dnsnetpol
+spec:
+  group: aci.dnsnetpol
+  names:
+    kind: DnsNetworkPolicy
+    listKind: DnsNetworkPolicyList
+    plural: dnsnetworkpolicies
+    singular: dnsnetworkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1beta
+    schema:
+      openAPIV3Schema:
+        description: dns network Policy
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              appliedTo:
+                properties:
+                  namespaceSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  podSelector:
+                    description: allow ingress from the same namespace
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+              egress:
+                description: Set of egress rules evaluated based on the order in which they are set.
+                properties:
+                  toFqdn:
+                    properties:
+                      matchNames:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - matchNames
+                    type: object
+                required:
+                - toFqdn
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: qospolicies.aci.qos
+spec:
+  group: aci.qos
+  names:
+    kind: QosPolicy
+    listKind: QosPolicyList
+    plural: qospolicies
+    singular: qospolicy
+  scope: Namespaced
+  preserveUnknownFields: false
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              podSelector:
+                description: 'Selection of Pods'
+                type: object
+                properties:
+                  matchLabels:
+                    type: object
+                    description:
+              ingress:
+                type: object
+                properties:
+                  policing_rate:
+                    type: integer
+                    minimum: 0
+                  policing_burst:
+                    type: integer
+                    minimum: 0
+              egress:
+                type: object
+                properties:
+                  policing_rate:
+                    type: integer
+                    minimum: 0
+                  policing_burst:
+                    type: integer
+                    minimum: 0
+              dscpmark:
+                type: integer
+                default: 0
+                minimum: 0
+                maximum: 63
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: netflowpolicies.aci.netflow
+spec:
+  group: aci.netflow
+  names:
+    kind: NetflowPolicy
+    listKind: NetflowPolicyList
+    plural: netflowpolicies
+    singular: netflowpolicy
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+  - name: v1alpha
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              flowSamplingPolicy:
+                type: object
+                properties:
+                  destIp:
+                    type: string
+                  destPort:
+                    type: integer
+                    minimum: 0
+                    maximum: 65535
+                    default: 2055
+                  flowType:
+                    type: string
+                    enum:
+                    - netflow
+                    - ipfix
+                    default: netflow
+                  activeFlowTimeOut:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                    default: 60
+                  idleFlowTimeOut:
+                    type: integer
+                    minimum: 0
+                    maximum: 600
+                    default: 15
+                  samplingRate:
+                    type: integer
+                    minimum: 0
+                    maximum: 1000
+                    default: 0
+                required:
+                - destIp
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: erspanpolicies.aci.erspan
+spec:
+  group: aci.erspan
+  names:
+    kind: ErspanPolicy
+    listKind: ErspanPolicyList
+    plural: erspanpolicies
+    singular: erspanpolicy
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+  - name: v1alpha
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            type: object
+            properties:
+              selector:
+                type: object
+                description: 'Selection of Pods'
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+                  namespace:
+                    type: string
+              source:
+                type: object
+                properties:
+                  adminState:
+                    description: Administrative state.
+                    default: start
+                    type: string
+                    enum:
+                    - start
+                    - stop
+                  direction:
+                    description: Direction of the packets to monitor.
+                    default: both
+                    type: string
+                    enum:
+                    - in
+                    - out
+                    - both
+              destination:
+                type: object
+                properties:
+                  destIP:
+                    description: Destination IP of the ERSPAN packet.
+                    type: string
+                  flowID:
+                    description: Unique flow ID of the ERSPAN packet.
+                    default: 1
+                    type: integer
+                    minimum: 1
+                    maximum: 1023
+                required:
+                - destIP
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: enabledroplogs.aci.droplog
+spec:
+  group: aci.droplog
+  names:
+    kind: EnableDropLog
+    listKind: EnableDropLogList
+    plural: enabledroplogs
+    singular: enabledroplog
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            description: Defines the desired state of EnableDropLog
+            type: object
+            properties:
+              disableDefaultDropLog:
+                description: Disables the default droplog enabled by acc-provision.
+                default: false
+                type: boolean
+              nodeSelector:
+                type: object
+                description: Drop logging is enabled on nodes selected based on labels
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: prunedroplogs.aci.droplog
+spec:
+  group: aci.droplog
+  names:
+    kind: PruneDropLog
+    listKind: PruneDropLogList
+    plural: prunedroplogs
+    singular: prunedroplog
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+   # openAPIV3Schema is the schema for validating custom objects.
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          spec:
+            description: Defines the desired state of PruneDropLog
+            type: object
+            properties:
+              nodeSelector:
+                type: object
+                description: Drop logging filters are applied to nodes selected based on labels
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                    additionalProperties:
+                      type: string
+              dropLogFilters:
+                type: object
+                properties:
+                  srcIP:
+                    type: string
+                  destIP:
+                    type: string
+                  srcMAC:
+                    type: string
+                  destMAC:
+                    type: string
+                  srcPort:
+                    type: integer
+                  destPort:
+                    type: integer
+                  ipProto:
+                    type: integer
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostprotpols.aci.hpp
+spec:
+  group: aci.hpp
+  names:
+    kind: HostprotPol
+    listKind: HostprotPolList
+    plural: hostprotpols
+    singular: hostprotpol
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+            description: 'APIVersion defines the versioned schema of this representation of an object.Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          kind:
+            type: string
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          metadata:
+            type: object
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+              networkPolicies:
+                type: array
+                items:
+                  type: string
+              hostprotSubj:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    hostprotRule:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          protocol:
+                            type: string
+                            description: Protocol
+                          rsRemoteIpContainer:
+                            type: array
+                            items:
+                              type: string
+                          hostprotRemoteIp:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                addr:
+                                  type: string
+                                hppEpLabel:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      value:
+                                        type: string
+                          toPort:
+                            type: string
+                            description: ToPort
+                          connTrack:
+                            type: string
+                            description: ConnTrack
+                          direction:
+                            type: string
+                            description: Direction
+                          ethertype:
+                            type: string
+                            description: Ethertype
+                          fromPort:
+                            type: string
+                            description: FromPort
+                          hostprotServiceRemoteIps:
+                            type: array
+                            items:
+                              type: string
+                          hostprotFilterContainer:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                hostprotFilter:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostprotremoteipcontainers.aci.hpp
+spec:
+  group: aci.hpp
+  names:
+    kind: HostprotRemoteIpContainer
+    listKind: HostprotRemoteIpContainerList
+    plural: hostprotremoteipcontainers
+    singular: hostprotremoteipcontainer
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          kind:
+            type: string
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          metadata:
+            type: object
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+              hostprotRemoteIp:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    addr:
+                      type: string
+                    hppEpLabel:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: accprovisioninputs.aci.ctrl
+spec:
+  group: aci.ctrl
+  names:
+    kind: AccProvisionInput
+    listKind: AccProvisionInputList
+    plural: accprovisioninputs
+    singular: accprovisioninput
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: accprovisioninput defines the input configuration for ACI CNI
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AccProvisionInputSpec defines the desired spec for accprovisioninput object
+            properties:
+              acc_provision_input:
+                type: object
+                properties:
+                  operator_managed_config:
+                    type: object
+                    properties:
+                      enable_updates:
+                        type: boolean
+                  aci_config:
+                    type: object
+                    properties:
+                      sync_login:
+                        type: object
+                        properties:
+                          certfile:
+                            type: string
+                          keyfile:
+                            type: string
+                      client_ssl:
+                        type: boolean
+                  net_config:
+                    type: object
+                    properties:
+                      interface_mtu:
+                        type: integer
+                      service_monitor_interval:
+                        type: integer
+                      pbr_tracking_non_snat:
+                        type: boolean
+                      pod_subnet_chunk_size:
+                        type: integer
+                      disable_wait_for_network:
+                        type: boolean
+                      duration_wait_for_network:
+                        type: integer
+                  registry:
+                    type: object
+                    properties:
+                      image_prefix:
+                        type: string
+                      image_pull_secret:
+                        type: string
+                      aci_containers_operator_version:
+                        type: string
+                      aci_containers_controller_version:
+                        type: string
+                      aci_containers_host_version:
+                        type: string
+                      acc_provision_operator_version:
+                        type: string
+                      aci_cni_operator_version:
+                        type: string
+                      cnideploy_version:
+                        type: string
+                      opflex_agent_version:
+                        type: string
+                      openvswitch_version:
+                        type: string
+                      gbp_version:
+                        type: string
+                  logging:
+                    type: object
+                    properties:
+                      size:
+                        type: integer
+                      controller_log_level:
+                        type: string
+                      hostagent_log_level:
+                        type: string
+                      opflexagent_log_level:
+                        type: string
+                  istio_config:
+                    type: object
+                    properties:
+                      install_profile:
+                        type: string
+                  multus:
+                    type: object
+                    properties:
+                      disable:
+                        type: boolean
+                  drop_log_config:
+                    type: object
+                    properties:
+                      enable:
+                        type: boolean
+                  nodepodif_config:
+                    type: object
+                    properties:
+                      enable:
+                        type: boolean
+                  sriov_config:
+                    type: object
+                    properties:
+                      enable:
+                        type: boolean
+                  kube_config:
+                    type: object
+                    properties:
+                      ovs_memory_limit:
+                        type: string
+                      use_privileged_containers:
+                        type: boolean
+                      image_pull_policy:
+                        type: string
+                      reboot_opflex_with_ovs:
+                        type: string
+                      snat_operator:
+                        type: object
+                        properties:
+                          port_range:
+                            type: object
+                            properties:
+                              start:
+                                type: integer
+                              end:
+                                type: integer
+                              ports_per_node:
+                                type: integer
+                          contract_scope:
+                            type: string
+                          disable_periodic_snat_global_info_sync:
+                            type: boolean
+              config:
+                type: string
+              flavor:
+                type: string
+            type: object
+          status:
+            description: AccProvisionInputStatus defines the successful completion of AccProvisionInput
+            properties:
+              status:
+                type: boolean
+            type: object
+        required:
+        - spec
+        type: object
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aci-operator-config
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  spec:
+    flavor: RKE2-kubernetes-1.34
+    config: "\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: aci-containers-system\n  labels:\n    aci-containers-config-version: \"dummy\"\n    network-plugin: aci-containers\n  annotations:\n    openshift.io/node-selector: ''\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: nodepodifs.aci.aw\nspec:\n  group: aci.aw\n  names:\n    kind: NodePodIF\n    listKind: NodePodIFList\n    plural: nodepodifs\n    singular: nodepodif\n  scope: Namespaced\n  versions:\n  - name: v1\n    served: true\n    storage: true\n    schema:\n      openAPIV3Schema:\n        properties:\n          apiVersion:\n            type: string\n          kind:\n            type: string\n          metadata:\n            type: object\n          spec:\n            type: object\n            properties:\n              podifs:\n                type: array\n                items:\n                  type: object\n                  properties:\n                    containerID:\n                      type: string\n                    epg:\n                      type: string\n                    ifname:\n                      type: string\n                    ipaddr:\n                      type: string\n                    macaddr:\n                      type: string\n                    podname:\n                      type: string\n                    podns:\n                      type: string\n                    vtep:\n                      type: string\n        required:\n        - spec\n        type: object\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: snatglobalinfos.aci.snat\nspec:\n  group: aci.snat\n  names:\n    kind: SnatGlobalInfo\n    listKind: SnatGlobalInfoList\n    plural: snatglobalinfos\n    singular: snatglobalinfo\n  scope: Namespaced\n  versions:\n  - name: v1\n    served: true\n    storage: true\n    schema:\n      openAPIV3Schema:\n        description: SnatGlobalInfo is the Schema for the snatglobalinfos API\n        properties:\n          apiVersion:\n            type: string\n          kind:\n            type: string\n          metadata:\n            type: object\n          spec:\n            properties:\n              globalInfos:\n                additionalProperties:\n                  items:\n                    properties:\n                      macAddress:\n                        type: string\n                      portRanges:\n                        items:\n                          properties:\n                            end:\n                              maximum: 65535\n                              minimum: 1\n                              type: integer\n                            start:\n                              maximum: 65535\n                              minimum: 1\n                              type: integer\n                          type: object\n                        type: array\n                      snatIp:\n                        type: string\n                      snatIpUid:\n                        type: string\n                      snatPolicyName:\n                        type: string\n                    required:\n                    - macAddress\n                    - portRanges\n                    - snatIp\n                    - snatIpUid\n                    - snatPolicyName\n                    type: object\n                  type: array\n                type: object\n            required:\n            - globalInfos\n            type: object\n          status:\n            description: SnatGlobalInfoStatus defines the observed state of SnatGlobalInfo\n            type: object\n        type: object\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: snatlocalinfos.aci.snat\nspec:\n  group: aci.snat\n  names:\n    kind: SnatLocalInfo\n    listKind: SnatLocalInfoList\n    plural: snatlocalinfos\n    singular: snatlocalinfo\n  scope: Namespaced\n  versions:\n  - name: v1\n    served: true\n    storage: true\n    schema:\n      openAPIV3Schema:\n        properties:\n          apiVersion:\n            type: string\n          kind:\n            type: string\n          metadata:\n            type: object\n          spec:\n            description: SnatLocalInfoSpec defines the desired state of SnatLocalInfo\n            properties:\n              localInfos:\n                items:\n                  properties:\n                    podName:\n                      type: string\n                    podNamespace:\n                      type: string\n                    podUid:\n                      type: string\n                    snatPolicies:\n                      items:\n                        properties:\n                          destIp:\n                            items:\n                              type: string\n                            type: array\n                          name:\n                            type: string\n                          snatIp:\n                            type: string\n                        required:\n                        - destIp\n                        - name\n                        - snatIp\n                        type: object\n                      type: array\n                  required:\n                  - podName\n                  - podNamespace\n                  - podUid\n                  - snatPolicies\n                  type: object\n                type: array\n            required:\n            - localInfos\n            type: object\n        type: object\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: snatpolicies.aci.snat\nspec:\n  group: aci.snat\n  names:\n    kind: SnatPolicy\n    listKind: SnatPolicyList\n    plural: snatpolicies\n    singular: snatpolicy\n  scope: Cluster\n  versions:\n  - name: v1\n    served: true\n    storage: true\n    subresources:\n      status: {}\n    schema:\n      openAPIV3Schema:\n        type: object\n        properties:\n          apiVersion:\n            type: string\n          kind:\n            type: string\n          metadata:\n            type: object\n          spec:\n            type: object\n            properties:\n              selector:\n                type: object\n                properties:\n                  labels:\n                    type: object\n                    description: 'Selection of Pods'\n                    properties:\n                    additionalProperties:\n                      type: string\n                  namespace:\n                    type: string\n              snatIp:\n                type: array\n                items:\n                  type: string\n              destIp:\n                type: array\n                items:\n                  type: string\n          status:\n            type: object\n            properties:\n            additionalProperties:\n              type: string\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: nodeinfos.aci.snat\nspec:\n  group: aci.snat\n  names:\n    kind: NodeInfo\n    listKind: NodeInfoList\n    plural: nodeinfos\n    singular: nodeinfo\n  scope: Namespaced\n  versions:\n  - name: v1\n    served: true\n    storage: true\n    schema:\n      openAPIV3Schema:\n        properties:\n          apiVersion:\n            type: string\n          kind:\n            type: string\n          metadata:\n            type: object\n          spec:\n            properties:\n              macaddress:\n                type: string\n              snatpolicynames:\n                additionalProperties:\n                  type: boolean\n                type: object\n            type: object\n          status:\n            description: NodeinfoStatus defines the observed state of Nodeinfo\n            type: object\n        type: object\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: rdconfigs.aci.snat\nspec:\n  group: aci.snat\n  names:\n    kind: RdConfig\n    listKind: RdConfigList\n    plural: rdconfigs\n    singular: rdconfig\n  scope: Namespaced\n  versions:\n  - name: v1\n    served: true\n    storage: true\n    schema:\n      openAPIV3Schema:\n        properties:\n          apiVersion:\n            type: string\n          kind:\n            type: string\n          metadata:\n            type: object\n          spec:\n            properties:\n              discoveredsubnets:\n                items:\n                  type: string\n                type: array\n              usersubnets:\n                items:\n                  type: string\n                type: array\n            type: object\n          status:\n            description: NodeinfoStatus defines the observed state of Nodeinfo\n            type: object\n        type: object\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: networkpolicies.aci.netpol\nspec:\n  group: aci.netpol\n  names:\n    kind: NetworkPolicy\n    listKind: NetworkPolicyList\n    plural: networkpolicies\n    singular: networkpolicy\n  scope: Namespaced\n  versions:\n  - name: v1\n    schema:\n      openAPIV3Schema:\n        description: Network Policy describes traffic flow at IP address or port level\n        properties:\n          apiVersion:\n            type: string\n          kind:\n            type: string\n          metadata:\n            type: object\n          spec:\n            properties:\n              appliedTo:\n                properties:\n                  namespaceSelector:\n                    properties:\n                      matchExpressions:\n                        items:\n                          properties:\n                            key:\n                              type: string\n                            operator:\n                              type: string\n                            values:\n                              items:\n                                type: string\n                              type: array\n                          required:\n                          - key\n                          - operator\n                          type: object\n                        type: array\n                      matchLabels:\n                        additionalProperties:\n                          type: string\n                        type: object\n                    type: object\n                  podSelector:\n                    description: allow ingress from the same namespace\n                    properties:\n                      matchExpressions:\n                        items:\n                          properties:\n                            key:\n                              type: string\n                            operator:\n                              type: string\n                            values:\n                              items:\n                                type: string\n                              type: array\n                          required:\n                          - key\n                          - operator\n                          type: object\n                        type: array\n                      matchLabels:\n                        additionalProperties:\n                          type: string\n                        type: object\n                    type: object\n                type: object\n              egress:\n                description: Set of egress rules evaluated based on the order in which they are set.\n                items:\n                  properties:\n                    action:\n                      description: Action specifies the action to be applied on the rule.\n                      type: string\n                    enableLogging:\n                      description: EnableLogging is used to indicate if agent should generate logs default to false.\n                      type: boolean\n                    ports:\n                      description: Set of port and protocol allowed/denied by the rule. If this field is unset or empty, this rule matches all ports.\n                      items:\n                        description: NetworkPolicyPort describes the port and protocol to match in a rule.\n                        properties:\n                          endPort:\n                            description: EndPort defines the end of the port range, being the end included within the range. It can only be specified when a numerical `port` is specified.\n                            format: int32\n                            type: integer\n                          port:\n                            anyOf:\n                            - type: integer\n                            - type: string\n                            description: The port on the given protocol. This can be either a numerical or named port on a Pod. If this field is not provided, this matches all port names and numbers.\n                            x-kubernetes-int-or-string: true\n                          protocol:\n                            default: TCP\n                            description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.\n                            type: string\n                        type: object\n                      type: array\n                    to:\n                      description: Rule is matched if traffic is intended for workloads selected by this field. If this field is empty or missing, this rule matches all destinations.\n                      items:\n                        properties:\n                          ipBlock:\n                            description: IPBlock describes the IPAddresses/IPBlocks that is matched in to/from. IPBlock cannot be set as part of the AppliedTo field. Cannot be set with any other selector.\n                            properties:\n                              cidr:\n                                description: CIDR is a string representing the IP Block Valid examples are \"192.168.1.1/24\" or \"2001:db9::/64\"\n                                type: string\n                              except:\n                                description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" or \"2001:db9::/64\" Except values will be rejected if they are outside the CIDR range\n                                items:\n                                  type: string\n                                type: array\n                            required:\n                            - cidr\n                            type: object\n                          namespaceSelector:\n                            description: Select all Pods from Namespaces matched by this selector, as workloads in To/From fields. If set with PodSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except PodSelector or ExternalEntitySelector.\n                            properties:\n                              matchExpressions:\n                                items:\n                                  properties:\n                                    key:\n                                      type: string\n                                    operator:\n                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\n                                      type: string\n                                    values:\n                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\n                                      items:\n                                        type: string\n                                      type: array\n                                  required:\n                                  - key\n                                  - operator\n                                  type: object\n                                type: array\n                              matchLabels:\n                                additionalProperties:\n                                  type: string\n                                type: object\n                            type: object\n                          podSelector:\n                            description: Select Pods from NetworkPolicy's Namespace as workloads in AppliedTo/To/From fields. If set with NamespaceSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except NamespaceSelector.\n                            properties:\n                              matchExpressions:\n                                items:\n                                  properties:\n                                    key:\n                                      type: string\n                                    operator:\n                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\n                                      type: string\n                                    values:\n                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\n                                      items:\n                                        type: string\n                                      type: array\n                                  required:\n                                  - key\n                                  - operator\n                                  type: object\n                                type: array\n                              matchLabels:\n                                additionalProperties:\n                                  type: string\n                                type: object\n                            type: object\n                        type: object\n                      type: array\n                    toFqDn:\n                      properties:\n                        matchNames:\n                          items:\n                            type: string\n                          type: array\n                      required:\n                      - matchNames\n                      type: object\n                  required:\n                  - enableLogging\n                  - toFqDn\n                  type: object\n                type: array\n              ingress:\n                description: Set of ingress rules evaluated based on the order in which they are set.\n                items:\n                  properties:\n                    action:\n                      description: Action specifies the action to be applied on the rule.\n                      type: string\n                    enableLogging:\n                      description: EnableLogging is used to indicate if agent should generate logs when rules are matched. Should be default to false.\n                      type: boolean\n                    from:\n                      description: Rule is matched if traffic originates from workloads selected by this field. If this field is empty, this rule matches all sources.\n                      items:\n                        properties:\n                          ipBlock:\n                            description: IPBlock describes the IPAddresses/IPBlocks that is matched in to/from. IPBlock cannot be set as part of the AppliedTo field. Cannot be set with any other selector.\n                            properties:\n                              cidr:\n                                description: CIDR is a string representing the IP Block Valid examples are \"192.168.1.1/24\" or \"2001:db9::/64\"\n                                type: string\n                              except:\n                                description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" or \"2001:db9::/64\" Except values will be rejected if they are outside the CIDR range\n                                items:\n                                  type: string\n                                type: array\n                            required:\n                            - cidr\n                            type: object\n                          namespaceSelector:\n                            properties:\n                              matchExpressions:\n                                items:\n                                  properties:\n                                    key:\n                                      type: string\n                                    operator:\n                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\n                                      type: string\n                                    values:\n                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\n                                      items:\n                                        type: string\n                                      type: array\n                                  required:\n                                  - key\n                                  - operator\n                                  type: object\n                                type: array\n                              matchLabels:\n                                additionalProperties:\n                                  type: string\n                                type: object\n                            type: object\n                          podSelector:\n                            description: Select Pods from NetworkPolicy's Namespace as workloads in AppliedTo/To/From fields. If set with NamespaceSelector, Pods are matched from Namespaces matched by the NamespaceSelector. Cannot be set with any other selector except NamespaceSelector.\n                            properties:\n                              matchExpressions:\n                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.\n                                items:\n                                  properties:\n                                    key:\n                                      type: string\n                                    operator:\n                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\n                                      type: string\n                                    values:\n                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\n                                      items:\n                                        type: string\n                                      type: array\n                                  required:\n                                  - key\n                                  - operator\n                                  type: object\n                                type: array\n                              matchLabels:\n                                additionalProperties:\n                                  type: string\n                                type: object\n                            type: object\n                        type: object\n                      type: array\n                    ports:\n                      description: Set of port and protocol allowed/denied by the rule. If this field is unset or empty, this rule matches all ports.\n                      items:\n                        description: NetworkPolicyPort describes the port and protocol to match in a rule.\n                        properties:\n                          endPort:\n                            description: EndPort defines the end of the port range, being the end included within the range. It can only be specified when a numerical `port` is specified.\n                            format: int32\n                            type: integer\n                          port:\n                            anyOf:\n                            - type: integer\n                            - type: string\n                            description: The port on the given protocol. This can be either a numerical or named port on a Pod. If this field is not provided, this matches all port names and numbers.\n                            x-kubernetes-int-or-string: true\n                          protocol:\n                            default: TCP\n                            description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.\n                            type: string\n                        type: object\n                      type: array\n                  type: object\n                type: array\n              policyTypes:\n                items:\n                  description: Policy Type string describes the NetworkPolicy type This type is beta-level in 1.8\n                  type: string\n                type: array\n              priority:\n                description: Priority specfies the order of the NetworkPolicy relative to other NetworkPolicies.\n                type: integer\n              type:\n                description: type of the policy.\n                type: string\n            required:\n            - type\n            type: object\n        required:\n        - spec\n        type: object\n    served: true\n    storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: dnsnetworkpolicies.aci.dnsnetpol\nspec:\n  group: aci.dnsnetpol\n  names:\n    kind: DnsNetworkPolicy\n    listKind: DnsNetworkPolicyList\n    plural: dnsnetworkpolicies\n    singular: dnsnetworkpolicy\n  scope: Namespaced\n  versions:\n  - name: v1beta\n    schema:\n      openAPIV3Schema:\n        description: dns network Policy\n        properties:\n          apiVersion:\n            type: string\n          kind:\n            type: string\n          metadata:\n            type: object\n          spec:\n            properties:\n              appliedTo:\n                properties:\n                  namespaceSelector:\n                    properties:\n                      matchExpressions:\n                        items:\n                          properties:\n                            key:\n                              type: string\n                            operator:\n                              type: string\n                            values:\n                              items:\n                                type: string\n                              type: array\n                          required:\n                          - key\n                          - operator\n                          type: object\n                        type: array\n                      matchLabels:\n                        additionalProperties:\n                          type: string\n                        type: object\n                    type: object\n                  podSelector:\n                    description: allow ingress from the same namespace\n                    properties:\n                      matchExpressions:\n                        items:\n                          properties:\n                            key:\n                              type: string\n                            operator:\n                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.\n                              type: string\n                            values:\n                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.\n                              items:\n                                type: string\n                              type: array\n                          required:\n                          - key\n                          - operator\n                          type: object\n                        type: array\n                      matchLabels:\n                        additionalProperties:\n                          type: string\n                        type: object\n                    type: object\n                type: object\n              egress:\n                description: Set of egress rules evaluated based on the order in which they are set.\n                properties:\n                  toFqdn:\n                    properties:\n                      matchNames:\n                        items:\n                          type: string\n                        type: array\n                    required:\n                    - matchNames\n                    type: object\n                required:\n                - toFqdn\n                type: object\n            type: object\n        required:\n        - spec\n        type: object\n    served: true\n    storage: true\nstatus:\n  acceptedNames:\n    kind: \"\"\n    plural: \"\"\n  conditions: []\n  storedVersions: []\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: qospolicies.aci.qos\nspec:\n  group: aci.qos\n  names:\n    kind: QosPolicy\n    listKind: QosPolicyList\n    plural: qospolicies\n    singular: qospolicy\n  scope: Namespaced\n  preserveUnknownFields: false\n  versions:\n  - name: v1\n    served: true\n    storage: true\n    subresources:\n      status: {}\n    schema:\n      openAPIV3Schema:\n        type: object\n        properties:\n          apiVersion:\n            type: string\n          kind:\n            type: string\n          spec:\n            type: object\n            properties:\n              podSelector:\n                description: 'Selection of Pods'\n                type: object\n                properties:\n                  matchLabels:\n                    type: object\n                    description:\n              ingress:\n                type: object\n                properties:\n                  policing_rate:\n                    type: integer\n                    minimum: 0\n                  policing_burst:\n                    type: integer\n                    minimum: 0\n              egress:\n                type: object\n                properties:\n                  policing_rate:\n                    type: integer\n                    minimum: 0\n                  policing_burst:\n                    type: integer\n                    minimum: 0\n              dscpmark:\n                type: integer\n                default: 0\n                minimum: 0\n                maximum: 63\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: netflowpolicies.aci.netflow\nspec:\n  group: aci.netflow\n  names:\n    kind: NetflowPolicy\n    listKind: NetflowPolicyList\n    plural: netflowpolicies\n    singular: netflowpolicy\n  scope: Cluster\n  preserveUnknownFields: false\n  versions:\n  - name: v1alpha\n    served: true\n    storage: true\n    schema:\n   # openAPIV3Schema is the schema for validating custom objects.\n      openAPIV3Schema:\n        type: object\n        properties:\n          apiVersion:\n            type: string\n          kind:\n            type: string\n          spec:\n            type: object\n            properties:\n              flowSamplingPolicy:\n                type: object\n                properties:\n                  destIp:\n                    type: string\n                  destPort:\n                    type: integer\n                    minimum: 0\n                    maximum: 65535\n                    default: 2055\n                  flowType:\n                    type: string\n                    enum:\n                    - netflow\n                    - ipfix\n                    default: netflow\n                  activeFlowTimeOut:\n                    type: integer\n                    minimum: 0\n                    maximum: 3600\n                    default: 60\n                  idleFlowTimeOut:\n                    type: integer\n                    minimum: 0\n                    maximum: 600\n                    default: 15\n                  samplingRate:\n                    type: integer\n                    minimum: 0\n                    maximum: 1000\n                    default: 0\n                required:\n                - destIp\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: erspanpolicies.aci.erspan\nspec:\n  group: aci.erspan\n  names:\n    kind: ErspanPolicy\n    listKind: ErspanPolicyList\n    plural: erspanpolicies\n    singular: erspanpolicy\n  scope: Cluster\n  preserveUnknownFields: false\n  versions:\n  - name: v1alpha\n    served: true\n    storage: true\n    schema:\n      openAPIV3Schema:\n        type: object\n        properties:\n          apiVersion:\n            type: string\n          kind:\n            type: string\n          spec:\n            type: object\n            properties:\n              selector:\n                type: object\n                description: 'Selection of Pods'\n                properties:\n                  labels:\n                    type: object\n                    properties:\n                    additionalProperties:\n                      type: string\n                  namespace:\n                    type: string\n              source:\n                type: object\n                properties:\n                  adminState:\n                    description: Administrative state.\n                    default: start\n                    type: string\n                    enum:\n                    - start\n                    - stop\n                  direction:\n                    description: Direction of the packets to monitor.\n                    default: both\n                    type: string\n                    enum:\n                    - in\n                    - out\n                    - both\n              destination:\n                type: object\n                properties:\n                  destIP:\n                    description: Destination IP of the ERSPAN packet.\n                    type: string\n                  flowID:\n                    description: Unique flow ID of the ERSPAN packet.\n                    default: 1\n                    type: integer\n                    minimum: 1\n                    maximum: 1023\n                required:\n                - destIP\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: enabledroplogs.aci.droplog\nspec:\n  group: aci.droplog\n  names:\n    kind: EnableDropLog\n    listKind: EnableDropLogList\n    plural: enabledroplogs\n    singular: enabledroplog\n  scope: Cluster\n  versions:\n  - name: v1alpha1\n    served: true\n    storage: true\n    schema:\n   # openAPIV3Schema is the schema for validating custom objects.\n      openAPIV3Schema:\n        type: object\n        properties:\n          apiVersion:\n            type: string\n          kind:\n            type: string\n          spec:\n            description: Defines the desired state of EnableDropLog\n            type: object\n            properties:\n              disableDefaultDropLog:\n                description: Disables the default droplog enabled by acc-provision.\n                default: false\n                type: boolean\n              nodeSelector:\n                type: object\n                description: Drop logging is enabled on nodes selected based on labels\n                properties:\n                  labels:\n                    type: object\n                    properties:\n                    additionalProperties:\n                      type: string\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: prunedroplogs.aci.droplog\nspec:\n  group: aci.droplog\n  names:\n    kind: PruneDropLog\n    listKind: PruneDropLogList\n    plural: prunedroplogs\n    singular: prunedroplog\n  scope: Cluster\n  versions:\n  - name: v1alpha1\n    served: true\n    storage: true\n    schema:\n   # openAPIV3Schema is the schema for validating custom objects.\n      openAPIV3Schema:\n        type: object\n        properties:\n          apiVersion:\n            type: string\n          kind:\n            type: string\n          spec:\n            description: Defines the desired state of PruneDropLog\n            type: object\n            properties:\n              nodeSelector:\n                type: object\n                description: Drop logging filters are applied to nodes selected based on labels\n                properties:\n                  labels:\n                    type: object\n                    properties:\n                    additionalProperties:\n                      type: string\n              dropLogFilters:\n                type: object\n                properties:\n                  srcIP:\n                    type: string\n                  destIP:\n                    type: string\n                  srcMAC:\n                    type: string\n                  destMAC:\n                    type: string\n                  srcPort:\n                    type: integer\n                  destPort:\n                    type: integer\n                  ipProto:\n                    type: integer\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: hostprotpols.aci.hpp\nspec:\n  group: aci.hpp\n  names:\n    kind: HostprotPol\n    listKind: HostprotPolList\n    plural: hostprotpols\n    singular: hostprotpol\n  scope: Namespaced\n  versions:\n  - name: v1\n    served: true\n    storage: true\n    subresources:\n      status: {}\n    schema:\n      openAPIV3Schema:\n        type: object\n        properties:\n          apiVersion:\n            type: string\n            description: 'APIVersion defines the versioned schema of this\n              representation of an object.Servers should convert recognized\n              schemas to the latest internal value, and may reject\n              unrecognized values.\n              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n          kind:\n            type: string\n            description: 'Kind is a string value representing the REST resource\n              this object represents. Servers may infer this from the endpoint\n              the client submits requests to. Cannot be updated. In CamelCase.\n              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n          metadata:\n            type: object\n          spec:\n            type: object\n            properties:\n              name:\n                type: string\n              networkPolicies:\n                type: array\n                items:\n                  type: string\n              hostprotSubj:\n                type: array\n                items:\n                  type: object\n                  properties:\n                    name:\n                      type: string\n                    hostprotRule:\n                      type: array\n                      items:\n                        type: object\n                        properties:\n                          name:\n                            type: string\n                          protocol:\n                            type: string\n                            description: Protocol\n                          rsRemoteIpContainer:\n                            type: array\n                            items:\n                              type: string\n                          hostprotRemoteIp:\n                            type: array\n                            items:\n                              type: object\n                              properties:\n                                addr:\n                                  type: string\n                                hppEpLabel:\n                                  type: array\n                                  items:\n                                    type: object\n                                    properties:\n                                      key:\n                                        type: string\n                                      value:\n                                        type: string\n                          toPort:\n                            type: string\n                            description: ToPort\n                          connTrack:\n                            type: string\n                            description: ConnTrack\n                          direction:\n                            type: string\n                            description: Direction\n                          ethertype:\n                            type: string\n                            description: Ethertype\n                          fromPort:\n                            type: string\n                            description: FromPort\n                          hostprotServiceRemoteIps:\n                            type: array\n                            items:\n                              type: string\n                          hostprotFilterContainer:\n                            type: array\n                            items:\n                              type: object\n                              properties:\n                                hostprotFilter:\n                                  type: array\n                                  items:\n                                    type: object\n                                    properties:\n                                      key:\n                                        type: string\n                                      operator:\n                                        type: string\n                                      values:\n                                        type: array\n                                        items:\n                                          type: string\n---\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: hostprotremoteipcontainers.aci.hpp\nspec:\n  group: aci.hpp\n  names:\n    kind: HostprotRemoteIpContainer\n    listKind: HostprotRemoteIpContainerList\n    plural: hostprotremoteipcontainers\n    singular: hostprotremoteipcontainer\n  scope: Namespaced\n  versions:\n  - name: v1\n    served: true\n    storage: true\n    subresources:\n      status: {}\n    schema:\n      openAPIV3Schema:\n        type: object\n        properties:\n          apiVersion:\n            type: string\n            description: 'APIVersion defines the versioned schema of this representation of an object.\n              Servers should convert recognized schemas to the latest internal value, and\n              may reject unrecognized values.\n              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'\n          kind:\n            type: string\n            description: 'Kind is a string value representing the REST resource this object represents.\n              Servers may infer this from the endpoint the client submits requests to.\n              Cannot be updated.\n              In CamelCase.\n              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'\n          metadata:\n            type: object\n          spec:\n            type: object\n            properties:\n              name:\n                type: string\n              hostprotRemoteIp:\n                type: array\n                items:\n                  type: object\n                  properties:\n                    addr:\n                      type: string\n                    hppEpLabel:\n                      type: array\n                      items:\n                        type: object\n                        properties:\n                          key:\n                            type: string\n                          value:\n                            type: string\n---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: aci-containers-config\n  namespace: aci-containers-system\n  labels:\n    aci-containers-config-version: \"dummy\"\n    network-plugin: aci-containers\ndata:\n  controller-config: |-\n    {\n        \"flavor\": \"RKE2-kubernetes-1.34\",\n        \"log-level\": \"info\",\n        \"apic-hosts\": [\n            \"10.30.120.100\",\n            \"10.30.120.101\",\n            \"10.30.120.102\"\n        ],\n        \"aep\" : \"rke2-aep\",\n        \"apic-request-retry-delay\": 2,\n        \"enable-apic-request-retry-delay\": true,\n        \"apic-username\": \"rke2\",\n        \"apic-private-key-path\": \"/usr/local/etc/aci-cert/user.key\",\n        \"aci-prefix\": \"rke2\",\n        \"aci-vmm-type\": \"Kubernetes\",\n        \"aci-vmm-domain\": \"rke2\",\n        \"aci-vmm-controller\": \"rke2\",\n        \"aci-policy-tenant\": \"rke2\",\n        \"filter-opflex-device\": true,\n        \"aci-podbd-dn\": \"uni/tn-rke2/BD-aci-containers-rke2-pod-bd\",\n        \"aci-nodebd-dn\": \"uni/tn-rke2/BD-aci-containers-rke2-node-bd\",\n        \"aci-service-phys-dom\": \"rke2-pdom\",\n        \"aci-service-encap\": \"vlan-4003\",\n        \"aci-service-monitor-interval\": 5,\n        \"aci-pbr-tracking-non-snat\": false,\n        \"aci-vrf-tenant\": \"common\",\n        \"aci-vrf-dn\": \"uni/tn-common/ctx-rke2\",\n        \"aci-l3out\": \"l3out\",\n        \"aci-ext-networks\": [\n            \"default\",\n            \"test_ext_net\"\n        ],\n        \"aci-vrf\": \"rke2\",\n        \"app-profile\": \"aci-containers-rke2\",\n        \"default-endpoint-group\": {\n            \"policy-space\": \"rke2\",\n            \"name\": \"aci-containers-rke2|aci-containers-default\"\n        },\n        \"max-nodes-svc-graph\": 32,\n        \"namespace-default-endpoint-group\": {\n            \"aci-containers-system\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-system\"\n            },\n            \"cattle-logging-system\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-system\"\n            },\n            \"cattle-monitoring-system\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-system\"\n            },\n            \"cattle-system\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-system\"\n            },\n            \"istio-operator\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-istio\"\n            },\n            \"istio-system\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-istio\"\n            },\n            \"kube-system\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-system\"\n            }        },\n        \"service-ip-pool\": [\n            {\n                \"end\": \"10.3.0.254\",\n                \"start\": \"10.3.0.2\"\n            }\n        ],\n        \"extern-static\": [\"10.4.0.1/24\"],\n        \"extern-dynamic\": [\"10.3.0.1/24\"],\n        \"snat-contract-scope\": \"global\",\n        \"static-service-ip-pool\": [\n            {\n                \"end\": \"10.4.0.254\",\n                \"start\": \"10.4.0.2\"\n            }\n        ],\n        \"pod-ip-pool\": [\n            {\n                \"end\": \"10.2.255.254\",\n                \"start\": \"10.2.0.2\"\n            }\n        ],\n        \"pod-subnet\": [\n            \"10.2.0.1/16\"\n        ],\n        \"pod-subnet-chunk-size\": 256,\n        \"node-service-ip-pool\": [\n            {\n                \"end\": \"10.5.0.254\",\n                \"start\": \"10.5.0.2\"\n            }\n        ],\n        \"node-service-subnets\": [\n            \"10.5.0.1/24\"\n        ]\n    }\n  host-agent-config: |-\n    {\n        \"flavor\": \"RKE2-kubernetes-1.34\",\n        \"app-profile\": \"aci-containers-rke2\",\n        \"epg-resolve-prioritize\": true,\n        \"opflex-mode\": null,\n        \"log-level\": \"info\",\n        \"aci-snat-namespace\": \"aci-containers-system\",\n        \"aci-vmm-type\": \"Kubernetes\",\n        \"aci-vmm-domain\": \"rke2\",\n        \"aci-vmm-controller\": \"rke2\",\n        \"aci-prefix\": \"rke2\",\n        \"aci-vrf\": \"rke2\",\n        \"aci-vrf-tenant\": \"common\",\n        \"service-vlan\": 4003,\n        \"kubeapi-vlan\": 4001,\n        \"pod-subnet\": [\n            \"10.2.0.1/16\"\n        ],\n        \"node-subnet\": [\n            \"10.1.0.1/16\"\n        ],\n        \"encap-type\": \"vxlan\",\n        \"aci-infra-vlan\": 4093,\n        \"cni-netconfig\": [\n            {\n                \"gateway\": \"10.2.0.1\",\n                \"routes\": [\n                    {\n                        \"dst\": \"0.0.0.0/0\",\n                        \"gw\": \"10.2.0.1\"\n                    }\n                ],\n                \"subnet\": \"10.2.0.0/16\"\n            }\n        ],\n        \"default-endpoint-group\": {\n            \"policy-space\": \"rke2\",\n            \"name\": \"aci-containers-rke2|aci-containers-default\"\n        },\n        \"namespace-default-endpoint-group\": {\n            \"aci-containers-system\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-system\"\n            },\n            \"cattle-logging-system\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-system\"\n            },\n            \"cattle-monitoring-system\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-system\"\n            },\n            \"cattle-system\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-system\"\n            },\n            \"istio-operator\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-istio\"\n            },\n            \"istio-system\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-istio\"\n            },\n            \"kube-system\": {\n                \"policy-space\": \"rke2\",\n                \"name\": \"aci-containers-rke2|aci-containers-system\"\n            }        },\n        \"enable-drop-log\": true,\n        \"enable-nodepodif\": false,\n        \"enable-ovs-hw-offload\": false\n    }\n  opflex-agent-config: |-\n    {\n        \"log\": {\n            \"level\": \"info\"\n        },\n        \"opflex\": {\n            \"notif\" : { \"enabled\" : \"false\" },\n            \"startup\": {\n                    \"enabled\": false,\n                    \"policy-file\": \"/usr/local/var/lib/opflex-agent-ovs/startup/pol.json\",\n                    \"policy-duration\": 60,\n                    \"resolve-aft-conn\": false\n            },\n            \"timers\" : {\n                    \"switch-sync-delay\": 5,\n                    \"switch-sync-dynamic\": 10\n            },\n            \"asyncjson\": { \"enabled\" : \"false\" },\n            \"force-ep-undeclares\": { \"enabled\": \"true\" }\n            ,\"epg-resolve-prioritize\": { \"enabled\": \"true\" }\n        },\n        \"ovs\": {\n            \"asyncjson\": { \"enabled\" : \"false\" }\n        },\n        \"prometheus\": {\n            \"enabled\": \"false\"\n        }\n    }\n---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: snat-operator-config\n  namespace: aci-containers-system\n  labels:\n    aci-containers-config-version: \"dummy\"\n    network-plugin: aci-containers\ndata:\n  \"start\": \"5000\"\n  \"end\": \"65000\"\n  \"ports-per-node\": \"3000\"\n---\napiVersion: v1\nkind: Secret\nmetadata:\n  name: aci-user-cert\n  namespace: aci-containers-system\n  labels:\n    aci-containers-config-version: \"dummy\"\ndata:\n  user.key: ZHVtbXkK\n  user.crt: ZHVtbXkK\n---\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: aci-containers-controller\n  namespace: aci-containers-system\n  labels:\n    aci-containers-config-version: \"dummy\"\n---\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: aci-containers-host-agent\n  namespace: aci-containers-system\n  labels:\n    aci-containers-config-version: \"dummy\"\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  labels:\n    aci-containers-config-version: \"dummy\"\n    network-plugin: aci-containers\n  name: aci-containers-controller\nrules:\n- apiGroups:\n  - \"\"\n  resources:\n  - nodes\n  - namespaces\n  - pods\n  - endpoints\n  - services\n  - events\n  - replicationcontrollers\n  - serviceaccounts\n  verbs:\n  - list\n  - watch\n  - get\n  - patch\n  - create\n  - update\n  - delete\n- apiGroups:\n  - \"\"\n  resources:\n  - configmaps\n  verbs:\n  - list\n  - watch\n  - get\n  - create\n  - update\n  - delete\n- apiGroups:\n  - \"apiextensions.k8s.io\"\n  resources:\n  - customresourcedefinitions\n  verbs:\n  - '*'\n- apiGroups:\n  - \"rbac.authorization.k8s.io\"\n  resources:\n  - clusterroles\n  - clusterrolebindings\n  verbs:\n  - '*'\n- apiGroups:\n  - \"networking.k8s.io\"\n  resources:\n  - networkpolicies\n  verbs:\n  - list\n  - watch\n  - get\n- apiGroups:\n  - \"apps\"\n  resources:\n  - deployments\n  - replicasets\n  - daemonsets\n  - statefulsets\n  verbs:\n  - '*'\n- apiGroups:\n  - \"\"\n  resources:\n  - nodes\n  - services/status\n  verbs:\n  - update\n- apiGroups:\n  - \"monitoring.coreos.com\"\n  resources:\n  - servicemonitors\n  verbs:\n  - get\n  - create\n- apiGroups:\n  - \"aci.snat\"\n  resources:\n  - snatpolicies/finalizers\n  - snatpolicies/status\n  - nodeinfos\n  verbs:\n  - update\n  - create\n  - list\n  - watch\n  - get\n  - delete\n- apiGroups:\n  - \"aci.snat\"\n  resources:\n  - snatglobalinfos\n  - snatpolicies\n  - nodeinfos\n  - rdconfigs\n  - snatlocalinfos\n  verbs:\n  - list\n  - watch\n  - get\n  - create\n  - update\n  - delete\n- apiGroups:\n  - \"aci.qos\"\n  resources:\n  - qospolicies\n  verbs:\n  - list\n  - watch\n  - get\n  - create\n  - update\n  - delete\n  - patch\n- apiGroups:\n  - \"aci.netflow\"\n  resources:\n  - netflowpolicies\n  verbs:\n  - list\n  - watch\n  - get\n  - update\n- apiGroups:\n  - \"aci.erspan\"\n  resources:\n  - erspanpolicies\n  verbs:\n  - list\n  - watch\n  - get\n  - update\n- apiGroups:\n  - \"aci.aw\"\n  resources:\n  - nodepodifs\n  verbs:\n  - '*'\n- apiGroups:\n  - apps.openshift.io\n  resources:\n  - deploymentconfigs\n  verbs:\n  - list\n  - watch\n  - get\n- apiGroups:\n  - discovery.k8s.io\n  resources:\n  - endpointslices\n  verbs:\n  - get\n  - list\n  - watch\n- apiGroups:\n  - \"aci.netpol\"\n  resources:\n  - networkpolicies\n  verbs:\n  - get\n  - list\n  - watch\n  - create\n  - update\n  - delete\n- apiGroups:\n  - \"aci.dnsnetpol\"\n  resources:\n  - dnsnetworkpolicies\n  verbs:\n  - get\n  - list\n  - watch\n  - create\n  - update\n  - delete\n- apiGroups:\n  - \"aci.hpp\"\n  resources:\n  - hostprotpols\n  - hostprotremoteipcontainers\n  verbs:\n  - list\n  - watch\n  - get\n  - create\n  - update\n  - delete\n  - deletecollection\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  labels:\n    aci-containers-config-version: \"dummy\"\n    network-plugin: aci-containers\n  name: aci-containers-host-agent\nrules:\n- apiGroups:\n  - \"\"\n  resources:\n  - nodes\n  - namespaces\n  - pods\n  - endpoints\n  - services\n  - replicationcontrollers\n  verbs:\n  - list\n  - watch\n  - get\n  - update\n- apiGroups:\n  - \"\"\n  resources:\n  - events\n  verbs:\n  - create\n  - patch\n- apiGroups:\n  - \"apiextensions.k8s.io\"\n  resources:\n  - customresourcedefinitions\n  verbs:\n  - list\n  - watch\n  - get\n- apiGroups:\n  - \"networking.k8s.io\"\n  resources:\n  - networkpolicies\n  verbs:\n  - list\n  - watch\n  - get\n- apiGroups:\n  - \"apps\"\n  resources:\n  - deployments\n  - replicasets\n  verbs:\n  - list\n  - watch\n  - get\n- apiGroups:\n  - \"aci.snat\"\n  resources:\n  - snatpolicies\n  - snatglobalinfos\n  - rdconfigs\n  verbs:\n  - list\n  - watch\n  - get\n- apiGroups:\n  - \"aci.qos\"\n  resources:\n  - qospolicies\n  verbs:\n  - list\n  - watch\n  - get\n  - create\n  - update\n  - delete\n  - patch\n- apiGroups:\n  - \"aci.droplog\"\n  resources:\n  - enabledroplogs\n  - prunedroplogs\n  verbs:\n  - list\n  - watch\n  - get\n- apiGroups:\n  - \"aci.snat\"\n  resources:\n  - nodeinfos\n  - snatlocalinfos\n  verbs:\n  - create\n  - update\n  - list\n  - watch\n  - get\n  - delete\n- apiGroups:\n  - discovery.k8s.io\n  resources:\n  - endpointslices\n  verbs:\n  - get\n  - list\n  - watch\n- apiGroups:\n  - \"aci.netpol\"\n  resources:\n  - networkpolicies\n  verbs:\n  - get\n  - list\n  - watch\n- apiGroups:\n  - \"aci.aw\"\n  resources:\n  - nodepodifs\n  verbs:\n  - \"*\"\n- apiGroups:\n  - \"aci.hpp\"\n  resources:\n  - hostprotpols\n  - hostprotremoteipcontainers\n  verbs:\n  - list\n  - watch\n  - get\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  name: aci-containers-controller\n  labels:\n    aci-containers-config-version: \"dummy\"\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n  name: aci-containers-controller\nsubjects:\n- kind: ServiceAccount\n  name: aci-containers-controller\n  namespace: aci-containers-system\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  name: aci-containers-host-agent\n  labels:\n    aci-containers-config-version: \"dummy\"\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n  name: aci-containers-host-agent\nsubjects:\n- kind: ServiceAccount\n  name: aci-containers-host-agent\n  namespace: aci-containers-system\n---\napiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: aci-containers-host\n  namespace: aci-containers-system\n  labels:\n    aci-containers-config-version: \"dummy\"\n    network-plugin: aci-containers\nspec:\n  updateStrategy:\n    type: RollingUpdate\n  selector:\n    matchLabels:\n      name: aci-containers-host\n      network-plugin: aci-containers\n  template:\n    metadata:\n      labels:\n        name: aci-containers-host\n        network-plugin: aci-containers\n      annotations:\n    spec:\n      hostNetwork: true\n      hostPID: true\n      hostIPC: true\n      serviceAccountName: aci-containers-host-agent\n      tolerations:\n      - operator: Exists\n      initContainers:\n      - name: cnideploy\n        image: quay.io/noiro/cnideploy:6.1.1.6.81c2369\n        imagePullPolicy: Always\n        securityContext:\n          capabilities:\n            add:\n            - SYS_ADMIN\n        volumeMounts:\n        - name: cni-bin\n          mountPath: /mnt/cni-bin\n      priorityClassName: system-node-critical\n      containers:\n      - name: aci-containers-host\n        image: quay.io/noiro/aci-containers-host:6.1.1.6.81c2369\n        imagePullPolicy: Always\n        resources:\n          limits:\n            memory: \"2Gi\"\n          requests:\n            memory: \"200Mi\"\n        securityContext:\n          capabilities:\n            add:\n            - SYS_ADMIN\n            - NET_ADMIN\n            - SYS_PTRACE\n            - NET_RAW\n        env:\n        - name: GOTRACEBACK\n          value: \"2\"\n        - name: KUBERNETES_NODE_NAME\n          valueFrom:\n            fieldRef:\n              fieldPath: spec.nodeName\n        - name: TENANT\n          value: \"rke2\"\n        - name: NODE_EPG\n          value: \"aci-containers-rke2|aci-containers-nodes\"\n        - name: DURATION_WAIT_FOR_NETWORK\n          value: \"210\"\n        volumeMounts:\n        - name: cni-bin\n          mountPath: /mnt/cni-bin\n        - name: cni-conf\n          mountPath: /mnt/cni-conf\n        - name: hostvar\n          mountPath: /usr/local/var\n        - name: hostrun\n          mountPath: /run\n        - name: hostrun\n          mountPath: /usr/local/run\n        - name: opflex-hostconfig-volume\n          mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d\n        - name: host-config-volume\n          mountPath: /usr/local/etc/aci-containers/\n        - name: varlogpods\n          mountPath: /var/log/pods\n          readOnly: true\n        - name: varlogcontainers\n          mountPath: /var/log/containers\n          readOnly: true\n        - name: varlibdocker\n          mountPath: /var/lib/docker\n          readOnly: true\n        - mountPath: /run/netns\n          name: host-run-netns\n          readOnly: true\n          mountPropagation: HostToContainer\n        livenessProbe:\n          failureThreshold: 10\n          httpGet:\n            path: /status\n            port: 8090\n            scheme: HTTP\n          initialDelaySeconds: 120\n          periodSeconds: 60\n          successThreshold: 1\n          timeoutSeconds: 30\n      - name: opflex-agent\n        env:\n        - name: REBOOT_WITH_OVS\n          value: \"true\"\n        image: quay.io/noiro/opflex:6.1.1.6.81c2369\n        imagePullPolicy: Always\n        resources:\n          limits:\n            memory: \"2Gi\"\n          requests:\n            memory: \"256Mi\"\n        securityContext:\n          capabilities:\n            add:\n            - NET_ADMIN\n        volumeMounts:\n        - name: hostvar\n          mountPath: /usr/local/var\n        - name: hostrun\n          mountPath: /run\n        - name: hostrun\n          mountPath: /usr/local/run\n        - name: opflex-hostconfig-volume\n          mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d\n        - name: opflex-config-volume\n          mountPath: /usr/local/etc/opflex-agent-ovs/conf.d\n      - name: mcast-daemon\n        image: quay.io/noiro/opflex:6.1.1.6.81c2369\n        command: [\"/bin/sh\"]\n        args: [\"/usr/local/bin/launch-mcastdaemon.sh\"]\n        imagePullPolicy: Always\n        resources:\n          limits:\n            memory: \"1Gi\"\n          requests:\n            memory: \"300Mi\"\n        volumeMounts:\n        - name: hostvar\n          mountPath: /usr/local/var\n        - name: hostrun\n          mountPath: /run\n        - name: hostrun\n          mountPath: /usr/local/run\n      restartPolicy: Always\n      volumes:\n      - name: cni-bin\n        hostPath:\n          path: /opt\n      - name: cni-conf\n        hostPath:\n          path: /etc\n      - name: hostvar\n        hostPath:\n          path: /var\n      - name: hostrun\n        hostPath:\n          path: /run\n      - name: host-config-volume\n        configMap:\n          name: aci-containers-config\n          items:\n          - key: host-agent-config\n            path: host-agent.conf\n      - name: opflex-hostconfig-volume\n        emptyDir:\n          medium: Memory\n      - name: varlogpods\n        hostPath:\n          path: /var/log/pods\n      - name: varlogcontainers\n        hostPath:\n          path: /var/log/containers\n      - name: varlibdocker\n        hostPath:\n          path: /var/lib/docker\n      - name: opflex-config-volume\n        configMap:\n          name: aci-containers-config\n          items:\n          - key: opflex-agent-config\n            path: local.conf\n      - name: host-run-netns\n        hostPath:\n          path: /run/netns\n---\napiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: aci-containers-openvswitch\n  namespace: aci-containers-system\n  labels:\n    aci-containers-config-version: \"dummy\"\n    network-plugin: aci-containers\nspec:\n  updateStrategy:\n    type: RollingUpdate\n  selector:\n    matchLabels:\n      name: aci-containers-openvswitch\n      network-plugin: aci-containers\n  template:\n    metadata:\n      labels:\n        name: aci-containers-openvswitch\n        network-plugin: aci-containers\n    spec:\n      hostNetwork: true\n      hostPID: true\n      hostIPC: true\n      serviceAccountName: aci-containers-host-agent\n      tolerations:\n      - operator: Exists\n      priorityClassName: system-node-critical\n      containers:\n      - name: aci-containers-openvswitch\n        image: quay.io/noiro/openvswitch:6.1.1.6.81c2369\n        imagePullPolicy: Always\n        resources:\n          limits:\n            memory: \"2Gi\"\n          requests:\n            memory: \"256Mi\"\n        securityContext:\n          capabilities:\n            add:\n            - NET_ADMIN\n            - SYS_MODULE\n            - SYS_NICE\n            - IPC_LOCK\n        env:\n        - name: OVS_RUNDIR\n          value: /usr/local/var/run/openvswitch\n        volumeMounts:\n        - name: hostvar\n          mountPath: /usr/local/var\n        - name: hostrun\n          mountPath: /run\n        - name: hostrun\n          mountPath: /usr/local/run\n        - name: hostetc\n          mountPath: /usr/local/etc\n        - name: hostmodules\n          mountPath: /lib/modules\n        - name: varlogpods\n          mountPath: /var/log/pods\n          readOnly: true\n        - name: varlogcontainers\n          mountPath: /var/log/containers\n          readOnly: true\n        - name: varlibdocker\n          mountPath: /var/lib/docker\n          readOnly: true\n        livenessProbe:\n          exec:\n            command:\n            - /usr/local/bin/liveness-ovs.sh\n      restartPolicy: Always\n      volumes:\n      - name: hostetc\n        hostPath:\n          path: /etc\n      - name: hostvar\n        hostPath:\n          path: /var\n      - name: hostrun\n        hostPath:\n          path: /run\n      - name: hostmodules\n        hostPath:\n          path: /lib/modules\n      - name: varlogpods\n        hostPath:\n          path: /var/log/pods\n      - name: varlogcontainers\n        hostPath:\n          path: /var/log/containers\n      - name: varlibdocker\n        hostPath:\n          path: /var/lib/docker\n---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: aci-containers-controller\n  namespace: aci-containers-system\n  labels:\n    aci-containers-config-version: \"dummy\"\n    network-plugin: aci-containers\n    name: aci-containers-controller\nspec:\n  replicas: 1\n  strategy:\n    type: Recreate\n  selector:\n    matchLabels:\n      name: aci-containers-controller\n      network-plugin: aci-containers\n  template:\n    metadata:\n      name: aci-containers-controller\n      namespace: aci-containers-system\n      labels:\n        name: aci-containers-controller\n        network-plugin: aci-containers\n    spec:\n      hostNetwork: true\n      serviceAccountName: aci-containers-controller\n      tolerations:\n      - effect: NoExecute\n        key: node.kubernetes.io/unreachable\n        operator: Exists\n        tolerationSeconds: 600\n      - effect: NoExecute\n        key: node.kubernetes.io/not-ready\n        operator: Exists\n        tolerationSeconds: 600\n      - effect: NoSchedule\n        key: node.kubernetes.io/not-ready\n        operator: Exists\n      - effect: NoSchedule\n        key: node-role.kubernetes.io/master\n        operator: Exists\n      - effect: NoSchedule\n        key: node-role.kubernetes.io/control-plane\n        operator: Exists\n      - effect: NoExecute\n        key: node-role.kubernetes.io/etcd\n        operator: Exists\n      priorityClassName: system-node-critical\n      containers:\n      - name: aci-containers-controller\n        image: quay.io/noiro/aci-containers-controller:6.1.1.6.81c2369\n        imagePullPolicy: Always\n        resources:\n          limits:\n            memory: \"2Gi\"\n          requests:\n            memory: \"256Mi\"\n        env:\n        - name: WATCH_NAMESPACE\n          value: \"\"\n        - name: ACI_SNAT_NAMESPACE\n          value: \"aci-containers-system\"\n        - name: ACI_SNAGLOBALINFO_NAME\n          value: \"snatglobalinfo\"\n        - name: ACI_RDCONFIG_NAME\n          value: \"routingdomain-config\"\n        - name: SYSTEM_NAMESPACE\n          value: \"aci-containers-system\"\n        volumeMounts:\n        - name: controller-config-volume\n          mountPath: /usr/local/etc/aci-containers/\n        - name: varlogpods\n          mountPath: /var/log/pods\n          readOnly: true\n        - name: varlogcontainers\n          mountPath: /var/log/containers\n          readOnly: true\n        - name: varlibdocker\n          mountPath: /var/lib/docker\n          readOnly: true\n        - name: aci-user-cert-volume\n          mountPath: /usr/local/etc/aci-cert/\n        livenessProbe:\n          failureThreshold: 10\n          httpGet:\n            path: /status\n            port: 8091\n            scheme: HTTP\n          initialDelaySeconds: 120\n          periodSeconds: 60\n          successThreshold: 1\n          timeoutSeconds: 30\n      volumes:\n      - name: aci-user-cert-volume\n        secret:\n          secretName: aci-user-cert\n      - name: controller-config-volume\n        configMap:\n          name: aci-containers-config\n          items:\n          - key: controller-config\n            path: controller.conf\n      - name: varlogpods\n        hostPath:\n          path: /var/log/pods\n      - name: varlogcontainers\n        hostPath:\n          path: /var/log/containers\n      - name: varlibdocker\n        hostPath:\n          path: /var/lib/docker\n---\napiVersion: v1\nkind: LimitRange\nmetadata:\n  name: memory-limit-range\n  namespace: aci-containers-system\nspec:\n  limits:\n  - default:\n      memory: 3Gi\n    defaultRequest:\n      memory: 128Mi\n    type: Container\n"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: acc-provision-config
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  spec: |-
+    {
+        "acc_provision_input": {
+            "operator_managed_config": {
+                "enable_updates": false
+            },
+            "aci_config": {
+                "system_id": "rke2",
+                "apic_hosts": [
+                    "10.30.120.100",
+                    "10.30.120.101",
+                    "10.30.120.102"
+                ],
+                "aep": "rke2-aep",
+                "vrf": {
+                    "name": "rke2",
+                    "tenant": "common"
+                },
+                "sync_login": {
+                    "certfile": "user.crt", 
+                    "keyfile": "user.key"
+                },
+                "vmm_domain": {
+                    "type": "Kubernetes",
+                    "encap_type": "vxlan",
+                    "mcast_fabric": "225.1.2.3",
+                    "mcast_range": {
+                        "start": "225.2.1.1",
+                        "end": "225.2.255.255"
+                    }
+                },
+                "l3out": {
+                    "name": "l3out",
+                    "external_networks": [
+                        "default",
+                        "test_ext_net"
+                    ]
+                }
+            },
+            "registry": {
+                "image_prefix": "quay.io/noiro"
+            },
+            "kube_config": {
+                "use_system_node_priority_class": true, 
+                "aci_containers_controller_memory_request": "256Mi", 
+                "aci_containers_controller_memory_limit": "2Gi", 
+                "aci_containers_host_memory_request": "200Mi", 
+                "aci_containers_host_memory_limit": "2Gi", 
+                "mcast_daemon_memory_request": "300Mi", 
+                "mcast_daemon_memory_limit": "1Gi", 
+                "opflex_agent_memory_request": "256Mi", 
+                "opflex_agent_memory_limit": "2Gi", 
+                "acc_provision_operator_memory_request": "256Mi", 
+                "acc_provision_operator_memory_limit": "1Gi", 
+                "aci_containers_operator_memory_request": "256Mi", 
+                "aci_containers_operator_memory_limit": "3Gi", 
+                "ovs_memory_request": "256Mi", 
+                "ovs_memory_limit": "2Gi"
+            },
+            "logging": {
+               "controller_log_level": "info", 
+               "hostagent_log_level": "info", 
+               "opflexagent_log_level": "info"
+            },
+            "net_config": {
+                "infra_vlan": 4093,
+                "service_vlan": 4003,
+                "kubeapi_vlan": 4001,
+                "extern_static": ["10.4.0.1/24"],
+                "extern_dynamic": ["10.3.0.1/24"],
+                "node_svc_subnet": "10.5.0.1/24",
+                "pod_subnet_chunk_size": 256,
+                "node_subnet": [
+                    "10.1.0.1/16"
+                ],
+                "pod_subnet": [
+                    "10.2.0.1/16"
+                ]
+            }
+        }
+     }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aci-containers-config
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  controller-config: |-
+    {
+        "flavor": "RKE2-kubernetes-1.34",
+        "log-level": "info",
+        "apic-hosts": [
+            "10.30.120.100",
+            "10.30.120.101",
+            "10.30.120.102"
+        ],
+        "aep" : "rke2-aep",
+        "apic-request-retry-delay": 2,
+        "enable-apic-request-retry-delay": true,
+        "apic-username": "rke2",
+        "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "aci-prefix": "rke2",
+        "aci-vmm-type": "Kubernetes",
+        "aci-vmm-domain": "rke2",
+        "aci-vmm-controller": "rke2",
+        "aci-policy-tenant": "rke2",
+        "filter-opflex-device": true,
+        "aci-podbd-dn": "uni/tn-rke2/BD-aci-containers-rke2-pod-bd",
+        "aci-nodebd-dn": "uni/tn-rke2/BD-aci-containers-rke2-node-bd",
+        "aci-service-phys-dom": "rke2-pdom",
+        "aci-service-encap": "vlan-4003",
+        "aci-service-monitor-interval": 5,
+        "aci-pbr-tracking-non-snat": false,
+        "aci-vrf-tenant": "common",
+        "aci-vrf-dn": "uni/tn-common/ctx-rke2",
+        "aci-l3out": "l3out",
+        "aci-ext-networks": [
+            "default",
+            "test_ext_net"
+        ],
+        "aci-vrf": "rke2",
+        "app-profile": "aci-containers-rke2",
+        "default-endpoint-group": {
+            "policy-space": "rke2",
+            "name": "aci-containers-rke2|aci-containers-default"
+        },
+        "max-nodes-svc-graph": 32,
+        "namespace-default-endpoint-group": {
+            "aci-containers-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "cattle-logging-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "cattle-monitoring-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "cattle-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "istio-operator": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-istio"
+            },
+            "istio-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-istio"
+            },
+            "kube-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            }        },
+        "service-ip-pool": [
+            {
+                "end": "10.3.0.254",
+                "start": "10.3.0.2"
+            }
+        ],
+        "extern-static": ["10.4.0.1/24"],
+        "extern-dynamic": ["10.3.0.1/24"],
+        "snat-contract-scope": "global",
+        "static-service-ip-pool": [
+            {
+                "end": "10.4.0.254",
+                "start": "10.4.0.2"
+            }
+        ],
+        "pod-ip-pool": [
+            {
+                "end": "10.2.255.254",
+                "start": "10.2.0.2"
+            }
+        ],
+        "pod-subnet": [
+            "10.2.0.1/16"
+        ],
+        "pod-subnet-chunk-size": 256,
+        "node-service-ip-pool": [
+            {
+                "end": "10.5.0.254",
+                "start": "10.5.0.2"
+            }
+        ],
+        "node-service-subnets": [
+            "10.5.0.1/24"
+        ]
+    }
+  host-agent-config: |-
+    {
+        "flavor": "RKE2-kubernetes-1.34",
+        "app-profile": "aci-containers-rke2",
+        "epg-resolve-prioritize": true,
+        "opflex-mode": null,
+        "log-level": "info",
+        "aci-snat-namespace": "aci-containers-system",
+        "aci-vmm-type": "Kubernetes",
+        "aci-vmm-domain": "rke2",
+        "aci-vmm-controller": "rke2",
+        "aci-prefix": "rke2",
+        "aci-vrf": "rke2",
+        "aci-vrf-tenant": "common",
+        "service-vlan": 4003,
+        "kubeapi-vlan": 4001,
+        "pod-subnet": [
+            "10.2.0.1/16"
+        ],
+        "node-subnet": [
+            "10.1.0.1/16"
+        ],
+        "encap-type": "vxlan",
+        "aci-infra-vlan": 4093,
+        "cni-netconfig": [
+            {
+                "gateway": "10.2.0.1",
+                "routes": [
+                    {
+                        "dst": "0.0.0.0/0",
+                        "gw": "10.2.0.1"
+                    }
+                ],
+                "subnet": "10.2.0.0/16"
+            }
+        ],
+        "default-endpoint-group": {
+            "policy-space": "rke2",
+            "name": "aci-containers-rke2|aci-containers-default"
+        },
+        "namespace-default-endpoint-group": {
+            "aci-containers-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "cattle-logging-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "cattle-monitoring-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "cattle-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            },
+            "istio-operator": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-istio"
+            },
+            "istio-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-istio"
+            },
+            "kube-system": {
+                "policy-space": "rke2",
+                "name": "aci-containers-rke2|aci-containers-system"
+            }        },
+        "enable-drop-log": true,
+        "enable-nodepodif": false,
+        "enable-ovs-hw-offload": false
+    }
+  opflex-agent-config: |-
+    {
+        "log": {
+            "level": "info"
+        },
+        "opflex": {
+            "notif" : { "enabled" : "false" },
+            "startup": {
+                    "enabled": false,
+                    "policy-file": "/usr/local/var/lib/opflex-agent-ovs/startup/pol.json",
+                    "policy-duration": 60,
+                    "resolve-aft-conn": false
+            },
+            "timers" : {
+                    "switch-sync-delay": 5,
+                    "switch-sync-dynamic": 10
+            },
+            "asyncjson": { "enabled" : "false" },
+            "force-ep-undeclares": { "enabled": "true" }
+            ,"epg-resolve-prioritize": { "enabled": "true" }
+        },
+        "ovs": {
+            "asyncjson": { "enabled" : "false" }
+        },
+        "prometheus": {
+            "enabled": "false"
+        }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snat-operator-config
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+data:
+  "start": "5000"
+  "end": "65000"
+  "ports-per-node": "3000"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aci-user-cert
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+data:
+  user.key: ZHVtbXkK
+  user.crt: ZHVtbXkK
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-controller
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-host-agent
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - endpoints
+  - services
+  - events
+  - replicationcontrollers
+  - serviceaccounts
+  verbs:
+  - list
+  - watch
+  - get
+  - patch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - services/status
+  verbs:
+  - update
+- apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatpolicies/finalizers
+  - snatpolicies/status
+  - nodeinfos
+  verbs:
+  - update
+  - create
+  - list
+  - watch
+  - get
+  - delete
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatglobalinfos
+  - snatpolicies
+  - nodeinfos
+  - rdconfigs
+  - snatlocalinfos
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "aci.qos"
+  resources:
+  - qospolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - "aci.netflow"
+  resources:
+  - netflowpolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - "aci.erspan"
+  resources:
+  - erspanpolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - "aci.aw"
+  resources:
+  - nodepodifs
+  verbs:
+  - '*'
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "aci.netpol"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "aci.dnsnetpol"
+  resources:
+  - dnsnetworkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "aci.hpp"
+  resources:
+  - hostprotpols
+  - hostprotremoteipcontainers
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+  - deletecollection
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers-host-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - endpoints
+  - services
+  - replicationcontrollers
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - snatpolicies
+  - snatglobalinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.qos"
+  resources:
+  - qospolicies
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - "aci.droplog"
+  resources:
+  - enabledroplogs
+  - prunedroplogs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "aci.snat"
+  resources:
+  - nodeinfos
+  - snatlocalinfos
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+  - delete
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "aci.netpol"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "aci.aw"
+  resources:
+  - nodepodifs
+  verbs:
+  - "*"
+- apiGroups:
+  - "aci.hpp"
+  resources:
+  - hostprotpols
+  - hostprotremoteipcontainers
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers-controller
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers-controller
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-controller
+  namespace: aci-containers-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers-host-agent
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers-host-agent
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-host-agent
+  namespace: aci-containers-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aci-containers-host
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-host
+      network-plugin: aci-containers
+  template:
+    metadata:
+      labels:
+        name: aci-containers-host
+        network-plugin: aci-containers
+      annotations:
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      serviceAccountName: aci-containers-host-agent
+      tolerations:
+      - operator: Exists
+      initContainers:
+      - name: cnideploy
+        image: quay.io/noiro/cnideploy:6.1.1.6.81c2369
+        imagePullPolicy: Always
+        securityContext:
+          capabilities:
+            add:
+            - SYS_ADMIN
+        volumeMounts:
+        - name: cni-bin
+          mountPath: /mnt/cni-bin
+      priorityClassName: system-node-critical
+      containers:
+      - name: aci-containers-host
+        image: quay.io/noiro/aci-containers-host:6.1.1.6.81c2369
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: "2Gi"
+          requests:
+            memory: "200Mi"
+        securityContext:
+          capabilities:
+            add:
+            - SYS_ADMIN
+            - NET_ADMIN
+            - SYS_PTRACE
+            - NET_RAW
+        env:
+        - name: GOTRACEBACK
+          value: "2"
+        - name: KUBERNETES_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: TENANT
+          value: "rke2"
+        - name: NODE_EPG
+          value: "aci-containers-rke2|aci-containers-nodes"
+        - name: DURATION_WAIT_FOR_NETWORK
+          value: "210"
+        volumeMounts:
+        - name: cni-bin
+          mountPath: /mnt/cni-bin
+        - name: cni-conf
+          mountPath: /mnt/cni-conf
+        - name: hostvar
+          mountPath: /usr/local/var
+        - name: hostrun
+          mountPath: /run
+        - name: hostrun
+          mountPath: /usr/local/run
+        - name: opflex-hostconfig-volume
+          mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+        - name: host-config-volume
+          mountPath: /usr/local/etc/aci-containers/
+        - name: varlogpods
+          mountPath: /var/log/pods
+          readOnly: true
+        - name: varlogcontainers
+          mountPath: /var/log/containers
+          readOnly: true
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+          readOnly: true
+        - mountPath: /run/netns
+          name: host-run-netns
+          readOnly: true
+          mountPropagation: HostToContainer
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /status
+            port: 8090
+            scheme: HTTP
+          initialDelaySeconds: 120
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 30
+      - name: opflex-agent
+        env:
+        - name: REBOOT_WITH_OVS
+          value: "true"
+        image: quay.io/noiro/opflex:6.1.1.6.81c2369
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: "2Gi"
+          requests:
+            memory: "256Mi"
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+        volumeMounts:
+        - name: hostvar
+          mountPath: /usr/local/var
+        - name: hostrun
+          mountPath: /run
+        - name: hostrun
+          mountPath: /usr/local/run
+        - name: opflex-hostconfig-volume
+          mountPath: /usr/local/etc/opflex-agent-ovs/base-conf.d
+        - name: opflex-config-volume
+          mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
+      - name: mcast-daemon
+        image: quay.io/noiro/opflex:6.1.1.6.81c2369
+        command: ["/bin/sh"]
+        args: ["/usr/local/bin/launch-mcastdaemon.sh"]
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: "1Gi"
+          requests:
+            memory: "300Mi"
+        volumeMounts:
+        - name: hostvar
+          mountPath: /usr/local/var
+        - name: hostrun
+          mountPath: /run
+        - name: hostrun
+          mountPath: /usr/local/run
+      restartPolicy: Always
+      volumes:
+      - name: cni-bin
+        hostPath:
+          path: /opt
+      - name: cni-conf
+        hostPath:
+          path: /etc
+      - name: hostvar
+        hostPath:
+          path: /var
+      - name: hostrun
+        hostPath:
+          path: /run
+      - name: host-config-volume
+        configMap:
+          name: aci-containers-config
+          items:
+          - key: host-agent-config
+            path: host-agent.conf
+      - name: opflex-hostconfig-volume
+        emptyDir:
+          medium: Memory
+      - name: varlogpods
+        hostPath:
+          path: /var/log/pods
+      - name: varlogcontainers
+        hostPath:
+          path: /var/log/containers
+      - name: varlibdocker
+        hostPath:
+          path: /var/lib/docker
+      - name: opflex-config-volume
+        configMap:
+          name: aci-containers-config
+          items:
+          - key: opflex-agent-config
+            path: local.conf
+      - name: host-run-netns
+        hostPath:
+          path: /run/netns
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aci-containers-openvswitch
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-openvswitch
+      network-plugin: aci-containers
+  template:
+    metadata:
+      labels:
+        name: aci-containers-openvswitch
+        network-plugin: aci-containers
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      serviceAccountName: aci-containers-host-agent
+      tolerations:
+      - operator: Exists
+      priorityClassName: system-node-critical
+      containers:
+      - name: aci-containers-openvswitch
+        image: quay.io/noiro/openvswitch:6.1.1.6.81c2369
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: "2Gi"
+          requests:
+            memory: "256Mi"
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_MODULE
+            - SYS_NICE
+            - IPC_LOCK
+        env:
+        - name: OVS_RUNDIR
+          value: /usr/local/var/run/openvswitch
+        volumeMounts:
+        - name: hostvar
+          mountPath: /usr/local/var
+        - name: hostrun
+          mountPath: /run
+        - name: hostrun
+          mountPath: /usr/local/run
+        - name: hostetc
+          mountPath: /usr/local/etc
+        - name: hostmodules
+          mountPath: /lib/modules
+        - name: varlogpods
+          mountPath: /var/log/pods
+          readOnly: true
+        - name: varlogcontainers
+          mountPath: /var/log/containers
+          readOnly: true
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+          readOnly: true
+        livenessProbe:
+          exec:
+            command:
+            - /usr/local/bin/liveness-ovs.sh
+      restartPolicy: Always
+      volumes:
+      - name: hostetc
+        hostPath:
+          path: /etc
+      - name: hostvar
+        hostPath:
+          path: /var
+      - name: hostrun
+        hostPath:
+          path: /run
+      - name: hostmodules
+        hostPath:
+          path: /lib/modules
+      - name: varlogpods
+        hostPath:
+          path: /var/log/pods
+      - name: varlogcontainers
+        hostPath:
+          path: /var/log/containers
+      - name: varlibdocker
+        hostPath:
+          path: /var/lib/docker
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aci-containers-controller
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+    name: aci-containers-controller
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: aci-containers-controller
+      network-plugin: aci-containers
+  template:
+    metadata:
+      name: aci-containers-controller
+      namespace: aci-containers-system
+      labels:
+        name: aci-containers-controller
+        network-plugin: aci-containers
+    spec:
+      hostNetwork: true
+      serviceAccountName: aci-containers-controller
+      tolerations:
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 600
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 600
+      - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoExecute
+        key: node-role.kubernetes.io/etcd
+        operator: Exists
+      priorityClassName: system-node-critical
+      containers:
+      - name: aci-containers-controller
+        image: quay.io/noiro/aci-containers-controller:6.1.1.6.81c2369
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: "2Gi"
+          requests:
+            memory: "256Mi"
+        env:
+        - name: WATCH_NAMESPACE
+          value: ""
+        - name: ACI_SNAT_NAMESPACE
+          value: "aci-containers-system"
+        - name: ACI_SNAGLOBALINFO_NAME
+          value: "snatglobalinfo"
+        - name: ACI_RDCONFIG_NAME
+          value: "routingdomain-config"
+        - name: SYSTEM_NAMESPACE
+          value: "aci-containers-system"
+        volumeMounts:
+        - name: controller-config-volume
+          mountPath: /usr/local/etc/aci-containers/
+        - name: varlogpods
+          mountPath: /var/log/pods
+          readOnly: true
+        - name: varlogcontainers
+          mountPath: /var/log/containers
+          readOnly: true
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+          readOnly: true
+        - name: aci-user-cert-volume
+          mountPath: /usr/local/etc/aci-cert/
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /status
+            port: 8091
+            scheme: HTTP
+          initialDelaySeconds: 120
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 30
+      volumes:
+      - name: aci-user-cert-volume
+        secret:
+          secretName: aci-user-cert
+      - name: controller-config-volume
+        configMap:
+          name: aci-containers-config
+          items:
+          - key: controller-config
+            path: controller.conf
+      - name: varlogpods
+        hostPath:
+          path: /var/log/pods
+      - name: varlogcontainers
+        hostPath:
+          path: /var/log/containers
+      - name: varlibdocker
+        hostPath:
+          path: /var/lib/docker
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: memory-limit-range
+  namespace: aci-containers-system
+spec:
+  limits:
+  - default:
+      memory: 3Gi
+    defaultRequest:
+      memory: 128Mi
+    type: Container
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-containers-operator
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    aci-containers-config-version: "dummy"
+    network-plugin: aci-containers
+  name: aci-containers-operator
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  - namespaces
+  - configmaps
+  - secrets
+  - pods
+  - services
+  - serviceaccounts
+  - serviceaccounts/token
+  - endpoints
+  - events
+  - limitranges
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.ctrl
+  resources:
+  - acicontainersoperators
+  - acicontainersoperators/status
+  - acicontainersoperators/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.ctrl
+  resources:
+  - accprovisioninputs
+  - accprovisioninputs/status
+  - accprovisioninputs/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - aci.snat
+  resources:
+  - snatpolicies
+  - snatglobalinfos
+  - rdconfigs
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - aci.snat
+  resources:
+  - nodeinfos
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+- apiGroups:
+  - config.openshift.io
+  - operator.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - update
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aci-containers-operator
+  labels:
+    aci-containers-config-version: "dummy"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aci-containers-operator
+subjects:
+- kind: ServiceAccount
+  name: aci-containers-operator
+  namespace: aci-containers-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aci-containers-operator
+  namespace: aci-containers-system
+  labels:
+    aci-containers-config-version: "dummy"
+    name: aci-containers-operator
+    network-plugin: aci-containers
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: aci-containers-operator
+      network-plugin: aci-containers
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: aci-containers-operator
+      namespace: aci-containers-system
+      labels:
+        name: aci-containers-operator
+        network-plugin: aci-containers
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: preferred-node
+                operator: In
+                values:
+                - aci-containers-operator-2577247291
+            weight: 1
+      containers:
+      - image: quay.io/noiro/aci-containers-operator:6.1.1.6.81c2369
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: "3Gi"
+          requests:
+            memory: "256Mi"
+        name: aci-containers-operator
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - name: aci-operator-config
+          mountPath: /usr/local/etc/aci-containers/
+        - name: acc-provision-config
+          mountPath: /usr/local/etc/acc-provision/
+        - name: varlogpods
+          mountPath: /var/log/pods
+          readOnly: true
+        - name: varlogcontainers
+          mountPath: /var/log/containers
+          readOnly: true
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+          readOnly: true
+        env:
+        - name: SYSTEM_NAMESPACE
+          value: "aci-containers-system"
+        - name: ACC_PROVISION_FLAVOR
+          value: "RKE2-kubernetes-1.34"
+        - name: OPERATOR_LOGGING_LEVEL
+          value: "info"
+      - env:
+        - name: ANSIBLE_GATHERING
+          value: explicit
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ACC_PROVISION_FLAVOR
+          value: "RKE2-kubernetes-1.34"
+        - name: ACC_PROVISION_INPUT_CR_NAME
+          value: "accprovisioninput"
+        image: quay.io/noiro/acc-provision-operator:6.1.1.6.81c2369
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: "1Gi"
+          requests:
+            memory: "256Mi"
+        name: acc-provision-operator
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: aci-containers-operator
+      serviceAccountName: aci-containers-operator
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - name: aci-operator-config
+        configMap:
+          name: aci-operator-config
+          items:
+          - key: spec
+            path: aci-operator.conf
+      - name: acc-provision-config
+        configMap:
+          name: acc-provision-config
+          items:
+          - key: spec
+            path: acc-provision-operator.conf
+      - name: varlogpods
+        hostPath:
+          path: /var/log/pods
+      - name: varlogcontainers
+        hostPath:
+          path: /var/log/containers
+      - name: varlibdocker
+        hostPath:
+          path: /var/lib/docker

--- a/provision/testdata/list_flavors.stdout.txt
+++ b/provision/testdata/list_flavors.stdout.txt
@@ -17,9 +17,9 @@ INFO: openshift-4.17-esx:	Red Hat OpenShift Container Platform 4.17 on ESX
 INFO: kubernetes-1.33:	Kubernetes 1.33
 INFO: kubernetes-1.32:	Kubernetes 1.32
 INFO: kubernetes-1.31:	Kubernetes 1.31
+INFO: RKE2-kubernetes-1.34:	Rancher Kubernetes Engine Government kubernetes version 1.34
 INFO: RKE2-kubernetes-1.33:	Rancher Kubernetes Engine Government kubernetes version 1.33
 INFO: RKE2-kubernetes-1.32:	Rancher Kubernetes Engine Government kubernetes version 1.32
-INFO: RKE2-kubernetes-1.31:	Rancher Kubernetes Engine Government kubernetes version 1.31
 INFO: RKE-1.8.3:	Rancher Kubernetes Engine min version 1.8.3 [Experimental]
 INFO: RKE-1.7.7:	Rancher Kubernetes Engine min version 1.7.7 [Experimental]
 INFO: RKE-1.7.2:	Rancher Kubernetes Engine min version 1.7.2


### PR DESCRIPTION
- Add a new flavor to be used with Rancher Kubernetes Engine Government kubernetes version 1.34
- Hide flavor RKE2-kubernetes-1.31

(cherry picked from commit d33be95280cca1ba2172326d05b6bed277840cb0)