### PR TITLE
Add SNAT operator port range documentation

### DIFF
--- a/doc/features/snat-operator-contract-scope.md
+++ b/doc/features/snat-operator-contract-scope.md
@@ -2,8 +2,7 @@
 
 # Table of contents
 * [Overview](#overview)
-* [Mechanism](#mechanism)  
-* [Examples](#examples)
+* [Mechanism](#mechanism)
     
 
 ## Overview
@@ -24,29 +23,20 @@ kube_config:
   snat_operator:
     contract_scope: tenant
 ```
-
-Run `acc-provision` tool on updated acc provision input file to generate new `aci_deployment.yaml`
+Run `acc-provision` tool to generate new aci_deployment.yaml
 ```sh
-acc-provision -c <acc_provision_input_file> -f <flavor> -u <apic_username> -p <apic_password> -o aci_deployment.yaml
+acc-provision --upgrade -c <acc_provision_input_file> -f <flavor> -u <apic_username> -p <apic_password> -o aci_deployment.yaml
 ```
 
-Delete old aci_deployment.yaml and wait till all the pods in the `aci-containers-system` namespace are deleted
+Apply newly generated aci_deployment.yaml and restart controller pod.
 ```sh
-$ oc delete -f aci_deployment.yaml
-$ oc get pods -n aci-containers-system
+$ kubectl apply -f aci_deployment.yaml
+$ kubectl delete po <controller_pod> -n aci-containers-system
 ```
 
-Apply newly generated aci_deployment.yaml and wait till all pods in `aci-containers-system` namespace are running
-```sh
-$ oc apply -f aci_deployment.yaml
-$ oc get pods -n aci-containers-system
-```
-
-Verify conrtact scop set in aci-containers-config config map:
+Verify contract scope set in aci-containers-config config map:
 
 ```sh
-noiro@oshift3-ext-rtr:~$ oc get cm -n aci-containers-system aci-containers-config -oyaml | grep snat-contract-scope
+noiro@rke-rketest135-ext-rtr:~$ kubectl get cm -n aci-containers-system aci-containers-config -oyaml | grep snat-contract-scope
         "snat-contract-scope": "tenant",
 ```
-
-## Examples

--- a/doc/features/snat-operator.md
+++ b/doc/features/snat-operator.md
@@ -1,0 +1,65 @@
+# SNAT operator port range configuration
+
+# Table of contents
+* [Overview](#overview)
+* [Mechanism](#mechanism)
+
+## Overview
+
+The SNAT port range and per-node port allocation can be configured in the acc provision input file as follows:
+```yaml
+kube_config:
+  snat_operator:
+    port_range:
+      start: <start-port>
+      end: <end-port>
+      ports_per_node: <count>
+```
+Default values:
+- start: 5000
+- end: 65000
+- ports_per_node: 3000
+
+The max number of nodes in the service graph can be configured using:
+```yaml
+kube_config:
+  max_nodes_svc_graph: <value>
+```
+Max number supported is 64 and default value is 32.
+
+For configuring the SNAT service graph contract scope, refer to [snat-operator-contract-scope.md](snat-operator-contract-scope.md).
+
+## Mechanism
+
+The SNAT port range can be configured in the acc provision input file:
+```yaml
+kube_config:
+  snat_operator:
+    port_range:
+      start: 50000
+      end: 59999
+      ports_per_node: 1000
+```
+
+Run `acc-provision` tool to generate new aci_deployment.yaml
+```sh
+acc-provision --upgrade -c <acc_provision_input_file> -f <flavor> -u <apic_username> -p <apic_password> -o aci_deployment.yaml
+```
+
+Apply newly generated aci_deployment.yaml and restart controller pod.
+```sh
+$ kubectl apply -f aci_deployment.yaml
+$ kubectl delete po <controller_pod> -n aci-containers-system
+```
+
+Verify port range set in snat-operator-config config map:
+
+```sh
+$ kubectl get cm -n aci-containers-system snat-operator-config -oyaml
+apiVersion: v1
+data:
+  end: "59999"
+  ports-per-node: "1000"
+  start: "50000"
+kind: ConfigMap
+```


### PR DESCRIPTION
Add new doc (snat-operator.md) covering:
- SNAT port range configuration (start, end, ports_per_node)
- max_nodes_svc_graph configuration
- Verification steps using snat-operator-config configmap
- Update snat-operator-contract-scope.md with correct order of steps