### PR TITLE
Added fix for broken acc-provision package in case of setuptools>81.0.0

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -18,7 +18,7 @@ import string
 import sys
 import uuid
 
-import pkg_resources
+from importlib.metadata import version as pkg_version, PackageNotFoundError
 import pkgutil
 import tarfile
 import yaml
@@ -3162,8 +3162,8 @@ class CustomFormatter(argparse.HelpFormatter):
 def parse_args(show_help):
     version = 'Unknown'
     try:
-        version = pkg_resources.require("acc_provision")[0].version
-    except pkg_resources.DistributionNotFound:
+        version = pkg_version("acc_provision")
+    except PackageNotFoundError:
         # ignore, expected in case running from source
         pass
 


### PR DESCRIPTION
Issue:
Previously, pkg_resources was a module bundled inside the setuptools (<81) and it was never be part of the Python standard library. Starting with setuptool version 82.0.0 (released in 2025), the pkg_resources module was completely removed. They used setuptools with version 82.0.0 and import failed.

Fix implemented is replacement of pkg_resources with importlib.metadata, which is part of Python’s standard library since Python3.8, so it requires no additional dependency.
(cherry picked from commit 39a6f6acd80ed862e050ad15234d2c1fae33397e)

