### PR TITLE
Add LLDP subscription refresh timer configuration for chained mode

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -577,6 +577,8 @@ def config_default():
             "preexisting_kube_bd": None,
             "apic_subscription_delay": None,
             "apic_refreshticker_adjust": None,
+            "apic_lldp_refreshtime": None,
+            "apic_lldp_refreshticker_adjust": None,
             "opflex_device_delete_timeout": None,
             "apic_tls_cert": None,
         },
@@ -1482,6 +1484,36 @@ def is_valid_apic_refreshticker_adjust(xval):
     raise (Exception("Must be integer between %d and %d" % (xmin, xmax)))
 
 
+def is_valid_apic_lldp_refreshtime(xval):
+    if xval is None:
+        # Will be defaulted to 120 seconds
+        return True
+    xmin = 0
+    xmax = 600  # Max 10 minutes for LLDP subscription refresh
+    try:
+        x = int(xval)
+        if xmin <= x <= xmax:
+            return True
+    except ValueError:
+        pass
+    raise (Exception("Must be integer between %d and %d" % (xmin, xmax)))
+
+
+def is_valid_apic_lldp_refreshticker_adjust(xval):
+    if xval is None:
+        # Will be defaulted to 20 seconds
+        return True
+    xmin = 1
+    xmax = 300
+    try:
+        x = int(xval)
+        if xmin <= x <= xmax:
+            return True
+    except ValueError:
+        pass
+    raise (Exception("Must be integer between %d and %d" % (xmin, xmax)))
+
+
 def is_valid_max_nodes_svc_graph(xval):
     if xval is None:
         return True
@@ -1609,6 +1641,10 @@ def config_validate(flavor_opts, config):
                                             is_valid_refreshtime),
             "aci_config/apic_refreshticker_adjust": (get(("aci_config", "apic_refreshticker_adjust")),
                                                      is_valid_apic_refreshticker_adjust),
+            "aci_config/apic_lldp_refreshtime": (get(("aci_config", "apic_lldp_refreshtime")),
+                                                  is_valid_apic_lldp_refreshtime),
+            "aci_config/apic_lldp_refreshticker_adjust": (get(("aci_config", "apic_lldp_refreshticker_adjust")),
+                                                           is_valid_apic_lldp_refreshticker_adjust),
             "aci_config/apic_subscription_delay": (get(("aci_config", "apic_subscription_delay")),
                                                    is_valid_apic_sub_delay),
             "aci_config/apic_host": (get(("aci_config", "apic_hosts")), required),

--- a/provision/acc_provision/templates/acc-provision-configmap.yaml
+++ b/provision/acc_provision/templates/acc-provision-configmap.yaml
@@ -46,6 +46,12 @@ data:
                 {% if config.aci_config.apic_refreshticker_adjust %}
                 "apic_refreshticker_adjust": {{ config.aci_config.apic_refreshticker_adjust|json }},
                 {% endif %}
+                {% if config.aci_config.apic_lldp_refreshtime %}
+                "apic_lldp_refreshtime": {{ config.aci_config.apic_lldp_refreshtime|json }},
+                {% endif %}
+                {% if config.aci_config.apic_lldp_refreshticker_adjust %}
+                "apic_lldp_refreshticker_adjust": {{ config.aci_config.apic_lldp_refreshticker_adjust|json }},
+                {% endif %}
                 {% if config.aci_config.opflex_device_delete_timeout %}
                 "opflex-device-delete-timeout": {{ config.aci_config.opflex_device_delete_timeout|json }},
                 {% endif %}

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -2757,6 +2757,12 @@ data:
         {% if config.aci_config.apic_refreshticker_adjust %}
         "apic-refreshticker-adjust": "{{ config.aci_config.apic_refreshticker_adjust|json }}",
         {% endif %}
+        {% if config.aci_config.apic_lldp_refreshtime %}
+        "apic-lldp-refreshtime": "{{ config.aci_config.apic_lldp_refreshtime|json }}",
+        {% endif %}
+        {% if config.aci_config.apic_lldp_refreshticker_adjust %}
+        "apic-lldp-refreshticker-adjust": "{{ config.aci_config.apic_lldp_refreshticker_adjust|json }}",
+        {% endif %}
         "apic-username": {{config.aci_config.sync_login.username|json}},
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
         {% if config.aci_config.apic_tls_cert %}

--- a/provision/acc_provision/templates/chained-mode-provision-config.yaml
+++ b/provision/acc_provision/templates/chained-mode-provision-config.yaml
@@ -6,6 +6,8 @@ aci_config:
   #apic-refreshtime: 1200       # Subscrption refresh-interval in seconds; Max=43200
   #apic_refreshticker_adjust: 150 # How early (seconds) the subscriptions to be refreshed than actual subscription refresh-timeout. Min=1, Max=65535
   #apic_subscription_delay: 100 # Delay after each subscription query in milliseconds; Min=1, Max=65535
+  #apic_lldp_refreshtime: 120   # LLDP subscription refresh timeout in seconds; Max=600. Default=120
+  #apic_lldp_refreshticker_adjust: 20 # How early (seconds) the LLDP subscriptions to be refreshed than actual refresh-timeout. Min=1, Max=300. Default=20
   #tenant:
     #name: pre_existing_tenant  # Add pre_existing_tenant name if it's manually created on the APIC
   apic_hosts:                   # List of APIC hosts to connect for APIC API


### PR DESCRIPTION
Add support for configurable LLDP subscription refresh parameters in acc-provision for chained mode deployments:

- apic_lldp_refreshtime: LLDP subscription refresh timeout (default: 120s)
- apic_lldp_refreshticker_adjust: How early to refresh LLDP subscriptions (default: 20s)