### PR TITLE
[mmr-6.1.1] Add support for flake8 checks in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ jobs:
         - pip install ./provision
       script:
         - cd provision
+        - flake8 --builtins="unicode" --ignore E501,E731,E741,W504 acc_provision || travis_terminate 1
         - coverage run --source=. -m pytest acc_provision
         - coveralls
     - stage: push-package


### PR DESCRIPTION
Add support for flake8 checks and terminate the pipeline immediately if errors occured

(cherry picked from commit aafdb71a0a39b6750fd766052e64608ac75da44c)