### PR TITLE
Replace deprecated distutils.StrictVersion with packaging.Version

### DIFF
--- a/provision/acc_provision/aci_set_service_bd_routing_disable_yes.py
+++ b/provision/acc_provision/aci_set_service_bd_routing_disable_yes.py
@@ -19,7 +19,7 @@ import os
 import os.path
 import yaml
 import time
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 debug_http = False
 
@@ -416,7 +416,7 @@ def set_service_bd_routing_disable(
         if apic is None:
             raise Exception("Failed to connect to APIC")
         for apic_version in apic.apic_versions:
-            if StrictVersion(apic_version) >= StrictVersion("6.0.4"):
+            if Version(apic_version) >= Version("6.0.4"):
                 dbg(
                     "APIC IP: {}, APIC Version: {}. Version is 6.0(4a) or higher".format(
                         config["aci_config"]["apic_hosts"][apic_id],

--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -8,7 +8,7 @@ from requests.exceptions import SSLError
 import urllib3
 import ipaddress
 import time
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 import yaml
 
@@ -761,7 +761,7 @@ class ApicKubeConfig(object):
 
     def is_newer_version(self, new, old):
         # Expects string arg like "5.2.0"
-        return (StrictVersion(new) >= StrictVersion(old))
+        return (Version(new) >= Version(old))
 
     def get_config(self, apic_version):
         def assert_attributes_is_first_key(data):

--- a/provision/debian/control
+++ b/provision/debian/control
@@ -12,6 +12,6 @@ Vcs-Browser: http://github.com/noironetworks/aci-containers/provision
 Package: acc-provision
 Architecture: amd64
 Depends: python3-openssl (>=0.13), python3-yaml (>=3.10), python3-requests (>=2.2),
-         python3-jinja2 (>=2.7), ${misc:Depends}, ${python3:Depends}
+         python3-jinja2 (>=2.7), python3-packaging, ${misc:Depends}, ${python3:Depends}
 Description: Tools to provision and support ACI fabric DC workloads
  Tools to provision and support ACI fabric DC workloads

--- a/provision/rpm/acc-provision.spec.in
+++ b/provision/rpm/acc-provision.spec.in
@@ -12,6 +12,7 @@ Requires:	python3-pyOpenSSL >= 0.13
 Requires:	python3-pyyaml >= 3.10
 Requires:	python3-requests >= 2.2
 Requires:	python3-jinja2 >= 2.7
+Requires:	python3-packaging
 
 %description
 Tools to provision and support ACI fabric DC workloads

--- a/provision/setup.py
+++ b/provision/setup.py
@@ -46,5 +46,6 @@ setup(
           'pyopenssl',
           'MarkupSafe',
           'ruamel.yaml',
+          'packaging',
     ],
 )


### PR DESCRIPTION
distutils was removed in Python 3.12 (PEP 632), causing acc-provision to fail at import with ModuleNotFoundError. Switch to packaging.version.Version (PEP 440) and declare the new `packaging` runtime dependency in setup.py, debian/control, and the RPM spec.