### PR TITLE
Add drop log rotation settings to acc-provision

### DIFF
--- a/doc/features/opflex-agent-drop-log.md
+++ b/doc/features/opflex-agent-drop-log.md
@@ -195,6 +195,16 @@ drop_log_config:
 ```
 The file is created with the provided filename in `/usr/local/var/log/' directory of the opflex-agent container in the containers-host pod.
 
+When droplogs are redirected to a file, the opflex-agent container runs a background `logrotate` loop to keep the file from growing unbounded. The rotation behaviour can be tuned with the following optional settings (all only take effect when `opflex_redirect_drop_logs` points to a file):
+```yaml
+drop_log_config:
+    opflex_redirect_drop_logs: <filename>
+    droplog_max_size_mb: 50        # rotate once the file reaches this size in MB (default 50)
+    droplog_rotate_count: 5        # number of rotated backups to keep (default 5)
+    droplog_rotate_interval: 7200  # interval in seconds between rotation checks (default 7200 = 2h)
+```
+These map to the `OPFLEXAGENT_DROPLOG_MAXSIZE`, `OPFLEXAGENT_DROPLOG_ROTATE` and `OPFLEXAGENT_DROPLOG_ROTATE_INTERVAL` environment variables on the opflex-agent container. If a setting is omitted, the opflex-agent default is used.
+
 
 ## 9. Cleanup
 

--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -1542,6 +1542,25 @@ def is_valid_apic_refreshticker_adjust(xval):
     raise (Exception("Must be integer between %d and %d" % (xmin, xmax)))
 
 
+def is_valid_positive_int(xval):
+    if xval is None:
+        # Not a required field.
+        return True
+    # Reject booleans explicitly.
+    if isinstance(xval, bool):
+        raise (Exception("Must be a positive integer"))
+    # Accept actual ints, or strings that are purely base-10 digits.
+    if isinstance(xval, int):
+        ival = xval
+    elif isinstance(xval, str) and re.fullmatch(r"[0-9]+", xval.strip()):
+        ival = int(xval)
+    else:
+        raise (Exception("Must be a positive integer"))
+    if ival > 0:
+        return True
+    raise (Exception("Must be a positive integer"))
+
+
 def is_valid_max_nodes_svc_graph(xval):
     if xval is None:
         return True
@@ -1888,6 +1907,18 @@ def config_validate(flavor_opts, config):
             "aci_config/apic_login/password":
             (get(("aci_config", "apic_login", "password")), required),
         })
+
+    # Drop log rotation knobs (applies to all flavors when redirecting
+    # drop logs to a file).
+    checks.update({
+        "drop_log_config/droplog_max_size_mb":
+        (get(("drop_log_config", "droplog_max_size_mb")), is_valid_positive_int),
+        "drop_log_config/droplog_rotate_count":
+        (get(("drop_log_config", "droplog_rotate_count")), is_valid_positive_int),
+        "drop_log_config/droplog_rotate_interval":
+        (get(("drop_log_config", "droplog_rotate_interval")),
+         is_valid_positive_int),
+    })
 
     checks = deep_merge(checks, extra_checks)
     ret = True

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -4098,6 +4098,18 @@ spec:
         {% elif config.drop_log_config.opflex_redirect_drop_logs %}
         - name: OPFLEXAGENT_DROPLOG_FILE
           value: "{{ config.drop_log_config.opflex_redirect_drop_logs }}"
+        {% if config.drop_log_config.droplog_max_size_mb %}
+        - name: OPFLEXAGENT_DROPLOG_MAXSIZE
+          value: "{{ config.drop_log_config.droplog_max_size_mb }}"
+        {% endif %}
+        {% if config.drop_log_config.droplog_rotate_count %}
+        - name: OPFLEXAGENT_DROPLOG_ROTATE
+          value: "{{ config.drop_log_config.droplog_rotate_count }}"
+        {% endif %}
+        {% if config.drop_log_config.droplog_rotate_interval %}
+        - name: OPFLEXAGENT_DROPLOG_ROTATE_INTERVAL
+          value: "{{ config.drop_log_config.droplog_rotate_interval }}"
+        {% endif %}
         {% endif %}
         {% if config.registry.use_digest %}
         image: {{ config.registry.image_prefix }}/opflex@sha256:{{ config.registry.opflex_agent_version }}

--- a/provision/acc_provision/templates/provision-config.yaml
+++ b/provision/acc_provision/templates/provision-config.yaml
@@ -190,6 +190,9 @@ registry:
   # enable: False                      # default is True
   # disable_events: True               # default is False
   # opflex_redirect_drop_logs: syslog  # to log packet drops to the file or syslog, specify filname to log to file.
+  # droplog_max_size_mb: 50            # max drop-log file size (MB) before rotation; default 50. Only applies when redirecting to a file.
+  # droplog_rotate_count: 5            # number of rotated drop-log backups to keep; default 5. Only applies when redirecting to a file.
+  # droplog_rotate_interval: 7200      # interval in seconds between rotation checks; default 7200 (2h).
 
 # multus:
   # disable: False       # default is True


### PR DESCRIPTION
- Make the drop log rotation parameters configurable via new settings droplog_max_size_mb, droplog_rotate_count and droplog_rotate_interval under drop_log_config, and inject them as OPFLEXAGENT_DROPLOG_MAXSIZE, OPFLEXAGENT_DROPLOG_ROTATE and OPFLEXAGENT_DROPLOG_ROTATE_INTERVAL on the opflex-agent container. The values are validated as positive integers; when omitted, the opflex-agent defaults are used.
- Also document the new settings in the sample input file and the drop log feature doc.